### PR TITLE
package.json: prep for npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,25 @@
 {
   "name": "open-museum-mcp",
   "version": "0.1.0",
-  "description": "MCP server for federated, license-verified search across open-access museum collections (The Met, Cleveland, AIC and more).",
+  "description": "MCP server for license-verified search across open-access museum collections (The Met, Cleveland, AIC and more).",
   "type": "module",
   "main": "dist/server.js",
   "bin": {
     "open-museum-mcp": "dist/server.js"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cfpramod/open-museum-mcp.git"
+  },
+  "bugs": {
+    "url": "https://github.com/cfpramod/open-museum-mcp/issues"
+  },
+  "homepage": "https://github.com/cfpramod/open-museum-mcp#readme",
   "scripts": {
     "build": "tsc",
     "dev": "tsx src/server.ts",


### PR DESCRIPTION
## Summary
Adds the package metadata needed for a clean \`npm publish\`. No version bump.

## Changes
- **\`files\` allowlist** — ships only \`dist/\`, \`README.md\`, \`LICENSE\`. The tarball stays at 32 files / ~30 kB packed instead of accidentally including \`src/\`, \`tests/\`, fixtures, or any future config files.
- **\`repository\`, \`bugs\`, \`homepage\`** — npmjs.com renders these as clickable links on the package page, pointing at GitHub.
- **Description** — dropped "federated" (overpromises while v0.1 is one museum).

## Verified with \`npm pack --dry-run\`

Tarball includes:
- \`dist/\` (compiled JS + .d.ts + sourcemaps + dynasty/region JSON data)
- \`README.md\` (11.7 kB)
- \`LICENSE\` (1.1 kB)
- \`package.json\`

Tarball excludes: \`src/\`, \`tests/\`, fixtures, \`tsconfig.json\`, \`vitest.config.ts\`, \`node_modules/\`, \`.gitignore\`.

Total: **29.8 kB packed, 100.7 kB unpacked, 32 files.**

## Test plan
- [x] \`npm run build\` produces \`dist/\` cleanly
- [x] \`npm pack --dry-run\` shows the expected file list
- [x] No version bump; existing \`v0.1.0\` tag remains valid

## Sequencing
After this PR + PR #3 (README polish) merge:
1. From \`main\`: \`npm login\` (one-time)
2. \`npm publish --access public\`
3. Update README install instructions to show the \`npx\` form (separate PR or piggybacked on the next change)

Co-Authored by Pramod Prasanth <pramod@chainalign.com>