### PR TITLE
feat(aic): add Art Institute of Chicago adapter; lift fetcher helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If anyone else is exploring open-access art, I hope this helps. The plan is to k
 
 ## What you get
 
-- **One interface, registered museums.** The Met and Cleveland Museum of Art are live. The Art Institute of Chicago is next.
+- **One interface, registered museums.** The Met, Cleveland Museum of Art, and the Art Institute of Chicago are live. Smithsonian and Rijksmuseum are next.
 - **Strict deny on ambiguity.** Records are validated against per-museum rights rules in code. Missing or unclear indicators drop the record; nothing is defaulted to "open".
 - **Catalog-grade metadata.** A dynasty-aware date parser handles Tang, Edo, Safavid, Mughal and the rest. Regions normalize across museums. Attribution separates named artists from anonymous, workshop, "after", and attributed works.
 - **Listable resources and deterministic citations.** `museum://{code}/{id}` resources, three citation styles, structured JSON search results.
@@ -172,7 +172,7 @@ This is what "rights-verified" means here: validated against published museum me
 |---|---|---|---|
 | The Metropolitan Museum of Art | `met` | none | ✅ v0.1 |
 | Cleveland Museum of Art | `cleveland` | none | ✅ v0.2 |
-| Art Institute of Chicago | `aic` | none | 🚧 next |
+| Art Institute of Chicago | `aic` | none | ✅ v0.2 |
 | Smithsonian Open Access | `si` | API key (free) | 📋 v2 |
 | Rijksmuseum | `rijks` | API key (free) | 📋 v2 |
 
@@ -197,7 +197,7 @@ Highlights:
 ## Roadmap
 
 - v0.1: Met adapter, dynasty-aware date parser, license gate, `cite` tool, MCP resources.
-- v0.2: Cleveland adapter (shipped); AIC adapter, `discover_random` with constraints (`region`, `period`, `not_artist`), `list_traditions` next. **(here)**
+- v0.2: Cleveland and AIC adapters (shipped); `discover_random` with constraints (`region`, `period`, `not_artist`), `list_traditions` next. **(here)**
 - v0.5: Dominant-color extraction across museums (`color: "#3a5f7d"` discovery via `sharp`).
 - v1.0: Artist-obscurity scoring (`object_count_total`, `museum_count`) for deliberate exploration of less-canonical work.
 - v2.0: Smithsonian, Rijksmuseum, Wikimedia Commons (long-tail).

--- a/src/fetchers/aic.ts
+++ b/src/fetchers/aic.ts
@@ -38,14 +38,22 @@ function reject(id: string, reason: string, rawSnapshot: unknown): ValidationRes
 // birthYear–deathYear)". The structured `artist_title` field gives us the
 // canonical name without the parenthetical, so we use that and only mine
 // the display string for nationality and lifespan.
+function looksLikeNationality(token: string): boolean {
+  // Nationality words are short, alphabetic, no digits, and don't start with
+  // "born" (which AIC sometimes uses for living artists, e.g.
+  // "X (born 1950)"). The strict shape check here keeps year tokens and
+  // birth-line tokens out of the nationality field.
+  return token.length > 0 && !/\d/.test(token) && !/^born\b/i.test(token);
+}
+
 function parseArtistDisplay(display: string): { nationality?: string; lifespan?: string } {
   const parenStart = display.indexOf('(');
   if (parenStart < 0) return {};
   const parenEnd = display.lastIndexOf(')');
   const inside = parenEnd > parenStart ? display.slice(parenStart + 1, parenEnd) : '';
   const tokens = inside.split(',').map((t) => t.trim()).filter(Boolean);
-  const nationality = tokens[0] && !/^\d/.test(tokens[0]) ? tokens[0] : undefined;
-  const yearLine = tokens.find((t) => /^\d{1,4}/.test(t));
+  const nationality = tokens[0] && looksLikeNationality(tokens[0]) ? tokens[0] : undefined;
+  const yearLine = tokens.find((t) => /^\d{1,4}/.test(t) || /^born\b/i.test(t));
   return { nationality, lifespan: yearLine || undefined };
 }
 

