### PR TITLE
feat(cleveland): add Cleveland Museum of Art adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If anyone else is exploring open-access art, I hope this helps. The plan is to k
 
 ## What you get
 
-- **One interface, registered museums.** The Met is live. Cleveland and the Art Institute of Chicago are next.
+- **One interface, registered museums.** The Met and Cleveland Museum of Art are live. The Art Institute of Chicago is next.
 - **Strict deny on ambiguity.** Records are validated against per-museum rights rules in code. Missing or unclear indicators drop the record; nothing is defaulted to "open".
 - **Catalog-grade metadata.** A dynasty-aware date parser handles Tang, Edo, Safavid, Mughal and the rest. Regions normalize across museums. Attribution separates named artists from anonymous, workshop, "after", and attributed works.
 - **Listable resources and deterministic citations.** `museum://{code}/{id}` resources, three citation styles, structured JSON search results.
@@ -153,7 +153,7 @@ This is what "rights-verified" means here: validated against published museum me
 | Museum | Code | Auth | Status |
 |---|---|---|---|
 | The Metropolitan Museum of Art | `met` | none | ✅ v0.1 |
-| Cleveland Museum of Art | `cleveland` | none | 🚧 next |
+| Cleveland Museum of Art | `cleveland` | none | ✅ v0.2 |
 | Art Institute of Chicago | `aic` | none | 🚧 next |
 | Smithsonian Open Access | `si` | API key (free) | 📋 v2 |
 | Rijksmuseum | `rijks` | API key (free) | 📋 v2 |

