### PR TITLE
ci: GitHub Actions + status & npm version badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Node ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run typecheck
+
+      - run: npm test
+
+      - run: npm run build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # open-museum-mcp
 
+[![CI](https://github.com/cfpramod/open-museum-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/cfpramod/open-museum-mcp/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/open-museum-mcp.svg)](https://www.npmjs.com/package/open-museum-mcp)
+
 > Open-access museum search for MCP clients, with rights verification per museum.
 
 ## Why I built this


### PR DESCRIPTION
## Summary
Adds a minimal CI pipeline and two status badges at the top of the README.

## Workflow
\`.github/workflows/ci.yml\` runs on every push to \`main\` and every PR:
- \`npm ci\` (with the npm cache action so subsequent runs are fast)
- \`npm run typecheck\`
- \`npm test\`
- \`npm run build\`

Matrix tests on **Node 20 and Node 22**. \`fail-fast: false\` so a failure on one Node version doesn't suppress the other's signal. \`permissions: contents: read\` scopes down the default \`GITHUB_TOKEN\`.

## Badges
At the top of the README, just under the title:
- **CI badge** linking to the workflow runs page
- **npm version badge** linking to the package page (auto-updates on every publish)

## What this signals
A passing green CI badge is the cheapest credibility marker for a public OSS repo. Combined with the npm badge, a visitor can see at a glance: this builds, this tests, this is published.

## Test plan
- [x] Workflow file is valid YAML (verified locally with the same matrix syntax used elsewhere)
- [x] Badge URLs follow the GitHub Actions and shields.io conventions
- [ ] First CI run on this PR will green-light the workflow itself; if anything breaks (e.g. a Node-22-specific test failure), I'll fix it in a follow-up commit on this branch before merge

Co-Authored by Pramod Prasanth <pramod@chainalign.com>