### PR TITLE
feat(discover_random): random pick from cache with constraint filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Then point the MCP config at the built binary:
 | `search_artworks(query, museum?, has_image?, limit?)` | Search across registered museums. Returns only records that pass the rights gate. |
 | `get_artwork(id)` | Fetch a single artwork by its normalized ID (e.g. `met:436535`). |
 | `cite(id, style?)` | Render a citation. `style`: `full` (artist, title, date, museum, license, URL), `caption` (image attribution), `short` (inline). |
+| `discover_random(region?, period?, not_artist?, museum?)` | Pick one random artwork from the local cache that matches the constraints. Operates over what has already been searched and cached. Useful for breaking out of repetitive search territory. |
 
 ### `cite` example outputs
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -12,6 +12,20 @@ export interface CacheConfig {
 }
 
 /**
+ * Constraints for {@link Cache.getRandomObject}. All fields are AND-combined.
+ * Region and period are exact matches against the normalized values stored
+ * by each fetcher; museum is the registered code (`met`, `cleveland`, …);
+ * notArtist is an exact-match exclusion list against the canonical
+ * `artist_name` column.
+ */
+export interface DiscoverFilter {
+  region?: string;
+  period?: string;
+  notArtist?: string[];
+  museumCode?: string;
+}
+
+/**
  * SQLite-backed cache for normalized artworks and search-result IDs.
  *
  * TTL contract:
@@ -136,6 +150,56 @@ export class Cache {
       full_record: JSON.stringify(art),
       cached_at: new Date().toISOString(),
     });
+  }
+
+  /**
+   * Pick one random non-expired artwork that matches the constraints, or
+   * null if nothing matches.
+   *
+   * The query operates over the local cache only — meaning what the user
+   * has already searched and pulled. This is intentional: discover_random
+   * is a forcing-function over your search history, not a federated
+   * sample of every museum's catalog. Callers should seed the cache via
+   * search_artworks first.
+   *
+   * Note on `ORDER BY RANDOM()`: SQLite scans the matching set, which is
+   * fine for caches under ~100k rows. The cache here is bounded by what
+   * the user actually fetches and the 90-day object TTL.
+   */
+  getRandomObject(filter: DiscoverFilter): Artwork | null {
+    const conditions: string[] = [];
+    const params: (string | number)[] = [];
+
+    if (filter.region) {
+      conditions.push('region = ?');
+      params.push(filter.region);
+    }
+    if (filter.period) {
+      conditions.push('period = ?');
+      params.push(filter.period);
+    }
+    if (filter.museumCode) {
+      conditions.push('museum_code = ?');
+      params.push(filter.museumCode);
+    }
+    if (filter.notArtist && filter.notArtist.length > 0) {
+      const placeholders = filter.notArtist.map(() => '?').join(',');
+      conditions.push(`artist_name NOT IN (${placeholders})`);
+      params.push(...filter.notArtist);
+    }
+    // TTL gate: defense in depth on top of pruneExpired() at construction.
+    conditions.push('cached_at > ?');
+    params.push(new Date(Date.now() - OBJECT_TTL_DAYS * MS_PER_DAY).toISOString());
+
+    const where = `WHERE ${conditions.join(' AND ')}`;
+    const sql = `SELECT full_record FROM objects ${where} ORDER BY RANDOM() LIMIT 1`;
+    const row = this.db.prepare(sql).get(...params) as { full_record: string } | undefined;
+    if (!row) return null;
+    try {
+      return JSON.parse(row.full_record) as Artwork;
+    } catch {
+      return null;
+    }
   }
 
   getObject(id: string): Artwork | null {

--- a/src/server.ts
+++ b/src/server.ts
@@ -72,6 +72,13 @@ const CiteInput = z.object({
   style: z.enum(['short', 'full', 'caption']).default('full'),
 });
 
+const DiscoverInput = z.object({
+  region: z.string().optional(),
+  period: z.string().optional(),
+  not_artist: z.array(z.string()).optional(),
+  museum: z.string().optional(),
+});
+
 async function fetchAndCache(id: string): Promise<{ ok: true; artwork: Artwork } | { ok: false; reason: string }> {
   if (!ID_REGEX.test(id)) {
     return { ok: false, reason: `invalid artwork id: ${id}` };
@@ -162,6 +169,33 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ['id'],
       },
     },
+    {
+      name: 'discover_random',
+      description:
+        'Pick one random artwork from the local cache that matches the given constraints. Useful for breaking out of repetitive search territory (e.g. surface a random Edo-period work to satisfy a no-back-to-back-European-pre-1900 pairing rule). Operates over what has already been searched and cached; returns an error if nothing matches, suggesting the caller seed the cache via search_artworks first.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          region: {
+            type: 'string',
+            description: 'Normalized region tag (e.g. "china", "japan", "netherlands"). Exact match.',
+          },
+          period: {
+            type: 'string',
+            description: 'Normalized period tag (e.g. "tang dynasty", "edo", "safavid"). Exact match.',
+          },
+          not_artist: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Artist names to exclude (exact match against the canonical artist name field).',
+          },
+          museum: {
+            type: 'string',
+            description: 'Optional museum code to restrict to (met, cleveland, aic).',
+          },
+        },
+      },
+    },
   ],
 }));
 
