### PR TITLE
cleveland: address PR #7 review feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,8 +196,8 @@ Highlights:
 
 ## Roadmap
 
-- v0.1: Met adapter, dynasty-aware date parser, license gate, `cite` tool, MCP resources. **(here)**
-- v0.2: Cleveland and AIC adapters, `discover_random` with constraints (`region`, `period`, `not_artist`), `list_traditions`.
+- v0.1: Met adapter, dynasty-aware date parser, license gate, `cite` tool, MCP resources.
+- v0.2: Cleveland adapter (shipped); AIC adapter, `discover_random` with constraints (`region`, `period`, `not_artist`), `list_traditions` next. **(here)**
 - v0.5: Dominant-color extraction across museums (`color: "#3a5f7d"` discovery via `sharp`).
 - v1.0: Artist-obscurity scoring (`object_count_total`, `museum_count`) for deliberate exploration of less-canonical work.
 - v2.0: Smithsonian, Rijksmuseum, Wikimedia Commons (long-tail).

--- a/src/fetchers/cleveland.ts
+++ b/src/fetchers/cleveland.ts
@@ -105,9 +105,11 @@ export const clevelandFetcher: Fetcher = {
     const earliest = asFiniteNumber(r.creation_date_earliest);
     const latest = asFiniteNumber(r.creation_date_latest);
     // Cleveland publishes earliest/latest year fields directly. Trust those
-    // when both are present; fall back to parseDisplayDate when they're not
-    // (or only partially given) so dynasty-aware parsing still helps for
-    // legacy or sparser records.
+    // when both are present; otherwise fall through to parseDisplayDate. We
+    // prefer the display-date parser over a single available bound because
+    // the displayDate string usually carries a richer signal — "1850s"
+    // parses to {1850, 1859}, more informative than an isolated
+    // creation_date_earliest=1850 with creation_date_latest missing.
     const dateRange =
       earliest !== null && latest !== null
         ? { yearStart: earliest, yearEnd: latest }

--- a/tests/cleveland.test.ts
+++ b/tests/cleveland.test.ts
@@ -67,6 +67,17 @@ describe('Cleveland adapter normalization', () => {
     expect(clevelandFetcher.normalize(42).status).toBe('rejected');
   });
 
+  it('surfaces "cleveland:unknown" id on CC0-but-missing-id rejections', () => {
+    // Record passes the rights gate but has no integer `id` — the fetcher
+    // still rejects (downstream ID_REGEX would reject anyway), and the
+    // rejection carries a placeholder id for log diagnostics.
+    const result = clevelandFetcher.normalize({ data: { share_license_status: 'CC0' } });
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.id).toBe('cleveland:unknown');
+    expect(result.rejection.reason).toContain('missing or non-integer id');
+  });
+
   it('accepts a record passed without the {data:...} envelope', () => {
     // A direct-record caller (e.g. a future test author) might pass the inner
     // object straight through. The fetcher tolerates either shape.


### PR DESCRIPTION
## Summary
Three small follow-ups to the PR #7 code review (which landed at 9.5/10 with one Important and two Suggestions). Addresses each on top of merged \`main\`.

## Changes

**Important** — README Roadmap reconciliation
The "Supported museums" table moved Cleveland to ✅ v0.2 in PR #7, but the Roadmap line still listed Cleveland as v0.2-planned. Now reads: "Cleveland adapter (shipped); AIC adapter, \`discover_random\` ... next."

**Suggestion** — Document the partial-info date fallback
The reviewer flagged that the date logic silently falls through to \`parseDisplayDate\` when only one of \`creation_date_earliest\`/\`creation_date_latest\` is given. Decision: keep the fallback (the displayDate string usually carries a richer signal than a single bound — "1850s" → 1850–1859 vs. an isolated earliest=1850). Documented why in the comment so future readers don't re-litigate.

**Suggestion** — Test for \`cleveland:unknown\` id surfacing
Added a unit test asserting that when a record passes the rights gate but has no integer \`id\`, the rejection carries \`cleveland:unknown\` as a placeholder. The reviewer flagged this assertion was missing; it's now there.

## Deferred (out of scope here)

- DRY-out of \`asString\`/\`asOptionalString\`/\`asFiniteNumber\` into \`src/fetchers/helpers.ts\` — agreed-on follow-up, will land with the AIC adapter PR (where the duplication would otherwise grow).
- Nested-paren creator description handling — Cleveland doesn't ship these today; will revisit if a real-world record surfaces it.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — **92/92 pass** (was 91, +1 new)
- [x] \`npm run build\` — clean
- [x] CI workflow on this PR will validate against main's protection rules (Node 20, Node 22)

Co-Authored by Pramod Prasanth <pramod@chainalign.com>