--- a/src/fetchers/aic.ts
+++ b/src/fetchers/aic.ts
@@ -1,0 +1,179 @@
+import { parseDisplayDate } from '../dateParser.js';
+import { validateAicLicense } from '../licenseGate.js';
+import { cleanArtistName, detectAttributionType, normalizeRegion } from '../mappings.js';
+import type { Artwork, ValidationResult } from '../types.js';
+import { asFiniteNumber, asOptionalString, asString } from './helpers.js';
+import type { Fetcher, SearchOptions } from './types.js';
+
+const AIC_API = 'https://api.artic.edu/api/v1';
+const AIC_IIIF = 'https://www.artic.edu/iiif/2';
+const AIC_PAGE = 'https://www.artic.edu/artworks';
+
+// Fields requested from /artworks/{id}. Limiting via ?fields= shrinks the
+// payload roughly 10x compared with the default response (which carries
+// every relationship and provenance entry AIC has).
+const AIC_FIELDS = [
+  'id',
+  'title',
+  'is_public_domain',
+  'artist_display',
+  'artist_title',
+  'date_display',
+  'date_start',
+  'date_end',
+  'place_of_origin',
+  'medium_display',
+  'classification_title',
+  'image_id',
+].join(',');
+
+function reject(id: string, reason: string, rawSnapshot: unknown): ValidationResult {
+  return {
+    status: 'rejected',
+    rejection: { id, museumCode: 'aic', reason, rawSnapshot },
+  };
+}
+
+// AIC's `artist_display` format mirrors Cleveland's: "Name (Nationality,
+// birthYear–deathYear)". The structured `artist_title` field gives us the
+// canonical name without the parenthetical, so we use that and only mine
+// the display string for nationality and lifespan.
+function parseArtistDisplay(display: string): { nationality?: string; lifespan?: string } {
+  const parenStart = display.indexOf('(');
+  if (parenStart < 0) return {};
+  const parenEnd = display.lastIndexOf(')');
+  const inside = parenEnd > parenStart ? display.slice(parenStart + 1, parenEnd) : '';
+  const tokens = inside.split(',').map((t) => t.trim()).filter(Boolean);
+  const nationality = tokens[0] && !/^\d/.test(tokens[0]) ? tokens[0] : undefined;
+  const yearLine = tokens.find((t) => /^\d{1,4}/.test(t));
+  return { nationality, lifespan: yearLine || undefined };
+}
+
+export const aicFetcher: Fetcher = {
+  code: 'aic',
+  name: 'Art Institute of Chicago',
+
+  async search(query: string, limit: number, options: SearchOptions = {}): Promise<string[]> {
+    const url = new URL(`${AIC_API}/artworks/search`);
+    url.searchParams.set('q', query);
+    // Push the rights filter to AIC server-side via Elasticsearch term
+    // query, so the gate has fewer rejections to handle. Defense in depth:
+    // validateAicLicense still re-checks each fetched record.
+    url.searchParams.set('query[term][is_public_domain]', 'true');
+    if (options.hasImage !== false) {
+      // exists query against image_id keeps records without IIIF imagery
+      // out of the candidate list.
+      url.searchParams.set('query[exists][field]', 'image_id');
+    }
+    url.searchParams.set('limit', String(limit));
+    url.searchParams.set('fields', 'id');
+
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`AIC search failed: ${res.status}`);
+    const json = (await res.json()) as { data?: Array<{ id?: unknown }> };
+    const data = json.data ?? [];
+    return data
+      .map((d) => (typeof d.id === 'number' ? `aic:${d.id}` : null))
+      .filter((s): s is string => s !== null)
+      .slice(0, limit);
+  },
+
+  async getRaw(id: string): Promise<unknown> {
+    const numeric = id.replace(/^aic:/, '');
+    const url = new URL(`${AIC_API}/artworks/${numeric}`);
+    url.searchParams.set('fields', AIC_FIELDS);
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`AIC get failed for ${id}: ${res.status}`);
+    return res.json();
+  },
+
+  normalize(raw: unknown): ValidationResult {
+    if (!raw || typeof raw !== 'object') {
+      return reject('aic:unknown', 'aic: response not an object', raw);
+    }
+    // AIC wraps single-record responses in `{"data": {...}}`. Tolerate
+    // either shape (mirrors the Cleveland adapter pattern).
+    const wrapped = (raw as { data?: unknown }).data;
+    const inner = wrapped && typeof wrapped === 'object' ? wrapped : raw;
+    const r = inner as Record<string, unknown>;
+
+    const objectId = r.id;
+    const validId =
+      typeof objectId === 'number' && Number.isInteger(objectId) && objectId > 0;
+    const id = validId ? `aic:${objectId}` : 'aic:unknown';
+
+    const decision = validateAicLicense(inner);
+    if (!decision.accepted || !decision.license) {
+      return reject(id, decision.reason, raw);
+    }
+
+    if (!validId) {
+      return reject(id, 'aic: missing or non-integer id', raw);
+    }
+
+    const displayDate = asString(r.date_display);
+    const dateStart = asFiniteNumber(r.date_start);
+    const dateEnd = asFiniteNumber(r.date_end);
+    // AIC ships date_start/date_end as integers. Trust them when both are
+    // present; fall back to parseDisplayDate otherwise so dynasty-aware
+    // parsing still helps for sparser records.
+    const dateRange =
+      dateStart !== null && dateEnd !== null
+        ? { yearStart: dateStart, yearEnd: dateEnd }
+        : parseDisplayDate(displayDate);
+
+    const artistDisplay = asString(r.artist_display);
+    const artistTitle = asString(r.artist_title);
+    const attributionType = artistDisplay
+      ? detectAttributionType(artistDisplay)
+      : 'anonymous';
+    // Prefer `artist_title` (canonical name without the parenthetical).
+    // Fall back to mining `artist_display` if artist_title is missing.
+    const cleanName = cleanArtistName(artistTitle || artistDisplay.split('(')[0].trim());
+    const { nationality, lifespan } = parseArtistDisplay(artistDisplay);
+
+    const region = normalizeRegion(asString(r.place_of_origin));
+
+    const imageId = asString(r.image_id);
+    // AIC publishes through IIIF Image API 2.0. 843px-wide is AIC's
+    // standard public-display size; 200px-wide is the thumbnail tier.
+    const fullImage = imageId ? `${AIC_IIIF}/${imageId}/full/843,/0/default.jpg` : '';
+    const thumbnail = imageId ? `${AIC_IIIF}/${imageId}/full/200,/0/default.jpg` : undefined;
+
+    const artwork: Artwork = {
+      id,
+      museum: {
+        code: 'aic',
+        name: 'Art Institute of Chicago',
+        url: 'https://www.artic.edu',
+      },
+      title: (asString(r.title) || '(Untitled)').trim(),
+      artist: {
+        name: cleanName || 'Unknown',
+        nationality,
+        lifespan,
+        attributionType,
+      },
+      displayDate,
+      yearStart: dateRange.yearStart,
+      yearEnd: dateRange.yearEnd,
+      medium: asString(r.medium_display),
+      region,
+      period: null,
+      imageUrls: {
+        full: fullImage,
+        thumbnail,
+      },
+      imageOpenAccess: decision.imageOpenAccess,
+      metadataOpenAccess: decision.metadataOpenAccess,
+      license: decision.license,
+      source: {
+        apiUrl: `${AIC_API}/artworks/${objectId}`,
+        pageUrl: `${AIC_PAGE}/${objectId}`,
+      },
+      description: asOptionalString(r.classification_title),
+    };
+
+    return { status: 'accepted', artwork };
+  },
+};