@@ -237,12 +271,32 @@ async function handleCite(args: unknown) {
   return { content: [{ type: 'text' as const, text: cite(out.artwork, input.style as CiteStyle) }] };
 }
 
+async function handleDiscoverRandom(args: unknown) {
+  const input = DiscoverInput.parse(args);
+  if (input.museum && !FETCHERS[input.museum]) {
+    return errorResult(`unknown museum: ${input.museum}`);
+  }
+  const artwork = cache.getRandomObject({
+    region: input.region,
+    period: input.period,
+    notArtist: input.not_artist,
+    museumCode: input.museum,
+  });
+  if (!artwork) {
+    return errorResult(
+      'No cached artwork matches these constraints. Seed the cache with search_artworks first; discover_random samples from records you have already pulled.',
+    );
+  }
+  return { content: [{ type: 'text' as const, text: JSON.stringify(artwork, null, 2) }] };
+}
+
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
   try {
     if (name === 'search_artworks') return await handleSearch(args);
     if (name === 'get_artwork') return await handleGet(args);
     if (name === 'cite') return await handleCite(args);
+    if (name === 'discover_random') return await handleDiscoverRandom(args);
     return errorResult(`unknown tool: ${name}`);
   } catch (err) {
     if (err instanceof z.ZodError) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -73,10 +73,10 @@ const CiteInput = z.object({
 });
 
 const DiscoverInput = z.object({
-  region: z.string().optional(),
-  period: z.string().optional(),
-  not_artist: z.array(z.string()).optional(),
-  museum: z.string().optional(),
+  region: z.string().min(1).optional(),
+  period: z.string().min(1).optional(),
+  not_artist: z.array(z.string().min(1)).optional(),
+  museum: z.string().min(1).optional(),
 });
 
 async function fetchAndCache(id: string): Promise<{ ok: true; artwork: Artwork } | { ok: false; reason: string }> {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -276,4 +276,15 @@ describe('Cache.getRandomObject', () => {
     });
     expect(result).toBe(null);
   });
+
+  it('treats an empty notArtist array as no exclusion', () => {
+    // Locks down the `notArtist.length > 0` guard. With an empty list and no
+    // other filters, every cached record remains a candidate.
+    const seen = new Set<string>();
+    for (let i = 0; i < 50; i++) {
+      const result = cache.getRandomObject({ notArtist: [] });
+      if (result) seen.add(result.id);
+    }
+    expect(seen.size).toBeGreaterThan(1);
+  });
 });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -6,10 +6,17 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { Cache } from '../src/db.js';
 import type { Artwork } from '../src/types.js';
 
