### PR TITLE
Review fix-pass: hardening, observability, test coverage

### DIFF
--- a/src/cite.ts
+++ b/src/cite.ts
@@ -25,6 +25,10 @@ function metCaption(a: Artwork): string {
   return `${terminated} ${a.source.pageUrl}`;
 }
 
+// Short uses bare "Unknown" rather than caption's "Unknown artist" because
+// the parenthetical inline form reads better with a single word: prefer
+// "Title (Unknown, 1500)" over "Title (Unknown artist, 1500)". Captions are
+// standalone sentences where the longer form is conventional.
 function shortStyle(a: Artwork): string {
   const artist = a.artist.attributionType === 'anonymous' ? 'Unknown' : a.artist.name;
   const date = a.displayDate || (a.yearStart != null ? String(a.yearStart) : '');
@@ -39,6 +43,20 @@ const PER_MUSEUM_CAPTION: Record<string, (a: Artwork) => string> = {
   met: metCaption,
 };
 
+/**
+ * Render an attribution string for an artwork.
+ *
+ * Style semantics:
+ *   - `full`: footnote/bibliography form. Period-separated.
+ *   - `caption`: museum-publication caption convention. Comma-separated head
+ *     (artist, title, date), medium called out, terse end with museum + license.
+ *   - `short`: inline reference like "Title (Artist, Date)".
+ *
+ * Per-museum overrides live in the PER_MUSEUM_FULL / PER_MUSEUM_CAPTION
+ * tables. Museums without an entry fall back to the Met formatters — keep
+ * them general-purpose enough to read sensibly across collections until a
+ * museum-specific style is contributed.
+ */
 export function cite(artwork: Artwork, style: CiteStyle = 'full'): string {
   if (style === 'short') return shortStyle(artwork);
   if (style === 'caption') {

--- a/src/dateParser.ts
+++ b/src/dateParser.ts
@@ -25,19 +25,29 @@ const ROMAN: Record<string, number> = {
   xix: 19, xx: 20, xxi: 21,
 };
 
+const ORDINAL_WORDS: Record<string, number> = {
+  first: 1, second: 2, third: 3, fourth: 4, fifth: 5, sixth: 6, seventh: 7,
+  eighth: 8, ninth: 9, tenth: 10, eleventh: 11, twelfth: 12, thirteenth: 13,
+  fourteenth: 14, fifteenth: 15, sixteenth: 16, seventeenth: 17,
+  eighteenth: 18, nineteenth: 19, twentieth: 20, 'twenty-first': 21,
+};
+
 function ordinalToNumber(token: string): number | null {
-  const t = token.toLowerCase().replace(/(st|nd|rd|th)$/, '');
-  if (/^\d+$/.test(t)) return parseInt(t, 10);
-  if (ROMAN[t] !== undefined) return ROMAN[t];
-  const words: Record<string, number> = {
-    first: 1, second: 2, third: 3, fourth: 4, fifth: 5, sixth: 6, seventh: 7,
-    eighth: 8, ninth: 9, tenth: 10, eleventh: 11, twelfth: 12, thirteenth: 13,
-    fourteenth: 14, fifteenth: 15, sixteenth: 16, seventeenth: 17,
-    eighteenth: 18, nineteenth: 19, twentieth: 20, 'twenty-first': 21,
-  };
-  return words[t] ?? null;
+  const lower = token.toLowerCase();
+  // Check the word dictionary BEFORE stripping suffixes — otherwise hyphenated
+  // forms like "twenty-first" get mangled into "twenty-fir" by the suffix
+  // regex and never match.
+  if (ORDINAL_WORDS[lower] !== undefined) return ORDINAL_WORDS[lower];
+  const stripped = lower.replace(/(st|nd|rd|th)$/, '');
+  if (/^\d+$/.test(stripped)) return parseInt(stripped, 10);
+  if (ROMAN[stripped] !== undefined) return ROMAN[stripped];
+  return ORDINAL_WORDS[stripped] ?? null;
 }
 
+// 19th century CE = 1801–1900 (no year zero, century N spans years
+// (N-1)*100+1 to N*100). qualifier divides the span into thirds; floor()
+// accepts that the 99-year span doesn't divide evenly — close enough for
+// catalog metadata and matches museum convention.
 function centuryRange(n: number, era: 'ce' | 'bce', qualifier?: string): DateRange {
   let start: number, end: number;
   if (era === 'ce') {
@@ -63,9 +73,11 @@ function centuryRange(n: number, era: 'ce' | 'bce', qualifier?: string): DateRan
   return { yearStart: start, yearEnd: end };
 }
 
+// True only when the string carries BOTH a BCE marker and a CE marker —
+// signals a cross-era range that tryRangeRegex must defer on so
+// tryCrossEraRange can handle it correctly.
 function hasMixedEras(s: string): boolean {
   const hasBce = /\b(b\.?c\.?e?\.?|bc)\b/i.test(s);
-  const hasCe = /\b(c\.?e\.?|ce)\b/i.test(s) && !/\b(b\.?c\.?e?\.?)\b/i.test(s.replace(/\b(c\.?e\.?|ce)\b/i, ''));
   if (!hasBce) return false;
   return /\bce\b/i.test(s) || /\bc\.e\./i.test(s);
 }
@@ -81,6 +93,12 @@ function tryCrossEraRange(s: string): DateRange | null {
   return null;
 }
 
+// Numeric range with optional trailing BCE marker. Bare digits separated by
+// hyphen/en-dash. Note: ordinal-century inputs like "14th-15th century" are
+// NOT matched here because the regex requires the dash to immediately follow
+// digits — the "th" between "14" and "-" breaks the match. Don't relax the
+// regex without locking down that invariant in tests; tryCenturyRange owns
+// ordinal-century parsing.
 function tryRangeRegex(s: string): DateRange | null {
   if (hasMixedEras(s)) return null;
 
@@ -94,6 +112,10 @@ function tryRangeRegex(s: string): DateRange | null {
     const firstIsCleanFourDigit = !firstStr.startsWith('-') && firstStr.length === 4;
     const secondIsShortSuffix = !secondStr.startsWith('-') && (secondStr.length === 1 || secondStr.length === 2);
 
+    // Short-suffix forms expand the second number by reusing digits from the
+    // first: "1820-5" → 1820–1825 (decade rollover), "1899–05" → 1899–1905
+    // (century rollover). When the candidate would land before the start
+    // year, bump it forward by the rollover unit.
     if (!m[3] && firstIsCleanFourDigit && secondIsShortSuffix) {
       const decade = Math.floor(a / 10) * 10;
       const century = Math.floor(a / 100) * 100;
@@ -211,6 +233,21 @@ function tryDynasty(s: string): DateRange | null {
   return null;
 }
 
+/**
+ * Parse a museum-supplied display date into a {yearStart, yearEnd} range.
+ *
+ * Strategies are tried in this exact order — earlier strategies win:
+ *   1. cross-era range ("500 BCE – 50 CE")
+ *   2. numeric range ("1820–1830", "1820-5", "1899–05")
+ *   3. ordinal-century range ("14th-15th century")
+ *   4. ordinal century with optional early/mid/late qualifier
+ *   5. decade ("1820s")
+ *   6. single year ("1888", "ca. 1820", "500 BCE")
+ *   7. dynasty/period lookup (longest key first to avoid prefix shadowing)
+ *
+ * Returns {null, null} when nothing matches — never guesses. BCE is encoded
+ * as negative integers so range arithmetic Just Works.
+ */
 export function parseDisplayDate(input: string | null | undefined): DateRange {
   if (!input || typeof input !== 'string') {
     return { yearStart: null, yearEnd: null };

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,15 +1,32 @@
 import Database from 'better-sqlite3';
-import { mkdirSync, existsSync } from 'node:fs';
+import { chmodSync, mkdirSync, existsSync } from 'node:fs';
 import { dirname } from 'node:path';
 import type { Artwork } from './types.js';
 
 const OBJECT_TTL_DAYS = 90;
 const QUERY_TTL_DAYS = 14;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 export interface CacheConfig {
   path: string;
 }
 
+/**
+ * SQLite-backed cache for normalized artworks and search-result IDs.
+ *
+ * TTL contract:
+ *   - `objects` rows live for {@link OBJECT_TTL_DAYS} days. Artworks don't
+ *     change once accessioned, so the long TTL keeps cold-cache HTTP cost low.
+ *   - `query_cache` rows live for {@link QUERY_TTL_DAYS} days. Museums add
+ *     new open-access objects regularly, so queries refresh on a shorter cycle.
+ *
+ * Stale rows are pruned on construction (cheap bulk DELETE) so a long-lived
+ * client doesn't accumulate dead rows indefinitely. Reads also treat expired
+ * rows as misses; the next write overwrites the row via ON CONFLICT.
+ *
+ * The DB file is created with mode 0o600. Parameterized statements only —
+ * no string-concatenated SQL paths.
+ */
 export class Cache {
   private db: Database.Database;
 
@@ -17,9 +34,21 @@ export class Cache {
     if (!existsSync(dirname(config.path))) {
       mkdirSync(dirname(config.path), { recursive: true, mode: 0o700 });
     }
+    const fileExisted = existsSync(config.path);
     this.db = new Database(config.path);
+    if (!fileExisted) {
+      // Tighten file mode immediately on creation so the cache (which can
+      // include rights metadata, snapshots of museum responses, etc.) isn't
+      // group/world-readable under loose umasks.
+      try {
+        chmodSync(config.path, 0o600);
+      } catch {
+        // Best-effort; non-fatal on filesystems that don't support chmod.
+      }
+    }
     this.db.pragma('journal_mode = WAL');
     this.init();
+    this.pruneExpired();
   }
 
   private init(): void {
@@ -115,7 +144,14 @@ export class Cache {
       | undefined;
     if (!row) return null;
     if (this.isExpired(row.cached_at, OBJECT_TTL_DAYS)) return null;
-    return JSON.parse(row.full_record) as Artwork;
+    try {
+      return JSON.parse(row.full_record) as Artwork;
+    } catch {
+      // A malformed row (manual DB tinkering, OS-level corruption, schema
+      // drift from a prior version) shouldn't poison the request — treat it
+      // as a cache miss; the next write will overwrite the row.
+      return null;
+    }
   }
 
   putQuery(cacheKey: string, ids: string[]): void {
@@ -134,12 +170,24 @@ export class Cache {
       | undefined;
     if (!row) return null;
     if (this.isExpired(row.cached_at, QUERY_TTL_DAYS)) return null;
-    return JSON.parse(row.ids_json) as string[];
+    try {
+      return JSON.parse(row.ids_json) as string[];
+    } catch {
+      return null;
+    }
+  }
+
+  pruneExpired(): { objects: number; queries: number } {
+    const objectsCutoff = new Date(Date.now() - OBJECT_TTL_DAYS * MS_PER_DAY).toISOString();
+    const queriesCutoff = new Date(Date.now() - QUERY_TTL_DAYS * MS_PER_DAY).toISOString();
+    const objects = this.db.prepare(`DELETE FROM objects WHERE cached_at < ?`).run(objectsCutoff);
+    const queries = this.db.prepare(`DELETE FROM query_cache WHERE cached_at < ?`).run(queriesCutoff);
+    return { objects: objects.changes, queries: queries.changes };
   }
 
   private isExpired(isoTimestamp: string, ttlDays: number): boolean {
     const cachedAt = new Date(isoTimestamp).getTime();
-    const expiresAt = cachedAt + ttlDays * 24 * 60 * 60 * 1000;
+    const expiresAt = cachedAt + ttlDays * MS_PER_DAY;
     return Date.now() > expiresAt;
   }
 

--- a/src/fetchers/met.ts
+++ b/src/fetchers/met.ts
@@ -6,6 +6,14 @@ import type { Fetcher, SearchOptions } from './types.js';
 
 const MET_API = 'https://collectionapi.metmuseum.org/public/collection/v1';
 
+function asString(v: unknown): string {
+  return typeof v === 'string' ? v : '';
+}
+
+function asOptionalString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
 export const metFetcher: Fetcher = {
   code: 'met',
   name: 'The Metropolitan Museum of Art',
@@ -46,7 +54,11 @@ export const metFetcher: Fetcher = {
     }
     const r = raw as Record<string, unknown>;
     const objectID = r.objectID;
-    const id = typeof objectID === 'number' ? `met:${objectID}` : 'met:unknown';
+    // Met IDs are always positive integers. Anything else flunks ID_REGEX
+    // downstream; emit a placeholder so the rejection still carries a stable
+    // (and obviously bogus) id for logs.
+    const validId = typeof objectID === 'number' && Number.isInteger(objectID) && objectID > 0;
+    const id = validId ? `met:${objectID}` : 'met:unknown';
 
     const decision = validateMetLicense(raw);
     if (!decision.accepted || !decision.license) {
@@ -61,23 +73,38 @@ export const metFetcher: Fetcher = {
       };
     }
 
-    const displayDate = (r.objectDate as string) || '';
+    if (!validId) {
+      return {
+        status: 'rejected',
+        rejection: {
+          id,
+          museumCode: 'met',
+          reason: 'met: missing or non-integer objectID',
+          rawSnapshot: raw,
+        },
+      };
+    }
+
+    const displayDate = asString(r.objectDate);
     const dateRange = parseDisplayDate(displayDate);
 
-    const artistRaw = (r.artistDisplayName as string) || '';
+    const artistRaw = asString(r.artistDisplayName);
     const attributionType = detectAttributionType(artistRaw);
     const cleanName = cleanArtistName(artistRaw);
 
     const cultureOrCountry =
-      (r.culture as string) || (r.country as string) || (r.classification as string) || '';
+      asString(r.culture) || asString(r.country) || asString(r.classification);
     const region = normalizeRegion(cultureOrCountry);
 
-    const periodRaw = ((r.period as string) || (r.dynasty as string) || '').toLowerCase().trim();
+    const periodRaw = (asString(r.period) || asString(r.dynasty)).toLowerCase().trim();
     const period = periodRaw.replace(/\s*\([^)]*\)\s*$/, '').trim() || null;
 
-    const fullImage =
-      (r.primaryImage as string) || (r.primaryImageSmall as string) || '';
-    const thumbnail = (r.primaryImageSmall as string) || undefined;
+    const fullImage = asString(r.primaryImage) || asString(r.primaryImageSmall);
+    const thumbnail = asOptionalString(r.primaryImageSmall);
+
+    const beginDate = asString(r.artistBeginDate);
+    const endDate = asString(r.artistEndDate);
+    const lifespan = beginDate || endDate ? `${beginDate}–${endDate}`.replace(/^–|–$/g, '') : undefined;
 
     const artwork: Artwork = {
       id,
@@ -86,20 +113,17 @@ export const metFetcher: Fetcher = {
         name: 'The Metropolitan Museum of Art',
         url: 'https://www.metmuseum.org',
       },
-      title: ((r.title as string) || '(Untitled)').trim(),
+      title: (asString(r.title) || '(Untitled)').trim(),
       artist: {
         name: cleanName || 'Unknown',
-        nationality: (r.artistNationality as string) || undefined,
-        lifespan:
-          r.artistBeginDate || r.artistEndDate
-            ? `${r.artistBeginDate ?? ''}–${r.artistEndDate ?? ''}`.replace(/^–|–$/g, '')
-            : undefined,
+        nationality: asOptionalString(r.artistNationality),
+        lifespan,
         attributionType,
       },
       displayDate,
       yearStart: dateRange.yearStart,
       yearEnd: dateRange.yearEnd,
-      medium: (r.medium as string) || '',
+      medium: asString(r.medium),
       region,
       period,
       imageUrls: {
@@ -111,12 +135,12 @@ export const metFetcher: Fetcher = {
       license: decision.license,
       source: {
         apiUrl: `${MET_API}/objects/${objectID}`,
-        pageUrl: (r.objectURL as string) || `https://www.metmuseum.org/art/collection/search/${objectID}`,
+        pageUrl: asString(r.objectURL) || `https://www.metmuseum.org/art/collection/search/${objectID}`,
       },
-      description: (r.objectName as string) || undefined,
+      description: asOptionalString(r.objectName),
       rawTags: Array.isArray(r.tags)
-        ? (r.tags as Array<{ term?: string }>)
-            .map((t) => t?.term)
+        ? (r.tags as Array<unknown>)
+            .map((t) => (t && typeof t === 'object' ? (t as { term?: unknown }).term : undefined))
             .filter((s): s is string => typeof s === 'string')
         : undefined,
     };

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,7 +23,34 @@ const FETCHERS: Record<string, Fetcher> = {
 const CACHE_PATH = process.env.OMM_CACHE_PATH ?? join(homedir(), '.open-museum-mcp', 'cache.db');
 const cache = new Cache({ path: CACHE_PATH });
 
-const ID_REGEX = /^[a-z]+:\d+$/;
+// Museum IDs are positive integers (no leading zeros). Tightening the regex
+// here makes `met:000123` and `met:0` user errors rather than valid IDs that
+// produce duplicate cache rows.
+const ID_REGEX = /^[a-z]+:[1-9]\d*$/;
+
+// Cap concurrent fetches to one museum's API. The Met has no batch endpoint,
+// so a search of limit 50 fans out into up to 50 object fetches; without a
+// cap, we'd hammer the upstream and risk rate-limit errors. 8 is empirically
+// gentle and keeps wall-clock time within the same order of magnitude.
+const FETCH_CONCURRENCY = 8;
+
+async function withConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const idx = next++;
+      if (idx >= items.length) return;
+      results[idx] = await fn(items[idx]);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
 
 const SearchInput = z.object({
   query: z.string().min(1),
@@ -49,14 +76,18 @@ async function fetchAndCache(id: string): Promise<{ ok: true; artwork: Artwork }
   const cached = cache.getObject(id);
   if (cached) return { ok: true, artwork: cached };
 
-  const [code] = id.split(':');
-  if (!code) return { ok: false, reason: `invalid artwork id: ${id}` };
+  // ID_REGEX guarantees a non-empty `[a-z]+` segment before ':'.
+  const code = id.slice(0, id.indexOf(':'));
   const fetcher = FETCHERS[code];
   if (!fetcher) return { ok: false, reason: `unknown museum code: ${code}` };
 
   const raw = await fetcher.getRaw(id);
   const result = fetcher.normalize(raw);
   if (result.status === 'rejected') {
+    // Rejections are expected — strict-default-deny is the project's spine.
+    // Log to stderr (stdout is the MCP protocol channel) so operators can
+    // diagnose "why did my search return fewer results than expected?".
+    console.error(`[open-museum-mcp] rejected ${id}: ${result.rejection.reason}`);
     return { ok: false, reason: result.rejection.reason };
   }
 
@@ -84,7 +115,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         type: 'object',
         properties: {
           query: { type: 'string', description: 'Free-text query.' },
-          museum: { type: 'string', description: 'Optional museum code (met, cleveland, aic).' },
+          museum: {
+            type: 'string',
+            description:
+              'Optional museum code. Currently registered: met. (Cleveland, AIC adapters are planned for v0.2.)',
+          },
           has_image: {
             type: 'boolean',
             default: true,
@@ -130,8 +165,13 @@ function errorResult(message: string) {
   return { content: [{ type: 'text' as const, text: message }], isError: true };
 }
 
-function searchCacheKey(query: string, museum: string | undefined, hasImage: boolean, limit: number): string {
-  return JSON.stringify({ q: query, m: museum ?? '*', hi: hasImage, lim: limit });
+// The cache key includes the overfetch count, not the user-facing `limit`.
+// That means limit:5 and limit:6 produce different keys (since 5*2=10 vs
+// 6*2=12). The trade-off: more cache rows, but each row is guaranteed to
+// hold enough IDs to satisfy a request at its overfetch tier even after
+// rights-gate rejections. Bucketing would need explicit refill logic.
+function searchCacheKey(query: string, museum: string | undefined, hasImage: boolean, overFetch: number): string {
+  return JSON.stringify({ q: query, m: museum ?? '*', hi: hasImage, of: overFetch });
 }
 
 async function handleSearch(args: unknown) {
@@ -157,13 +197,11 @@ async function handleSearch(args: unknown) {
     cache.putQuery(cacheKey, allIds);
   }
 
-  const fetched = await Promise.all(
-    allIds.map((id) =>
-      fetchAndCache(id).catch((err: unknown) => ({
-        ok: false as const,
-        reason: err instanceof Error ? err.message : 'fetch failed',
-      })),
-    ),
+  const fetched = await withConcurrency(allIds, FETCH_CONCURRENCY, (id) =>
+    fetchAndCache(id).catch((err: unknown) => ({
+      ok: false as const,
+      reason: err instanceof Error ? err.message : 'fetch failed',
+    })),
   );
   const accepted: Artwork[] = fetched
     .filter((r): r is { ok: true; artwork: Artwork } => r.ok)

--- a/tests/cite.test.ts
+++ b/tests/cite.test.ts
@@ -76,4 +76,35 @@ describe('cite', () => {
     const out = cite(anon, 'caption');
     expect(out).toContain('Unknown artist');
   });
+
+  it('uses bare "Unknown" for anonymous works in short style', () => {
+    const anon: Artwork = {
+      ...sample,
+      artist: { ...sample.artist, name: 'Unknown', attributionType: 'anonymous' },
+    };
+    expect(cite(anon, 'short')).toBe('Wheat Field with Cypresses (Unknown, 1889)');
+  });
+
+  it('omits the artist segment for anonymous works in full style', () => {
+    const anon: Artwork = {
+      ...sample,
+      artist: { ...sample.artist, name: 'Unknown', attributionType: 'anonymous' },
+    };
+    const out = cite(anon, 'full');
+    expect(out.startsWith('Wheat Field with Cypresses')).toBe(true);
+    expect(out).not.toMatch(/^Unknown[, ]/);
+  });
+
+  it('falls back to Met formatters for unregistered museum codes', () => {
+    const cleveland: Artwork = {
+      ...sample,
+      id: 'cleveland:1',
+      museum: { code: 'cleveland', name: 'Cleveland Museum of Art', url: 'https://www.clevelandart.org' },
+    };
+    const full = cite(cleveland, 'full');
+    expect(full).toContain('Cleveland Museum of Art');
+    expect(full).toContain('CC0');
+    const caption = cite(cleveland, 'caption');
+    expect(caption).toContain('Cleveland Museum of Art, CC0');
+  });
 });

--- a/tests/dateParser.test.ts
+++ b/tests/dateParser.test.ts
@@ -183,4 +183,19 @@ describe('parseDisplayDate', () => {
       expect(parseDisplayDate(null)).toEqual({ yearStart: null, yearEnd: null });
     });
   });
+
+  describe('strategy ordering invariants', () => {
+    // Locks down a subtle invariant: tryRangeRegex runs BEFORE
+    // tryCenturyRange in parseDisplayDate. The numeric-range regex looks like
+    // it could match the digits inside "14th-15th century" as `14-15`, but
+    // the "th" between digit and dash breaks the match. If someone relaxes
+    // the regex later, this test catches the regression.
+    it('"14th-15th century" parses as a century range, not a small-number range', () => {
+      expect(parseDisplayDate('14th-15th century')).toEqual({ yearStart: 1301, yearEnd: 1500 });
+    });
+
+    it('"twenty-first century" resolves via word ordinal (regression for hyphen-suffix bug)', () => {
+      expect(parseDisplayDate('twenty-first century')).toEqual({ yearStart: 2001, yearEnd: 2100 });
+    });
+  });
 });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1,0 +1,149 @@
+import Database from 'better-sqlite3';
+import { mkdtempSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Cache } from '../src/db.js';
+import type { Artwork } from '../src/types.js';
+
+function makeArtwork(id: string): Artwork {
+  return {
+    id,
+    museum: { code: 'met', name: 'The Metropolitan Museum of Art', url: 'https://www.metmuseum.org' },
+    title: 'Test Work',
+    artist: { name: 'Test Artist', attributionType: 'named' },
+    displayDate: '1900',
+    yearStart: 1900,
+    yearEnd: 1900,
+    medium: 'Oil on canvas',
+    region: 'netherlands',
+    period: null,
+    imageUrls: { full: 'https://example.org/img.jpg' },
+    imageOpenAccess: true,
+    metadataOpenAccess: true,
+    license: {
+      type: 'CC0',
+      rawValue: 'true',
+      verificationSource: 'met.isPublicDomain',
+      verifiedAt: '2026-04-25T00:00:00Z',
+      confidence: 'high',
+    },
+    source: { apiUrl: 'https://example.org/api', pageUrl: 'https://example.org/page' },
+  };
+}
+
+describe('Cache', () => {
+  let dir: string;
+  let path: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'open-museum-mcp-cache-'));
+    path = join(dir, 'cache.db');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('round-trips an artwork through upsert/get', () => {
+    const cache = new Cache({ path });
+    const art = makeArtwork('met:1');
+    cache.upsertObject(art);
+    expect(cache.getObject('met:1')).toEqual(art);
+    cache.close();
+  });
+
+  it('returns null for an unknown id', () => {
+    const cache = new Cache({ path });
+    expect(cache.getObject('met:999')).toBe(null);
+    cache.close();
+  });
+
+  it('overwrites on conflict', () => {
+    const cache = new Cache({ path });
+    const a1 = makeArtwork('met:1');
+    cache.upsertObject(a1);
+    const a2 = { ...a1, title: 'New Title' };
+    cache.upsertObject(a2);
+    expect(cache.getObject('met:1')?.title).toBe('New Title');
+    cache.close();
+  });
+
+  it('treats expired object rows as cache misses', () => {
+    const cache = new Cache({ path });
+    cache.upsertObject(makeArtwork('met:1'));
+    cache.close();
+
+    // Directly age the row past the 90-day TTL.
+    const db = new Database(path);
+    const longAgo = new Date(Date.now() - 91 * 24 * 60 * 60 * 1000).toISOString();
+    db.prepare('UPDATE objects SET cached_at = ? WHERE id = ?').run(longAgo, 'met:1');
+    db.close();
+
+    const cache2 = new Cache({ path });
+    // pruneExpired (run in constructor) removes the row entirely.
+    expect(cache2.getObject('met:1')).toBe(null);
+    cache2.close();
+  });
+
+  it('round-trips query cache and respects TTL', () => {
+    const cache = new Cache({ path });
+    cache.putQuery('q:foo', ['met:1', 'met:2']);
+    expect(cache.getQuery('q:foo')).toEqual(['met:1', 'met:2']);
+    cache.close();
+
+    const db = new Database(path);
+    const longAgo = new Date(Date.now() - 15 * 24 * 60 * 60 * 1000).toISOString();
+    db.prepare('UPDATE query_cache SET cached_at = ? WHERE cache_key = ?').run(longAgo, 'q:foo');
+    db.close();
+
+    const cache2 = new Cache({ path });
+    expect(cache2.getQuery('q:foo')).toBe(null);
+    cache2.close();
+  });
+
+  it('treats malformed JSON as a cache miss instead of throwing', () => {
+    const cache = new Cache({ path });
+    cache.upsertObject(makeArtwork('met:1'));
+    cache.close();
+
+    const db = new Database(path);
+    db.prepare('UPDATE objects SET full_record = ? WHERE id = ?').run('{not json', 'met:1');
+    db.close();
+
+    const cache2 = new Cache({ path });
+    expect(cache2.getObject('met:1')).toBe(null);
+    cache2.close();
+  });
+
+  it('pruneExpired returns counts and clears stale rows', () => {
+    const cache = new Cache({ path });
+    cache.upsertObject(makeArtwork('met:1'));
+    cache.upsertObject(makeArtwork('met:2'));
+    cache.putQuery('q:a', ['met:1']);
+    cache.close();
+
+    const db = new Database(path);
+    const longAgo = new Date(Date.now() - 91 * 24 * 60 * 60 * 1000).toISOString();
+    db.prepare('UPDATE objects SET cached_at = ? WHERE id = ?').run(longAgo, 'met:1');
+    db.prepare('UPDATE query_cache SET cached_at = ?').run(longAgo);
+    db.close();
+
+    // Re-open: pruneExpired runs in the constructor.
+    const cache2 = new Cache({ path });
+    expect(cache2.getObject('met:1')).toBe(null);
+    expect(cache2.getObject('met:2')).not.toBe(null);
+    expect(cache2.getQuery('q:a')).toBe(null);
+    // Calling prune again on a clean DB returns zero counts.
+    expect(cache2.pruneExpired()).toEqual({ objects: 0, queries: 0 });
+    cache2.close();
+  });
+
+  it('creates the cache file with mode 0o600', () => {
+    const cache = new Cache({ path });
+    cache.upsertObject(makeArtwork('met:1'));
+    const mode = statSync(path).mode & 0o777;
+    expect(mode).toBe(0o600);
+    cache.close();
+  });
+});

--- a/tests/mappings.test.ts
+++ b/tests/mappings.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import {
+  cleanArtistName,
+  detectAttributionType,
+  normalizeRegion,
+} from '../src/mappings.js';
+
+describe('normalizeRegion', () => {
+  it('matches a canonical key by exact alias', () => {
+    expect(normalizeRegion('China')).toBe('china');
+    expect(normalizeRegion('Japanese')).toBe('japan');
+    expect(normalizeRegion('Dutch')).toBe('netherlands');
+  });
+
+  it('matches by substring (culture string with extra words)', () => {
+    expect(normalizeRegion('Tang dynasty')).toBe('china');
+    expect(normalizeRegion('Edo period, Kyoto')).toBe('japan');
+  });
+
+  it('returns null for null/empty/undefined input', () => {
+    expect(normalizeRegion('')).toBe(null);
+    expect(normalizeRegion(null)).toBe(null);
+    expect(normalizeRegion(undefined)).toBe(null);
+  });
+
+  it('returns null for unmapped culture', () => {
+    expect(normalizeRegion('Atlantis')).toBe(null);
+  });
+
+  it('maps "American" to americas', () => {
+    expect(normalizeRegion('American')).toBe('americas');
+  });
+});
+
+describe('detectAttributionType', () => {
+  it('returns "named" for a regular artist string', () => {
+    expect(detectAttributionType('Vincent van Gogh')).toBe('named');
+  });
+
+  it('returns "anonymous" for empty / whitespace / Unknown', () => {
+    expect(detectAttributionType('')).toBe('anonymous');
+    expect(detectAttributionType('   ')).toBe('anonymous');
+    expect(detectAttributionType('Unknown')).toBe('anonymous');
+    expect(detectAttributionType('Anonymous')).toBe('anonymous');
+    expect(detectAttributionType('Unidentified Artist')).toBe('anonymous');
+  });
+
+  it('detects workshop / attributed / circle / follower', () => {
+    expect(detectAttributionType('Workshop of Rubens')).toBe('workshop');
+    expect(detectAttributionType('Attributed to Rembrandt')).toBe('attributed');
+    expect(detectAttributionType('Circle of Caravaggio')).toBe('circle');
+    expect(detectAttributionType('Follower of Raphael')).toBe('follower');
+  });
+
+  it('detects "after" attribution', () => {
+    expect(detectAttributionType('After Goya')).toBe('after');
+  });
+
+  it('returns "named" for null/undefined', () => {
+    // Type-relaxed call to exercise the runtime guard.
+    expect(detectAttributionType(null)).toBe('anonymous');
+    expect(detectAttributionType(undefined)).toBe('anonymous');
+  });
+});
+
+describe('cleanArtistName', () => {
+  it('strips workshop/attributed/circle/follower/after prefixes', () => {
+    expect(cleanArtistName('Workshop of Rubens')).toBe('Rubens');
+    expect(cleanArtistName('Attributed to Rembrandt')).toBe('Rembrandt');
+    expect(cleanArtistName('Circle of Caravaggio')).toBe('Caravaggio');
+    expect(cleanArtistName('Follower of Raphael')).toBe('Raphael');
+    expect(cleanArtistName('After Goya')).toBe('Goya');
+  });
+
+  it('passes through a clean name', () => {
+    expect(cleanArtistName('Vincent van Gogh')).toBe('Vincent van Gogh');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(cleanArtistName('  Vincent van Gogh  ')).toBe('Vincent van Gogh');
+  });
+});


### PR DESCRIPTION
## Summary
Fix-pass addressing findings from a full-codebase review focused on the strict-default-deny rights gate (which holds — these are surrounding hardening items).

**Server (`src/server.ts`)**
- stderr log on every record rejection so silent search-time drops are diagnosable (README contract claimed this; code didn't deliver it)
- Tightened `ID_REGEX` to `^[a-z]+:[1-9]\d*$` — `met:000123` and `met:0` are now user errors instead of duplicate cache rows
- Inline 8-way concurrency cap on per-object fetches; the Met has no batch endpoint, so a `limit:50` search previously fanned out into 50 simultaneous requests
- Tool description corrected — was advertising `cleveland`/`aic` before adapters landed
- Removed dead `if (!code)` branch unreachable after `ID_REGEX`
- Documented the cache-key-includes-overfetch trade-off

**Date parser (`src/dateParser.ts`)**
- Removed dead `hasCe` computation in `hasMixedEras`
- Fixed `twenty-first` ordinal — suffix-stripping was mangling hyphenated forms before dictionary lookup
- Doc comment with strategy precedence order
- Inline comments on short-suffix range rollover and century-thirds math

**Met fetcher (`src/fetchers/met.ts`)**
- `(r.field as string)` casts replaced with `asString` / `asOptionalString` helpers (CONTRIBUTING says: type as `unknown` and narrow)
- `objectID` narrowed to positive integer with explicit reject path on missing/non-integer

**Cache (`src/db.ts`)**
- Class-level doc comment with TTL contract
- `pruneExpired()` runs on construction — long-lived clients no longer accumulate stale rows
- `JSON.parse` failures are treated as cache misses, not thrown errors
- `chmod 0600` on cache file creation

**Citation (`src/cite.ts`)**
- Doc comment covering style semantics and per-museum override fallback
- Comment explaining the `Unknown` vs `Unknown artist` asymmetry between short and caption forms

**Tests**
- New `tests/mappings.test.ts` (13 tests): `normalizeRegion`, `detectAttributionType`, `cleanArtistName`
- New `tests/db.test.ts` (8 tests): `Cache` round-trip, conflict overwrite, TTL expiry, JSON corruption fallback, `pruneExpired`, 0600 file mode
- Extended `tests/cite.test.ts`: anonymous-short, anonymous-full, non-Met fallback path
- Extended `tests/dateParser.test.ts`: strategy ordering invariant ("14th-15th century"), twenty-first century regression

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — **85/85 pass** (was 59)
- [x] `npm run build` — clean
- [x] `npm audit` — 0 vulnerabilities
- [x] Stub scan — no real stubs

## Diff stat
9 files changed, 489 insertions(+), 47 deletions(-)

Co-Authored by Pramod Prasanth <pramod@chainalign.com>