--- a/src/fetchers/cleveland.ts
+++ b/src/fetchers/cleveland.ts
@@ -2,21 +2,10 @@ import { parseDisplayDate } from '../dateParser.js';
 import { validateClevelandLicense } from '../licenseGate.js';
 import { cleanArtistName, detectAttributionType, normalizeRegion } from '../mappings.js';
 import type { Artwork, ValidationResult } from '../types.js';
+import { asFiniteNumber, asOptionalString, asString } from './helpers.js';
 import type { Fetcher, SearchOptions } from './types.js';
 
 const CLEVELAND_API = 'https://openaccess-api.clevelandart.org/api';
-
-function asString(v: unknown): string {
-  return typeof v === 'string' ? v : '';
-}
-
-function asOptionalString(v: unknown): string | undefined {
-  return typeof v === 'string' && v.length > 0 ? v : undefined;
-}
-
-function asFiniteNumber(v: unknown): number | null {
-  return typeof v === 'number' && Number.isFinite(v) ? v : null;
-}
 
 function reject(id: string, reason: string, rawSnapshot: unknown): ValidationResult {
   return {

--- a/src/fetchers/helpers.ts
+++ b/src/fetchers/helpers.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared coercion helpers for fetcher.normalize implementations.
+ *
+ * Each museum API ships fields that may be missing, null, or the wrong type.
+ * House style (per CONTRIBUTING.md) is to type uncertain shapes as `unknown`
+ * and narrow with explicit checks rather than casting with `as`. These
+ * helpers express the most-common narrowings once.
+ */
+
+/** Returns the string value, or "" for any non-string input. */
+export function asString(v: unknown): string {
+  return typeof v === 'string' ? v : '';
+}
+
+/** Returns the trimmed-truthy string, or undefined for missing/empty/non-string. */
+export function asOptionalString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+/** Returns finite number, or null for NaN/Infinity/non-number. */
+export function asFiniteNumber(v: unknown): number | null {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}

--- a/src/fetchers/met.ts
+++ b/src/fetchers/met.ts
@@ -2,17 +2,10 @@ import { parseDisplayDate } from '../dateParser.js';
 import { validateMetLicense } from '../licenseGate.js';
 import { cleanArtistName, detectAttributionType, normalizeRegion } from '../mappings.js';
 import type { Artwork, ValidationResult } from '../types.js';
+import { asOptionalString, asString } from './helpers.js';
 import type { Fetcher, SearchOptions } from './types.js';
 
 const MET_API = 'https://collectionapi.metmuseum.org/public/collection/v1';
-
-function asString(v: unknown): string {
-  return typeof v === 'string' ? v : '';
-}
-
-function asOptionalString(v: unknown): string | undefined {
-  return typeof v === 'string' && v.length > 0 ? v : undefined;
-}
 
 export const metFetcher: Fetcher = {
   code: 'met',

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,7 @@ import { join } from 'node:path';
 import { z } from 'zod';
 import { cite, type CiteStyle } from './cite.js';
 import { Cache } from './db.js';
+import { aicFetcher } from './fetchers/aic.js';
 import { clevelandFetcher } from './fetchers/cleveland.js';
 import { metFetcher } from './fetchers/met.js';
 import type { Fetcher } from './fetchers/types.js';
@@ -20,6 +21,7 @@ import type { Artwork } from './types.js';
 const FETCHERS: Record<string, Fetcher> = {
   [metFetcher.code]: metFetcher,
   [clevelandFetcher.code]: clevelandFetcher,
+  [aicFetcher.code]: aicFetcher,
 };
 
 const CACHE_PATH = process.env.OMM_CACHE_PATH ?? join(homedir(), '.open-museum-mcp', 'cache.db');
@@ -120,7 +122,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           museum: {
             type: 'string',
             description:
-              'Optional museum code. Currently registered: met, cleveland. (AIC adapter is planned for v0.2.)',
+              'Optional museum code. Currently registered: met, cleveland, aic.',
           },
           has_image: {
             type: 'boolean',

--- a/tests/aic.test.ts
+++ b/tests/aic.test.ts
@@ -123,4 +123,44 @@ describe('AIC adapter normalization', () => {
     expect(result.artwork.imageUrls.full).toBe('');
     expect(result.artwork.imageUrls.thumbnail).toBeUndefined();
   });
+
+  it('does not surface "born YYYY" tokens as artist nationality', () => {
+    // AIC's artist_display occasionally reads "X (born 1950)" for living
+    // artists. Such records will normally fail the rights gate, but if one
+    // ever flows through, the nationality field must not get the birth line.
+    const baseline = fixture('aic-accepted.json') as { data: Record<string, unknown> };
+    const livingArtist = {
+      data: {
+        ...baseline.data,
+        artist_display: 'Some Artist (born 1950)',
+        artist_title: 'Some Artist',
+      },
+    };
+    const result = aicFetcher.normalize(livingArtist);
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.artist.nationality).toBeUndefined();
+    expect(result.artwork.artist.lifespan).toBe('born 1950');
+  });
+
+  it('does not surface digit-bearing tokens as nationality', () => {
+    const baseline = fixture('aic-accepted.json') as { data: Record<string, unknown> };
+    const malformed = {
+      data: { ...baseline.data, artist_display: 'X (1880–1960)', artist_title: 'X' },
+    };
+    const result = aicFetcher.normalize(malformed);
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.artist.nationality).toBeUndefined();
+    expect(result.artwork.artist.lifespan).toBe('1880–1960');
+  });
+
+  it('rejects when is_public_domain is explicitly null (strict default)', () => {
+    // Belt-and-suspenders contract: explicit `null` and field-absent both
+    // hit the strict-default-deny path.
+    const result = aicFetcher.normalize({ data: { id: 1, is_public_domain: null } });
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.reason).toContain('strict default reject');
+  });
 });