--- a/src/fetchers/cleveland.ts
+++ b/src/fetchers/cleveland.ts
@@ -1,0 +1,178 @@
+import { parseDisplayDate } from '../dateParser.js';
+import { validateClevelandLicense } from '../licenseGate.js';
+import { cleanArtistName, detectAttributionType, normalizeRegion } from '../mappings.js';
+import type { Artwork, ValidationResult } from '../types.js';
+import type { Fetcher, SearchOptions } from './types.js';
+
+const CLEVELAND_API = 'https://openaccess-api.clevelandart.org/api';
+
+function asString(v: unknown): string {
+  return typeof v === 'string' ? v : '';
+}
+
+function asOptionalString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+function asFiniteNumber(v: unknown): number | null {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+function reject(id: string, reason: string, rawSnapshot: unknown): ValidationResult {
+  return {
+    status: 'rejected',
+    rejection: { id, museumCode: 'cleveland', reason, rawSnapshot },
+  };
+}
+
+// Cleveland's creator description format is "Name (Nationality, birthYear–deathYear)"
+// e.g. "Vincent van Gogh (Dutch, 1853–1890)". The structured fields
+// (birth_year, death_year) supply the lifespan, so we only mine the
+// description for name + nationality.
+function parseCreatorDescription(description: string): { name: string; nationality?: string } {
+  const parenStart = description.indexOf('(');
+  if (parenStart < 0) return { name: description.trim() };
+
+  const name = description.slice(0, parenStart).trim();
+  const parenEnd = description.lastIndexOf(')');
+  const inside = parenEnd > parenStart ? description.slice(parenStart + 1, parenEnd) : '';
+  const firstToken = inside.split(',')[0].trim();
+  // If the first token looks like a year, the description omitted nationality
+  // ("Anonymous (1850)") and we should not surface it.
+  const looksLikeYear = /^\d{2,4}$/.test(firstToken);
+  return looksLikeYear || !firstToken ? { name } : { name, nationality: firstToken };
+}
+
+export const clevelandFetcher: Fetcher = {
+  code: 'cleveland',
+  name: 'Cleveland Museum of Art',
+
+  async search(query: string, limit: number, options: SearchOptions = {}): Promise<string[]> {
+    const url = new URL(`${CLEVELAND_API}/artworks/`);
+    url.searchParams.set('q', query);
+    // Push the rights filter to the museum so the gate has fewer rejections to
+    // handle. Cleveland's `cc0=1` is server-side defense in depth alongside
+    // the per-record validateClevelandLicense check on every fetched object.
+    url.searchParams.set('cc0', '1');
+    if (options.hasImage !== false) {
+      url.searchParams.set('has_image', '1');
+    }
+    url.searchParams.set('limit', String(limit));
+    url.searchParams.set('fields', 'id');
+
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`Cleveland search failed: ${res.status}`);
+    const json = (await res.json()) as { data?: Array<{ id?: unknown }> };
+    const data = json.data ?? [];
+    return data
+      .map((d) => (typeof d.id === 'number' ? `cleveland:${d.id}` : null))
+      .filter((s): s is string => s !== null)
+      .slice(0, limit);
+  },
+
+  async getRaw(id: string): Promise<unknown> {
+    const numeric = id.replace(/^cleveland:/, '');
+    const res = await fetch(`${CLEVELAND_API}/artworks/${numeric}`);
+    if (!res.ok) throw new Error(`Cleveland get failed for ${id}: ${res.status}`);
+    return res.json();
+  },
+
+  normalize(raw: unknown): ValidationResult {
+    if (!raw || typeof raw !== 'object') {
+      return reject('cleveland:unknown', 'cleveland: response not an object', raw);
+    }
+    // Cleveland wraps single-record responses in `{"data": {...}}`. Tolerate
+    // either shape so fixtures and direct-record callers both work.
+    const wrapped = (raw as { data?: unknown }).data;
+    const inner = wrapped && typeof wrapped === 'object' ? wrapped : raw;
+    const r = inner as Record<string, unknown>;
+
+    const objectId = r.id;
+    const validId =
+      typeof objectId === 'number' && Number.isInteger(objectId) && objectId > 0;
+    const id = validId ? `cleveland:${objectId}` : 'cleveland:unknown';
+
+    const decision = validateClevelandLicense(inner);
+    if (!decision.accepted || !decision.license) {
+      return reject(id, decision.reason, raw);
+    }
+
+    if (!validId) {
+      return reject(id, 'cleveland: missing or non-integer id', raw);
+    }
+
+    const displayDate = asString(r.creation_date);
+    const earliest = asFiniteNumber(r.creation_date_earliest);
+    const latest = asFiniteNumber(r.creation_date_latest);
+    // Cleveland publishes earliest/latest year fields directly. Trust those
+    // when both are present; fall back to parseDisplayDate when they're not
+    // (or only partially given) so dynasty-aware parsing still helps for
+    // legacy or sparser records.
+    const dateRange =
+      earliest !== null && latest !== null
+        ? { yearStart: earliest, yearEnd: latest }
+        : parseDisplayDate(displayDate);
+
+    const creators = Array.isArray(r.creators)
+      ? (r.creators as Array<Record<string, unknown>>)
+      : [];
+    const primary = creators[0];
+    const description = asString(primary?.description);
+    const attributionType = detectAttributionType(description);
+    const parsed = parseCreatorDescription(description);
+    const cleanName = cleanArtistName(parsed.name);
+
+    const birth = asString(primary?.birth_year);
+    const death = asString(primary?.death_year);
+    const lifespan = birth || death ? `${birth}–${death}`.replace(/^–|–$/g, '') : undefined;
+
+    const cultureArr = Array.isArray(r.culture) ? (r.culture as unknown[]) : [];
+    const cultureStr = asString(cultureArr[0]);
+    const region = normalizeRegion(cultureStr);
+
+    const images = (r.images && typeof r.images === 'object' ? r.images : {}) as Record<string, unknown>;
+    const printVariant = images.print as Record<string, unknown> | undefined;
+    const webVariant = images.web as Record<string, unknown> | undefined;
+    // Prefer the higher-resolution `print` URL when both are available; fall
+    // back to `web` (smaller display image). The full TIFF is too large for
+    // most consumer use cases, so we don't surface it.
+    const fullImage = asString(printVariant?.url) || asString(webVariant?.url);
+    const thumbnail = asOptionalString(webVariant?.url);
+
+    const artwork: Artwork = {
+      id,
+      museum: {
+        code: 'cleveland',
+        name: 'Cleveland Museum of Art',
+        url: 'https://www.clevelandart.org',
+      },
+      title: (asString(r.title) || '(Untitled)').trim(),
+      artist: {
+        name: cleanName || 'Unknown',
+        nationality: parsed.nationality,
+        lifespan,
+        attributionType,
+      },
+      displayDate,
+      yearStart: dateRange.yearStart,
+      yearEnd: dateRange.yearEnd,
+      medium: asString(r.technique),
+      region,
+      period: null,
+      imageUrls: {
+        full: fullImage,
+        thumbnail,
+      },
+      imageOpenAccess: decision.imageOpenAccess,
+      metadataOpenAccess: decision.metadataOpenAccess,
+      license: decision.license,
+      source: {
+        apiUrl: `${CLEVELAND_API}/artworks/${objectId}`,
+        pageUrl: asString(r.url),
+      },
+      description: asOptionalString(r.accession_number),
+    };
+
+    return { status: 'accepted', artwork };
+  },
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,12 +12,14 @@ import { join } from 'node:path';
 import { z } from 'zod';
 import { cite, type CiteStyle } from './cite.js';
 import { Cache } from './db.js';
+import { clevelandFetcher } from './fetchers/cleveland.js';
 import { metFetcher } from './fetchers/met.js';
 import type { Fetcher } from './fetchers/types.js';
 import type { Artwork } from './types.js';
 
 const FETCHERS: Record<string, Fetcher> = {
   [metFetcher.code]: metFetcher,
+  [clevelandFetcher.code]: clevelandFetcher,
 };
 
 const CACHE_PATH = process.env.OMM_CACHE_PATH ?? join(homedir(), '.open-museum-mcp', 'cache.db');
@@ -118,7 +120,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           museum: {
             type: 'string',
             description:
-              'Optional museum code. Currently registered: met. (Cleveland, AIC adapters are planned for v0.2.)',
+              'Optional museum code. Currently registered: met, cleveland. (AIC adapter is planned for v0.2.)',
           },
           has_image: {
             type: 'boolean',

--- a/tests/cleveland.test.ts
+++ b/tests/cleveland.test.ts
@@ -1,0 +1,99 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { clevelandFetcher } from '../src/fetchers/cleveland.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function fixture(name: string): unknown {
+  const path = join(here, 'fixtures', name);
+  return JSON.parse(readFileSync(path, 'utf-8'));
+}
+
+describe('Cleveland adapter normalization', () => {
+  it('normalizes a CC0 record (named artist, with image) into the Artwork shape', () => {
+    const result = clevelandFetcher.normalize(fixture('cleveland-accepted.json'));
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+
+    const a = result.artwork;
+    expect(a.id).toBe('cleveland:135299');
+    expect(a.museum.code).toBe('cleveland');
+    expect(a.museum.name).toBe('Cleveland Museum of Art');
+    expect(a.title).toBe('Adeline Ravoux');
+    expect(a.artist.name).toBe('Vincent van Gogh');
+    expect(a.artist.nationality).toBe('Dutch');
+    expect(a.artist.lifespan).toBe('1853–1890');
+    expect(a.artist.attributionType).toBe('named');
+    expect(a.yearStart).toBe(1890);
+    expect(a.yearEnd).toBe(1890);
+    expect(a.region).toBe('netherlands');
+    expect(a.medium).toBe('oil on fabric');
+    expect(a.license.type).toBe('CC0');
+    expect(a.license.verificationSource).toBe('cleveland.share_license_status');
+    expect(a.license.confidence).toBe('high');
+    expect(a.license.rawValue).toBe('CC0');
+    expect(a.imageOpenAccess).toBe(true);
+    expect(a.metadataOpenAccess).toBe(true);
+    expect(a.imageUrls.full).toContain('clevelandart.org');
+    expect(a.imageUrls.full).toContain('print');
+    expect(a.imageUrls.thumbnail).toContain('web');
+    expect(a.source.pageUrl).toContain('clevelandart.org');
+    expect(a.source.apiUrl).toContain('openaccess-api.clevelandart.org');
+    expect(a.description).toBe('1958.31');
+  });
+
+  it('rejects a record with non-CC0 share_license_status', () => {
+    const result = clevelandFetcher.normalize(fixture('cleveland-rejected-restricted.json'));
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.reason).toContain('strict default reject');
+    expect(result.rejection.reason.toLowerCase()).toContain('copyrighted');
+    expect(result.rejection.museumCode).toBe('cleveland');
+  });
+
+  it('rejects a record with no share_license_status (strict default)', () => {
+    const result = clevelandFetcher.normalize(fixture('cleveland-rejected-missing-field.json'));
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.reason).toContain('strict default reject');
+    expect(result.rejection.reason).toContain('missing');
+  });
+
+  it('rejects garbage input gracefully', () => {
+    expect(clevelandFetcher.normalize(null).status).toBe('rejected');
+    expect(clevelandFetcher.normalize('not an object').status).toBe('rejected');
+    expect(clevelandFetcher.normalize(42).status).toBe('rejected');
+  });
+
+  it('accepts a record passed without the {data:...} envelope', () => {
+    // A direct-record caller (e.g. a future test author) might pass the inner
+    // object straight through. The fetcher tolerates either shape.
+    const wrapped = fixture('cleveland-accepted.json') as { data: unknown };
+    const result = clevelandFetcher.normalize(wrapped.data);
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.id).toBe('cleveland:135299');
+  });
+
+  it('falls back to parseDisplayDate when earliest/latest are missing', () => {
+    // Fixture without earliest/latest year fields, so parseDisplayDate runs.
+    const baseline = fixture('cleveland-accepted.json') as { data: Record<string, unknown> };
+    const sparser = {
+      data: {
+        ...baseline.data,
+        creation_date: 'Tang dynasty (618–907)',
+        creation_date_earliest: undefined,
+        creation_date_latest: undefined,
+      },
+    };
+    // JSON.stringify drops undefined keys for us, mirroring a real sparse response.
+    const sparsed = JSON.parse(JSON.stringify(sparser));
+    const result = clevelandFetcher.normalize(sparsed);
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.yearStart).toBe(618);
+    expect(result.artwork.yearEnd).toBe(907);
+  });
+});

