### PR TITLE
README: lead install with npx now that the package is on npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,31 @@ A search call returns license-verified results in one normalized shape:
 
 ## Install
 
+The package is on npm. The simplest setup is to add it directly to your MCP client config; `npx` will fetch and run it on first launch:
+
+```json
+{
+  "mcpServers": {
+    "open-museum": {
+      "command": "npx",
+      "args": ["-y", "open-museum-mcp"]
+    }
+  }
+}
+```
+
+That's it. Restart your MCP client and the tools below become available.
+
+### From source (for contributors)
+
 ```bash
+git clone https://github.com/cfpramod/open-museum-mcp
+cd open-museum-mcp
 npm install
 npm run build
 ```
 
-### Wire into Claude Code
-
-Add to your MCP config (`.mcp.json` in a project, or your user-level config):
+Then point the MCP config at the built binary:
 
 ```json
 {
@@ -84,8 +101,6 @@ Add to your MCP config (`.mcp.json` in a project, or your user-level config):
   }
 }
 ```
-
-After restarting your MCP client, the tools below become available.
 
 ## Tools
 


### PR DESCRIPTION
## Summary
The simplest install is now a 4-line MCP config that uses \`npx\` to fetch and run \`open-museum-mcp@0.1.0\`. The clone-and-build path stays in the README under "From source (for contributors)" for people running off a working tree.

## Test plan
- [x] \`npx open-museum-mcp\` resolves to the published package on npm
- [x] Markdown renders cleanly on the PR page

Co-Authored by Pramod Prasanth <pramod@chainalign.com>