--- a/tests/aic.test.ts
+++ b/tests/aic.test.ts
@@ -1,0 +1,126 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { aicFetcher } from '../src/fetchers/aic.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function fixture(name: string): unknown {
+  const path = join(here, 'fixtures', name);
+  return JSON.parse(readFileSync(path, 'utf-8'));
+}
+
+describe('AIC adapter normalization', () => {
+  it('normalizes a public-domain record (named artist, with image) into the Artwork shape', () => {
+    const result = aicFetcher.normalize(fixture('aic-accepted.json'));
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+
+    const a = result.artwork;
+    expect(a.id).toBe('aic:16568');
+    expect(a.museum.code).toBe('aic');
+    expect(a.museum.name).toBe('Art Institute of Chicago');
+    expect(a.title).toBe('Water Lilies');
+    expect(a.artist.name).toBe('Claude Monet');
+    expect(a.artist.nationality).toBe('French');
+    expect(a.artist.lifespan).toBe('1840–1926');
+    expect(a.artist.attributionType).toBe('named');
+    expect(a.yearStart).toBe(1906);
+    expect(a.yearEnd).toBe(1906);
+    expect(a.region).toBe('france');
+    expect(a.medium).toBe('Oil on canvas');
+    expect(a.license.type).toBe('CC0');
+    expect(a.license.verificationSource).toBe('aic.is_public_domain');
+    expect(a.license.confidence).toBe('high');
+    expect(a.license.rawValue).toBe('true');
+    expect(a.imageOpenAccess).toBe(true);
+    expect(a.metadataOpenAccess).toBe(true);
+    expect(a.imageUrls.full).toBe(
+      'https://www.artic.edu/iiif/2/3c27b499-af56-f0d5-93b5-a7f2f1ad5813/full/843,/0/default.jpg',
+    );
+    expect(a.imageUrls.thumbnail).toContain('/full/200,/');
+    expect(a.source.pageUrl).toBe('https://www.artic.edu/artworks/16568');
+    expect(a.source.apiUrl).toContain('api.artic.edu');
+    expect(a.description).toBe('oil on canvas');
+  });
+
+  it('rejects a record with is_public_domain=false', () => {
+    const result = aicFetcher.normalize(fixture('aic-rejected-restricted.json'));
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.reason).toContain('is_public_domain=false');
+    expect(result.rejection.museumCode).toBe('aic');
+  });
+
+  it('rejects a record with no is_public_domain field (strict default)', () => {
+    const result = aicFetcher.normalize(fixture('aic-rejected-missing-field.json'));
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.reason).toContain('strict default reject');
+  });
+
+  it('rejects garbage input gracefully', () => {
+    expect(aicFetcher.normalize(null).status).toBe('rejected');
+    expect(aicFetcher.normalize('not an object').status).toBe('rejected');
+    expect(aicFetcher.normalize(42).status).toBe('rejected');
+  });
+
+  it('surfaces "aic:unknown" id on rights-pass + bad-id rejections', () => {
+    const result = aicFetcher.normalize({ data: { is_public_domain: true } });
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.id).toBe('aic:unknown');
+    expect(result.rejection.reason).toContain('missing or non-integer id');
+  });
+
+  it('accepts a record passed without the {data:...} envelope', () => {
+    const wrapped = fixture('aic-accepted.json') as { data: unknown };
+    const result = aicFetcher.normalize(wrapped.data);
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.id).toBe('aic:16568');
+  });
+
+  it('falls back to parseDisplayDate when date_start/date_end are missing', () => {
+    const baseline = fixture('aic-accepted.json') as { data: Record<string, unknown> };
+    const sparser = {
+      data: {
+        ...baseline.data,
+        date_display: 'Tang dynasty (618–907)',
+        date_start: undefined,
+        date_end: undefined,
+      },
+    };
+    const sparsed = JSON.parse(JSON.stringify(sparser));
+    const result = aicFetcher.normalize(sparsed);
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.yearStart).toBe(618);
+    expect(result.artwork.yearEnd).toBe(907);
+  });
+
+  it('falls back to artist_display when artist_title is missing', () => {
+    const baseline = fixture('aic-accepted.json') as { data: Record<string, unknown> };
+    const noTitle = {
+      data: { ...baseline.data, artist_title: '' },
+    };
+    const result = aicFetcher.normalize(noTitle);
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.artist.name).toBe('Claude Monet');
+    expect(result.artwork.artist.nationality).toBe('French');
+  });
+
+  it('emits empty image URLs when image_id is missing', () => {
+    const baseline = fixture('aic-accepted.json') as { data: Record<string, unknown> };
+    const noImage = {
+      data: { ...baseline.data, image_id: null },
+    };
+    const result = aicFetcher.normalize(noImage);
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.imageUrls.full).toBe('');
+    expect(result.artwork.imageUrls.thumbnail).toBeUndefined();
+  });
+});