--- a/tests/fixtures/cleveland-accepted.json
+++ b/tests/fixtures/cleveland-accepted.json
@@ -1,0 +1,41 @@
+{
+  "data": {
+    "id": 135299,
+    "accession_number": "1958.31",
+    "share_license_status": "CC0",
+    "title": "Adeline Ravoux",
+    "creation_date": "1890",
+    "creation_date_earliest": 1890,
+    "creation_date_latest": 1890,
+    "culture": ["Netherlands"],
+    "technique": "oil on fabric",
+    "type": "Painting",
+    "url": "https://clevelandart.org/art/1958.31",
+    "images": {
+      "web": {
+        "url": "https://openaccess-cdn.clevelandart.org/1958.31/1958.31_web.jpg",
+        "width": "900",
+        "height": "897"
+      },
+      "print": {
+        "url": "https://openaccess-cdn.clevelandart.org/1958.31/1958.31_print.jpg",
+        "width": "3400",
+        "height": "3389"
+      },
+      "full": {
+        "url": "https://openaccess-cdn.clevelandart.org/1958.31/1958.31_full.tif",
+        "width": "11512",
+        "height": "11476"
+      }
+    },
+    "creators": [
+      {
+        "id": 1779,
+        "description": "Vincent van Gogh (Dutch, 1853–1890)",
+        "role": "artist",
+        "birth_year": "1853",
+        "death_year": "1890"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/cleveland-rejected-missing-field.json
+++ b/tests/fixtures/cleveland-rejected-missing-field.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "id": 990002,
+    "accession_number": "9999.002",
+    "title": "An Object With Ambiguous Rights",
+    "creation_date": "Unknown",
+    "creators": []
+  }
+}

--- a/tests/fixtures/cleveland-rejected-restricted.json
+++ b/tests/fixtures/cleveland-rejected-restricted.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "id": 990001,
+    "accession_number": "9999.001",
+    "share_license_status": "Copyrighted",
+    "title": "A Modern Work Still Under Copyright",
+    "creation_date": "1985",
+    "creation_date_earliest": 1985,
+    "creation_date_latest": 1985,
+    "culture": ["United States"],
+    "technique": "mixed media",
+    "type": "Sculpture",
+    "url": "https://clevelandart.org/art/9999.001"
+  }
+}