-function makeArtwork(id: string): Artwork {
+const MUSEUMS: Record<string, { code: string; name: string; url: string }> = {
+  met: { code: 'met', name: 'The Metropolitan Museum of Art', url: 'https://www.metmuseum.org' },
+  cleveland: { code: 'cleveland', name: 'Cleveland Museum of Art', url: 'https://www.clevelandart.org' },
+  aic: { code: 'aic', name: 'Art Institute of Chicago', url: 'https://www.artic.edu' },
+};
+
+function makeArtwork(id: string, overrides: Partial<Artwork> = {}): Artwork {
+  const code = id.split(':')[0];
   return {
     id,
-    museum: { code: 'met', name: 'The Metropolitan Museum of Art', url: 'https://www.metmuseum.org' },
+    museum: MUSEUMS[code] ?? MUSEUMS.met,
     title: 'Test Work',
     artist: { name: 'Test Artist', attributionType: 'named' },
     displayDate: '1900',
@@ -29,6 +36,7 @@ function makeArtwork(id: string): Artwork {
       confidence: 'high',
     },
     source: { apiUrl: 'https://example.org/api', pageUrl: 'https://example.org/page' },
+    ...overrides,
   };
 }
 
@@ -145,5 +153,127 @@ describe('Cache', () => {
     const mode = statSync(path).mode & 0o777;
     expect(mode).toBe(0o600);
     cache.close();
+  });
+});
+
+describe('Cache.getRandomObject', () => {
+  let dir: string;
+  let path: string;
+  let cache: Cache;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'open-museum-mcp-cache-'));
+    path = join(dir, 'cache.db');
+    cache = new Cache({ path });
+
+    cache.upsertObject(
+      makeArtwork('met:1', {
+        region: 'china',
+        period: 'tang dynasty',
+        artist: { name: 'Anonymous', attributionType: 'anonymous' },
+      }),
+    );
+    cache.upsertObject(
+      makeArtwork('met:2', {
+        region: 'japan',
+        period: 'edo',
+        artist: { name: 'Hokusai', attributionType: 'named' },
+      }),
+    );
+    cache.upsertObject(
+      makeArtwork('cleveland:3', {
+        region: 'netherlands',
+        period: null,
+        artist: { name: 'Vincent van Gogh', attributionType: 'named' },
+      }),
+    );
+    cache.upsertObject(
+      makeArtwork('cleveland:4', {
+        region: 'iran',
+        period: 'safavid',
+        artist: { name: 'Anonymous', attributionType: 'anonymous' },
+      }),
+    );
+    cache.upsertObject(
+      makeArtwork('aic:5', {
+        region: 'france',
+        period: null,
+        artist: { name: 'Claude Monet', attributionType: 'named' },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    cache.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('filters by region', () => {
+    const result = cache.getRandomObject({ region: 'japan' });
+    expect(result?.region).toBe('japan');
+    expect(result?.id).toBe('met:2');
+  });
+
+  it('filters by period', () => {
+    const result = cache.getRandomObject({ period: 'tang dynasty' });
+    expect(result?.period).toBe('tang dynasty');
+    expect(result?.id).toBe('met:1');
+  });
+
+  it('filters by museum code', () => {
+    for (let i = 0; i < 10; i++) {
+      const result = cache.getRandomObject({ museumCode: 'cleveland' });
+      expect(result?.museum.code).toBe('cleveland');
+    }
+  });
+
+  it('combines multiple constraints (AND)', () => {
+    const result = cache.getRandomObject({ region: 'iran', period: 'safavid' });
+    expect(result?.id).toBe('cleveland:4');
+  });
+
+  it('excludes artists in notArtist list', () => {
+    for (let i = 0; i < 30; i++) {
+      const result = cache.getRandomObject({ notArtist: ['Vincent van Gogh', 'Claude Monet'] });
+      if (result) {
+        expect(result.artist.name).not.toBe('Vincent van Gogh');
+        expect(result.artist.name).not.toBe('Claude Monet');
+      }
+    }
+  });
+
+  it('returns null when no records match', () => {
+    expect(cache.getRandomObject({ region: 'oceania' })).toBe(null);
+    expect(cache.getRandomObject({ period: 'jomon' })).toBe(null);
+    expect(cache.getRandomObject({ region: 'china', period: 'edo' })).toBe(null);
+  });
+
+  it('skips expired rows', () => {
+    cache.close();
+    const db = new Database(path);
+    const longAgo = new Date(Date.now() - 91 * 24 * 60 * 60 * 1000).toISOString();
+    db.prepare('UPDATE objects SET cached_at = ?').run(longAgo);
+    db.close();
+    // Re-open: pruneExpired runs at construction, removing the rows.
+    cache = new Cache({ path });
+    expect(cache.getRandomObject({})).toBe(null);
+  });
+
+  it('returns randomized results across queries (statistical)', () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      const result = cache.getRandomObject({});
+      if (result) seen.add(result.id);
+    }
+    // With 5 records seeded, we should hit at least 2 distinct IDs over 100
+    // pulls (the chance of single-ID outcome under uniform random is < 1e-69).
+    expect(seen.size).toBeGreaterThan(1);
+  });
+
+  it('matches no rows when notArtist excludes everything', () => {
+    const result = cache.getRandomObject({
+      notArtist: ['Anonymous', 'Hokusai', 'Vincent van Gogh', 'Claude Monet'],
+    });
+    expect(result).toBe(null);
   });
 });