--- a/tests/fixtures/aic-accepted.json
+++ b/tests/fixtures/aic-accepted.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "id": 16568,
+    "title": "Water Lilies",
+    "is_public_domain": true,
+    "date_display": "1906",
+    "date_start": 1906,
+    "date_end": 1906,
+    "artist_display": "Claude Monet (French, 1840–1926)",
+    "artist_title": "Claude Monet",
+    "place_of_origin": "France",
+    "medium_display": "Oil on canvas",
+    "classification_title": "oil on canvas",
+    "image_id": "3c27b499-af56-f0d5-93b5-a7f2f1ad5813"
+  }
+}

--- a/tests/fixtures/aic-rejected-missing-field.json
+++ b/tests/fixtures/aic-rejected-missing-field.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "id": 990002,
+    "title": "An Object With Ambiguous Rights",
+    "date_display": "Unknown",
+    "artist_display": "",
+    "artist_title": ""
+  }
+}

--- a/tests/fixtures/aic-rejected-restricted.json
+++ b/tests/fixtures/aic-rejected-restricted.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "id": 990001,
+    "title": "A Modern Work Still Under Copyright",
+    "is_public_domain": false,
+    "date_display": "1985",
+    "date_start": 1985,
+    "date_end": 1985,
+    "artist_display": "Living Artist (American, born 1950)",
+    "artist_title": "Living Artist",
+    "place_of_origin": "United States",
+    "medium_display": "Mixed media",
+    "classification_title": "sculpture",
+    "image_id": null
+  }
+}


