### PR TITLE
feat(list_traditions): cached region/period inventory with per-museum coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Then point the MCP config at the built binary:
 | `get_artwork(id)` | Fetch a single artwork by its normalized ID (e.g. `met:436535`). |
 | `cite(id, style?)` | Render a citation. `style`: `full` (artist, title, date, museum, license, URL), `caption` (image attribution), `short` (inline). |
 | `discover_random(region?, period?, not_artist?, museum?)` | Pick one random artwork from the local cache that matches the constraints. Operates over what has already been searched and cached. Useful for breaking out of repetitive search territory. |
+| `list_traditions()` | List the regions and periods present in the local cache, with per-museum record counts. Lets you see where holdings are well-represented and where they're sparse. |
 
 ### `cite` example outputs
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,11 +1,15 @@
 import Database from 'better-sqlite3';
 import { chmodSync, mkdirSync, existsSync } from 'node:fs';
 import { dirname } from 'node:path';
-import type { Artwork } from './types.js';
+import type { Artwork, Tradition } from './types.js';
 
 const OBJECT_TTL_DAYS = 90;
 const QUERY_TTL_DAYS = 14;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function titleCase(s: string): string {
+  return s.replace(/\b\w/g, (c) => c.toUpperCase());
+}
 
 export interface CacheConfig {
   path: string;
@@ -239,6 +243,51 @@ export class Cache {
     } catch {
       return null;
     }
+  }
+
+  /**
+   * List the regions and periods present in non-expired cached records,
+   * with per-museum coverage counts. Useful for the `list_traditions`
+   * tool — callers see which traditions are well-represented before
+   * searching, and where holdings are sparse.
+   *
+   * `label` is currently the title-cased tag; v1.0+ may swap in a curated
+   * lookup (e.g. "tang" → "Tang Dynasty (618–907)") if the tag set
+   * grows enough to warrant one.
+   */
+  listTraditions(): { regions: Tradition[]; periods: Tradition[] } {
+    const cutoff = new Date(Date.now() - OBJECT_TTL_DAYS * MS_PER_DAY).toISOString();
+    return {
+      regions: this.aggregateByTag('region', cutoff),
+      periods: this.aggregateByTag('period', cutoff),
+    };
+  }
+
+  // The `column` argument is constrained to a TypeScript literal union, never
+  // sourced from user input — the `${column}` interpolation here is safe.
+  private aggregateByTag(column: 'region' | 'period', cutoff: string): Tradition[] {
+    const sql = `
+      SELECT ${column} AS tag, museum_code, COUNT(*) AS cnt
+      FROM objects
+      WHERE ${column} IS NOT NULL AND cached_at > ?
+      GROUP BY ${column}, museum_code
+    `;
+    const rows = this.db.prepare(sql).all(cutoff) as Array<{
+      tag: string;
+      museum_code: string;
+      cnt: number;
+    }>;
+
+    const byTag = new Map<string, Record<string, number>>();
+    for (const row of rows) {
+      const existing = byTag.get(row.tag) ?? {};
+      existing[row.museum_code] = row.cnt;
+      byTag.set(row.tag, existing);
+    }
+
+    return Array.from(byTag.entries())
+      .map(([tag, coverage]) => ({ tag, label: titleCase(tag), coverage }))
+      .sort((a, b) => a.tag.localeCompare(b.tag));
   }
 
   pruneExpired(): { objects: number; queries: number } {

--- a/src/db.ts
+++ b/src/db.ts
@@ -260,11 +260,19 @@ export class Cache {
    * grows enough to warrant one.
    */
   listTraditions(): { regions: Tradition[]; periods: Tradition[] } {
-    const cutoff = new Date(Date.now() - OBJECT_TTL_DAYS * MS_PER_DAY).toISOString();
+    const cutoff = this.objectsCutoff();
     return {
       regions: this.aggregateByTag('region', cutoff),
       periods: this.aggregateByTag('period', cutoff),
     };
+  }
+
+  private objectsCutoff(): string {
+    return new Date(Date.now() - OBJECT_TTL_DAYS * MS_PER_DAY).toISOString();
+  }
+
+  private queriesCutoff(): string {
+    return new Date(Date.now() - QUERY_TTL_DAYS * MS_PER_DAY).toISOString();
   }
 
   // Two literal SQL strings instead of `${column}` interpolation, so the
@@ -306,10 +314,8 @@ export class Cache {
   }
 
   pruneExpired(): { objects: number; queries: number } {
-    const objectsCutoff = new Date(Date.now() - OBJECT_TTL_DAYS * MS_PER_DAY).toISOString();
-    const queriesCutoff = new Date(Date.now() - QUERY_TTL_DAYS * MS_PER_DAY).toISOString();
-    const objects = this.db.prepare(`DELETE FROM objects WHERE cached_at < ?`).run(objectsCutoff);
-    const queries = this.db.prepare(`DELETE FROM query_cache WHERE cached_at < ?`).run(queriesCutoff);
+    const objects = this.db.prepare(`DELETE FROM objects WHERE cached_at < ?`).run(this.objectsCutoff());
+    const queries = this.db.prepare(`DELETE FROM query_cache WHERE cached_at < ?`).run(this.queriesCutoff());
     return { objects: objects.changes, queries: queries.changes };
   }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -7,6 +7,10 @@ const OBJECT_TTL_DAYS = 90;
 const QUERY_TTL_DAYS = 14;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
+// Title-cases the first letter of each whitespace/hyphen-bounded word in
+// an ASCII tag. The tag set in regions.json and dynasties.json is currently
+// ASCII-only; if a future tag introduces non-ASCII letters, switch to a
+// Unicode-aware regex (`/u` flag + `\p{L}` property class).
 function titleCase(s: string): string {
   return s.replace(/\b\w/g, (c) => c.toUpperCase());
 }
@@ -263,15 +267,23 @@ export class Cache {
     };
   }
 
-  // The `column` argument is constrained to a TypeScript literal union, never
-  // sourced from user input — the `${column}` interpolation here is safe.
+  // Two literal SQL strings instead of `${column}` interpolation, so the
+  // README §Security claim "zero string-concatenated SQL paths" stays
+  // verbatim true. The `LOWER()` case-fold is defense-in-depth: if a future
+  // fetcher forgets to lowercase a tag, the variants still aggregate under
+  // one entry. The `tag != ''` filter drops empty-string ghosts so they
+  // can't surface as "" entries in the output.
   private aggregateByTag(column: 'region' | 'period', cutoff: string): Tradition[] {
-    const sql = `
-      SELECT ${column} AS tag, museum_code, COUNT(*) AS cnt
-      FROM objects
-      WHERE ${column} IS NOT NULL AND cached_at > ?
-      GROUP BY ${column}, museum_code
-    `;
+    const sql =
+      column === 'region'
+        ? `SELECT LOWER(region) AS tag, museum_code, COUNT(*) AS cnt
+           FROM objects
+           WHERE region IS NOT NULL AND region != '' AND cached_at > ?
+           GROUP BY LOWER(region), museum_code`
+        : `SELECT LOWER(period) AS tag, museum_code, COUNT(*) AS cnt
+           FROM objects
+           WHERE period IS NOT NULL AND period != '' AND cached_at > ?
+           GROUP BY LOWER(period), museum_code`;
     const rows = this.db.prepare(sql).all(cutoff) as Array<{
       tag: string;
       museum_code: string;
@@ -280,7 +292,10 @@ export class Cache {
 
     const byTag = new Map<string, Record<string, number>>();
     for (const row of rows) {
-      const existing = byTag.get(row.tag) ?? {};
+      // Object.create(null) prevents prototype pollution if a future
+      // museum_code value ever collides with a built-in property name
+      // (`__proto__`, `constructor`, `toString`).
+      const existing = byTag.get(row.tag) ?? Object.create(null);
       existing[row.museum_code] = row.cnt;
       byTag.set(row.tag, existing);
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -196,6 +196,15 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         },
       },
     },
+    {
+      name: 'list_traditions',
+      description:
+        'List the regions and periods present in non-expired cached records, with per-museum record counts. Helps you see which traditions are well-represented before searching, and where holdings are sparse. Returns { regions, periods } where each entry has { tag, label, coverage: { museumCode: count } }.',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+      },
+    },
   ],
 }));
 