### PR DESCRIPTION
## Summary
The forcing-function tool from the v0.2 roadmap. \`discover_random\` picks one random non-expired artwork from the local cache that matches a set of constraints — useful for breaking out of repetitive search territory ("no back-to-back European pre-1900 pairings", "give me an Edo-period work I haven't pulled before").

Operates over the cache only — meaning what the user has already searched and pulled. This is intentional: it's a function over your existing search history, not a federated sample of every museum's full catalog. When nothing matches, the tool returns an error pointing at the seed-via-search workflow rather than implying a bug.

## What's new

**\`Cache.getRandomObject(filter)\`** in \`src/db.ts\` — AND-combined filters (region, period, museumCode, notArtist), parameterized SQL, TTL gate, JSON.parse recovery to null. \`ORDER BY RANDOM()\` over the matching set.

**\`discover_random\` tool** in \`src/server.ts\` — Zod-validated input, museum code checked against registered FETCHERS, empty-result error shaped to be actionable rather than confusing.

**Test helper refactor** — \`makeArtwork\` in \`tests/db.test.ts\` now derives the museum from the id prefix and accepts \`Partial<Artwork>\` overrides. Needed for multi-museum seeding in the new tests; reusable for future fetcher additions.

**Tests (9 new):**
- region / period / museum / notArtist filters individually
- multi-constraint AND
- no-match → null
- TTL gate (expired rows excluded)
- statistical randomization (>1 distinct id across 100 pulls)
- empty-by-exclusion edge case

**README:** new row in the Tools table.

## Design note: why cache-only?

A federated random pick across every museum's full catalog would mean either (a) keeping a list of every artwork ID in every museum and randomly sampling, or (b) issuing arbitrary search queries against each museum and picking from the response. Both have problems: (a) needs proactive crawling and stays stale; (b) collapses to a random query, not a random artwork.

The cache-over-search-history version compounds with usage: the more you search, the richer the discovery pool. For the editorial workflow (essay companions, no-repeat-region rule), this is actually the right semantic — you want to be reminded of what you've already encountered but might forget about, not to fish in a corpus you've never seen.

A future v1.0+ could add proactive backfill (e.g. a \`seed_random\` tool that issues a constrained search across museums to populate the cache). Out of scope for v0.2.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — **113/113 pass** (was 104, +9)
- [x] \`npm run build\` — clean
- [x] Strict-default-deny invariant unchanged (no fetcher or licenseGate paths touched)
- [x] CI on PR will validate Node 20 + Node 22 under branch protection

Co-Authored by Pramod Prasanth <pramod@chainalign.com>