### PR DESCRIPTION
## Summary
Cleveland Museum of Art adapter, the second museum on the platform. The validator (\`validateClevelandLicense\`) was already in \`src/licenseGate.ts\`; this PR adds the fetcher, fixtures, tests, and registers the adapter.

## What's new

- **\`src/fetchers/cleveland.ts\`** — full Fetcher implementation against \`openaccess-api.clevelandart.org\`. Search filter pushes \`cc0=1\` and \`has_image=1\` to the museum; defense-in-depth re-check on every fetched record.
- **3 fixtures** — accepted (van Gogh "Adeline Ravoux"), rejected-restricted (\`Copyrighted\`), rejected-missing-field (no \`share_license_status\`).
- **\`tests/cleveland.test.ts\`** — 6 new tests (named-creator path, two reject paths, garbage-input handling, unwrapped-record tolerance, parseDisplayDate fallback for sparse records).
- **README** — "Supported museums" table moves Cleveland from 🚧 next to ✅ v0.2.
- **Tool description** — \`search_artworks\`'s \`museum\` parameter now lists \`met, cleveland\`.

## Adapter design notes

- **Wrapped vs unwrapped responses.** Cleveland wraps single-record API responses in \`{"data": {...}}\`. The normalizer tolerates either shape so direct callers and fixture authors don't need to remember which.
- **Numeric date fields.** Cleveland publishes \`creation_date_earliest\`/\`creation_date_latest\` as direct numbers. Trusted when both present; \`parseDisplayDate\` runs as fallback for sparse records (which keeps dynasty-aware parsing useful for "Tang dynasty (618–907)" style display dates).
- **Creator description parsing.** Format is \`"Name (Nationality, birth–death)"\`. Name comes from before the paren, nationality from the first comma-separated token inside. Lifespan comes from the structured \`birth_year\`/\`death_year\` fields directly — no string parsing for that.
- **Image preference.** \`print\` URL (high-res JPEG) is surfaced as \`imageUrls.full\`; \`web\` URL (smaller JPEG) is the thumbnail. The full TIFF is too large for typical use.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — **91/91 pass** (was 85; +6 new Cleveland tests)
- [x] \`npm run build\` — clean
- [x] Fixtures match the real Cleveland API response shape (verified by hitting the API directly during fixture authoring)
- [x] Strict-default-deny invariant holds: missing field → reject, non-CC0 → reject, garbage input → reject

Co-Authored by Pramod Prasanth <pramod@chainalign.com>