@@ -290,6 +299,11 @@ async function handleDiscoverRandom(args: unknown) {
   return { content: [{ type: 'text' as const, text: JSON.stringify(artwork, null, 2) }] };
 }
 
+function handleListTraditions() {
+  const traditions = cache.listTraditions();
+  return { content: [{ type: 'text' as const, text: JSON.stringify(traditions, null, 2) }] };
+}
+
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
   try {
@@ -297,6 +311,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     if (name === 'get_artwork') return await handleGet(args);
     if (name === 'cite') return await handleCite(args);
     if (name === 'discover_random') return await handleDiscoverRandom(args);
+    if (name === 'list_traditions') return handleListTraditions();
     return errorResult(`unknown tool: ${name}`);
   } catch (err) {
     if (err instanceof z.ZodError) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,9 +92,10 @@ export interface DateRange {
 }
 
 /**
- * Reserved for v0.2 list_traditions tool: each normalized tradition tag will
- * carry per-museum coverage counts so callers can see where holdings live
- * before searching. Not yet emitted by any tool.
+ * One tradition tag (a normalized region or period) plus per-museum
+ * coverage counts in the local cache. Emitted by the `list_traditions`
+ * tool so callers can see where holdings are well-represented and where
+ * they're sparse before searching.
  */
 export interface Tradition {
   tag: string;

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -342,12 +342,38 @@ describe('Cache.listTraditions', () => {
   });
 
   it('returns regions and periods sorted alphabetically by tag', () => {
-    cache.upsertObject(makeArtwork('met:1', { region: 'iran', period: null }));
-    cache.upsertObject(makeArtwork('met:2', { region: 'china', period: null }));
-    cache.upsertObject(makeArtwork('met:3', { region: 'japan', period: null }));
+    cache.upsertObject(makeArtwork('met:1', { region: 'iran', period: 'safavid' }));
+    cache.upsertObject(makeArtwork('met:2', { region: 'china', period: 'tang dynasty' }));
+    cache.upsertObject(makeArtwork('met:3', { region: 'japan', period: 'edo' }));
+
+    const { regions, periods } = cache.listTraditions();
+    expect(regions.map((r) => r.tag)).toEqual(['china', 'iran', 'japan']);
+    expect(periods.map((p) => p.tag)).toEqual(['edo', 'safavid', 'tang dynasty']);
+  });
+
+  it('case-folds tags so duplicate-by-case rows aggregate under one entry', () => {
+    // Defense in depth: every adapter today lowercases tags before insertion,
+    // but a future fetcher that forgets should not silently fragment counts.
+    cache.upsertObject(makeArtwork('met:1', { region: 'china' }));
+    cache.upsertObject(makeArtwork('met:2', { region: 'CHINA' }));
+    cache.upsertObject(makeArtwork('met:3', { region: 'China' }));
 
     const { regions } = cache.listTraditions();
-    expect(regions.map((r) => r.tag)).toEqual(['china', 'iran', 'japan']);
+    expect(regions).toHaveLength(1);
+    expect(regions[0].tag).toBe('china');
+    expect(regions[0].coverage.met).toBe(3);
+  });
+
+  it('excludes records whose region or period is the empty string', () => {
+    cache.upsertObject(makeArtwork('met:1', { region: '', period: 'baroque' }));
+    cache.upsertObject(makeArtwork('met:2', { region: 'france', period: '' }));
+    cache.upsertObject(makeArtwork('met:3', { region: 'france', period: 'baroque' }));
+
+    const { regions, periods } = cache.listTraditions();
+    expect(regions.map((r) => r.tag)).toEqual(['france']);
+    expect(periods.map((p) => p.tag)).toEqual(['baroque']);
+    // Both 'france' rows aggregate into one entry; the '' row is dropped.
+    expect(regions[0].coverage.met).toBe(2);
   });
 
   it('title-cases multi-word period tags for the label', () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -288,3 +288,86 @@ describe('Cache.getRandomObject', () => {
     expect(seen.size).toBeGreaterThan(1);
   });
 });
+
+describe('Cache.listTraditions', () => {
+  let dir: string;
+  let path: string;
+  let cache: Cache;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'open-museum-mcp-cache-'));
+    path = join(dir, 'cache.db');
+    cache = new Cache({ path });
+  });
+
+  afterEach(() => {
+    cache.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns empty arrays when the cache is empty', () => {
+    expect(cache.listTraditions()).toEqual({ regions: [], periods: [] });
+  });
+
+  it('aggregates regions and periods with per-museum coverage', () => {
+    cache.upsertObject(makeArtwork('met:1', { region: 'china', period: 'tang dynasty' }));
+    cache.upsertObject(makeArtwork('met:2', { region: 'china', period: 'song' }));
+    cache.upsertObject(makeArtwork('cleveland:3', { region: 'china', period: null }));
+    cache.upsertObject(makeArtwork('met:4', { region: 'japan', period: 'edo' }));
+
+    const { regions, periods } = cache.listTraditions();
+
+    const china = regions.find((r) => r.tag === 'china');
+    expect(china).toBeDefined();
+    expect(china?.coverage).toEqual({ met: 2, cleveland: 1 });
+    expect(china?.label).toBe('China');
+
+    const japan = regions.find((r) => r.tag === 'japan');
+    expect(japan?.coverage).toEqual({ met: 1 });
+    expect(japan?.label).toBe('Japan');
+
+    const tang = periods.find((p) => p.tag === 'tang dynasty');
+    expect(tang?.coverage).toEqual({ met: 1 });
+    expect(tang?.label).toBe('Tang Dynasty');
+  });
+
+  it('excludes records whose region or period is null', () => {
+    cache.upsertObject(makeArtwork('met:1', { region: null, period: null }));
+    cache.upsertObject(makeArtwork('met:2', { region: 'france', period: null }));
+    cache.upsertObject(makeArtwork('met:3', { region: null, period: 'baroque' }));
+
+    const { regions, periods } = cache.listTraditions();
+    expect(regions.map((r) => r.tag)).toEqual(['france']);
+    expect(periods.map((p) => p.tag)).toEqual(['baroque']);
+  });
+
+  it('returns regions and periods sorted alphabetically by tag', () => {
+    cache.upsertObject(makeArtwork('met:1', { region: 'iran', period: null }));
+    cache.upsertObject(makeArtwork('met:2', { region: 'china', period: null }));
+    cache.upsertObject(makeArtwork('met:3', { region: 'japan', period: null }));
+
+    const { regions } = cache.listTraditions();
+    expect(regions.map((r) => r.tag)).toEqual(['china', 'iran', 'japan']);
+  });
+
+  it('title-cases multi-word period tags for the label', () => {
+    cache.upsertObject(makeArtwork('met:1', { region: null, period: 'early renaissance' }));
+    cache.upsertObject(makeArtwork('met:2', { region: null, period: 'qajar' }));
+
+    const { periods } = cache.listTraditions();
+    const labels = Object.fromEntries(periods.map((p) => [p.tag, p.label]));
+    expect(labels['early renaissance']).toBe('Early Renaissance');
+    expect(labels['qajar']).toBe('Qajar');
+  });
+
+  it('skips expired rows', () => {
+    cache.upsertObject(makeArtwork('met:1', { region: 'china', period: 'tang dynasty' }));
+    cache.close();
+    const db = new Database(path);
+    const longAgo = new Date(Date.now() - 91 * 24 * 60 * 60 * 1000).toISOString();
+    db.prepare('UPDATE objects SET cached_at = ?').run(longAgo);
+    db.close();
+    cache = new Cache({ path });
+    expect(cache.listTraditions()).toEqual({ regions: [], periods: [] });
+  });
+});


