### PR TITLE
chore: gitignore local CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ data/cache.db
 coverage/
 .vscode/
 .idea/
+
+# Local-only Claude Code project guidance — kept out of the OSS repo
+CLAUDE.md
+


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` to `.gitignore` so per-environment Claude Code project guidance stays local and doesn't get accidentally committed by future contributors.

## Why
This is an OSS repo. Each contributor's local `CLAUDE.md` is environment-specific (paths, agent preferences, session state). Ignoring it prevents drift from individual machines into shared history.

## Test plan
- [x] `git check-ignore -v CLAUDE.md` confirms the file is ignored
- [x] No tracked files affected

Co-Authored by Pramod Prasanth <pramod@chainalign.com>