### PR TITLE
feat: museum-source issue template + Suggest a museum README path

### DIFF
--- a/.github/ISSUE_TEMPLATE/museum-source.yml
+++ b/.github/ISSUE_TEMPLATE/museum-source.yml
@@ -1,0 +1,107 @@
+name: Museum source
+description: Suggest an open-access museum collection that should be added to open-museum-mcp.
+title: "[museum] "
+labels: ["museum-source"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for thinking of a collection. **You don't need to write code to file this.** The form asks for the API URL, the rights field, and a sample record. Anyone — me or a future contributor — can pick it up from there and build the adapter.
+
+        The contribution that matters is the source knowledge. Knowing what's in a collection and how that museum represents rights is the part the code can't do for itself.
+
+  - type: input
+    id: museum_name
+    attributes:
+      label: Museum name
+      placeholder: e.g. The Walters Art Museum
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: Location
+      description: City and country.
+      placeholder: e.g. Baltimore, USA
+
+  - type: input
+    id: api_url
+    attributes:
+      label: API base URL
+      description: Where the JSON API lives.
+      placeholder: e.g. https://api.thewalters.org
+    validations:
+      required: true
+
+  - type: input
+    id: docs_url
+    attributes:
+      label: API documentation URL
+      placeholder: e.g. https://api.thewalters.org/docs
+
+  - type: input
+    id: license_field
+    attributes:
+      label: Rights / license field name
+      description: The exact JSON field in each artwork record that signals open-access status (e.g. `is_public_domain`, `share_license_status`, `rights_statement`, `rights_uri`).
+    validations:
+      required: true
+
+  - type: input
+    id: license_value
+    attributes:
+      label: Field value that indicates open access
+      description: What value of the field above means "open"? (e.g. `true`, `"CC0"`, `"Public Domain"`, a specific rights URL.)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: auth
+    attributes:
+      label: Authentication required
+      options:
+        - none
+        - API key (free)
+        - API key (paid)
+        - OAuth / login required
+        - unsure
+    validations:
+      required: true
+
+  - type: input
+    id: sample_record
+    attributes:
+      label: Sample artwork URL or JSON
+      description: A real open-access record we can verify the rights field against. A link to the API response is ideal.
+
+  - type: input
+    id: collection_size
+    attributes:
+      label: Approximate open-access collection size
+      description: Rough is fine. "Half the records have images" type observations help.
+      placeholder: e.g. ~12,000 records, ~half with images
+
+  - type: dropdown
+    id: rights_complexity
+    attributes:
+      label: Are there caveats on the open-access rights?
+      description: Some museums (e.g. Art Institute of Chicago) note that even CC0 images may carry obligations around third-party permissions or culturally sensitive material. Anything you know up front saves a lot of time.
+      options:
+        - "No: open is open"
+        - "Yes: third-party permissions sometimes apply"
+        - "Yes: cultural-heritage sensitivities flagged"
+        - "Yes: image rights and metadata rights differ"
+        - "Unsure"
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Anything else
+      description: Quirks, search-endpoint shape, IIIF or no-IIIF, regions/periods covered, contact at the museum, anything you wish you'd known. No length limit.
+
+  - type: input
+    id: contact
+    attributes:
+      label: Want credit if the adapter ships?
+      description: Optional. Your name or handle for the contributors list.

--- a/README.md
+++ b/README.md
@@ -176,6 +176,14 @@ This is what "rights-verified" means here: validated against published museum me
 | Smithsonian Open Access | `si` | API key (free) | 📋 v2 |
 | Rijksmuseum | `rijks` | API key (free) | 📋 v2 |
 
+## Suggest a museum
+
+If you know an open-access collection that should be on this list and you can't write the adapter yourself, [open a museum-source issue](https://github.com/cfpramod/open-museum-mcp/issues/new?template=museum-source.yml). The form asks for the API URL, the rights field, and a sample record. Anyone — me, or a future contributor — can pick it up from there and build the adapter.
+
+The contribution that matters is the source knowledge. Knowing what's in a collection and how that museum represents rights is the part the code can't do for itself.
+
+If you can write the adapter, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## Schema
 
 Full TypeScript definitions in [`src/types.ts`](src/types.ts). The `Artwork` shape is stable; additional fields may be added but existing fields will not be repurposed.


### PR DESCRIPTION
## Summary
A structured GitHub issue form so non-developers can contribute open-access museum source information without writing an adapter. The contribution that matters is the source knowledge — what's in a collection and how the museum represents rights.

## What's new

**\`.github/ISSUE_TEMPLATE/museum-source.yml\`** — GitHub Issue Form (YAML schema). Fields cover everything an adapter implementer needs to know:
- Museum name, location, API base URL, docs URL
- **Rights field name and accept-condition value** — the heart of every per-museum gate
- Auth requirement (none / free key / paid key / OAuth)
- Sample artwork URL for ground-truthing the rights field
- Approximate collection size
- Rights-complexity caveats (third-party permissions, cultural heritage flags, image-vs-metadata asymmetry)
- Free-form notes
- Optional contributor credit

Submitting an issue auto-applies the \`museum-source\` label.

**\`README.md\`** — new "Suggest a museum" section between "Supported museums" and "Schema". Frames the request honestly:

> The contribution that matters is the source knowledge. Knowing what's in a collection and how that museum represents rights is the part the code can't do for itself.

## Why GitHub Issues, not Airtable / Google Forms

For an OSS repo, GitHub Issue Templates have three advantages over external forms:
1. **Live with the code** — no separate tool to maintain or pay for
2. **Triage queue is the issue list** — natural workflow for picking up adapters
3. **Anyone with a GitHub account can file** — no separate auth surface

If we later attract submitters without GitHub accounts, we can add an Airtable mirror that funnels into the same issue label. Out of scope for this PR.

## Test plan
- [x] YAML validated locally (\`python3 -c "import yaml; yaml.safe_load(...)"\`)
- [x] README markdown renders cleanly on the PR diff
- [ ] After merge: file a test issue using the form to confirm GitHub renders the schema correctly. If anything's off, follow-up PR with a tweak.

Co-Authored by Pramod Prasanth <pramod@chainalign.com>