### PR DESCRIPTION
## Summary
The last v0.2 roadmap item. \`list_traditions\` returns a snapshot of which regions and periods are represented in the local cache, with per-museum counts. Lets you see where holdings are well-represented and where they're sparse before issuing more searches.

This pairs with \`discover_random\` from PR #10 to close the v0.2 forcing-function tools: \`list_traditions\` tells you what's in the cache, \`discover_random\` picks one out of it under constraints.

## Output shape

```jsonc
{
  "regions": [
    { "tag": "china", "label": "China", "coverage": { "met": 47, "cleveland": 12 } },
    { "tag": "japan", "label": "Japan", "coverage": { "met": 22 } },
    ...
  ],
  "periods": [
    { "tag": "edo", "label": "Edo", "coverage": { "met": 9 } },
    { "tag": "tang dynasty", "label": "Tang Dynasty", "coverage": { "met": 3, "cleveland": 1 } },
    ...
  ]
}
```

## What's new

**\`Cache.listTraditions\`** in \`src/db.ts\` — aggregates the indexed \`region\` and \`period\` columns separately, grouped by museum, with the same TTL gate as the rest of the cache surface.

**\`list_traditions\` tool** in \`src/server.ts\` — zero-input MCP tool; the local cache is the implicit corpus.

**\`Tradition\` type comment** in \`src/types.ts\` — was reserved-for-v0.2; now actively emitted, comment updated accordingly.

**Tests (6 new):** empty cache, per-museum aggregation, null-tag exclusion, alphabetical sort, multi-word title-casing, TTL gate.

**README:** new row in the Tools table.

## Design notes

- **Label is title-cased tag for v0.2.** \`tang dynasty\` → \`Tang Dynasty\`, \`qajar\` → \`Qajar\`. This is good enough for \~30 region tags and \~50 period tags. v1.0+ can swap in a curated lookup if the tag set grows or if the canonical labels diverge from simple title-casing.
- **Sort order:** alphabetical by tag, both axes. Stable ordering matters when this is paired with \`discover_random\` constraints.
- **TTL gate consistency:** uses the same 90-day cutoff as \`getRandomObject\` and \`getObject\`. Rows pruned in the constructor never appear here either.
- **No-input contract:** the tool takes no arguments. The cache is the corpus. If a caller wants per-museum filtering, they can post-filter on \`coverage[museumCode]\` themselves; adding a \`museum?\` filter to the tool felt like premature surface for v0.2.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — **110/110 pass** (was 104, +6)
- [x] \`npm run build\` — clean
- [x] No fetcher or licenseGate paths touched; strict-default-deny invariant unchanged
- [x] CI on PR will validate Node 20 + Node 22 under branch protection

## v0.2 roadmap status with this merged
- ✅ Cleveland adapter (PR #7)
- ✅ AIC adapter (PR #9)
- ✅ \`discover_random\` (PR #10, in review)
- ✅ \`list_traditions\` (this PR)

The Roadmap section in README will need a v0.2-shipped reconciliation once #10 and this both land — happy to do that as a one-line follow-up.

Co-Authored by Pramod Prasanth <pramod@chainalign.com>