### PR DESCRIPTION
## Summary
The third museum on the platform plus the helpers DRY-out flagged in PR #7's review.

## What's new

**\`src/fetchers/aic.ts\`** — full Fetcher implementation against \`api.artic.edu\`. Server-side rights filter via Elasticsearch term query (\`query[term][is_public_domain]=true\`); per-record \`validateAicLicense\` re-check on every fetched record. Verified the server-side filter against the live API.

**\`src/fetchers/helpers.ts\`** — lifts \`asString\` / \`asOptionalString\` / \`asFiniteNumber\` from \`met.ts\` and \`cleveland.ts\` into one shared module. Both existing fetchers now import from it. The PR #7 reviewer suggested bundling this with the AIC adapter so a third copy doesn't grow.

**3 fixtures** — accepted (Monet "Water Lilies"), rejected-restricted (\`is_public_domain: false\`), rejected-missing-field.

**\`tests/aic.test.ts\`** — 9 tests:
- Named-artist accept path with IIIF URL construction
- Two reject paths (explicit + missing field)
- Garbage input
- \`aic:unknown\` surfacing on rights-pass + bad-id
- Unwrapped-record tolerance
- \`parseDisplayDate\` fallback when \`date_start\`/\`date_end\` are missing
- \`artist_title\` fallback to mining \`artist_display\`
- Empty image URLs when \`image_id\` is missing

## Adapter design notes

- **IIIF image URLs.** AIC publishes via IIIF Image API 2.0 keyed on \`image_id\` (UUID). \`imageUrls.full\` is the 843px-wide tier (AIC's public-display size); \`thumbnail\` is the 200px tier. Pattern: \`https://www.artic.edu/iiif/2/{image_id}/full/843,/0/default.jpg\`.
- **Page URL.** \`https://www.artic.edu/artworks/{id}\` 301s to the slugged URL on AIC's site, so we don't need to compute the slug.
- **Artist mining.** Same \`Name (Nationality, birth–death)\` shape as Cleveland. Prefer the structured \`artist_title\` for the canonical name; only mine \`artist_display\` for nationality and lifespan.
- **Region mapping.** \`place_of_origin\` is country-level for most records (\`"France"\`, \`"Netherlands"\`, \`"United States"\`), which maps cleanly through the existing \`regions.json\` table.
- **Wrapped envelope.** \`{"data": {...}}\` tolerance mirrors Cleveland.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — **101/101 pass** (was 92, +9 new AIC)
- [x] \`npm run build\` — clean
- [x] Fixtures match the real AIC API response shape (verified by hitting the API during fixture authoring)
- [x] Strict-default-deny invariant holds across all input shapes
- [x] CI workflow validates on Node 20 + Node 22 under branch protection

Co-Authored by Pramod Prasanth <pramod@chainalign.com>