### PR TITLE
chore: bump to v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,10 +160,10 @@ Each accepted record carries:
 
 - `imageOpenAccess`: the artwork's image may be reused under the recorded license.
 - `metadataOpenAccess`: the artwork's catalog metadata may be reused (often broader than image rights).
-- `license.type`: normalized license tier (`CC0`, `PD`, `CC-BY`, …; v0.1 only emits `CC0`).
+- `license.type`: normalized license tier (`CC0`, `PD`, `CC-BY`, …; currently only emits `CC0`).
 - `license.rawValue`: the museum's own field value, preserved.
 - `license.verificationSource`: the exact museum field that was checked (e.g. `met.isPublicDomain`).
-- `license.confidence`: `high` for unambiguous accepts (the only level v0.1 emits).
+- `license.confidence`: `high` for unambiguous accepts (the only level emitted today).
 - `license.verifiedAt`: ISO timestamp of when this verification ran.
 
 This is what "rights-verified" means here: validated against published museum metadata using source-specific rules implemented in this repo, with strict deny on ambiguity. It is **not** a guarantee of third-party rights beyond what each museum's API publicly represents. See [Disclaimer](#disclaimer).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-museum-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-museum-mcp",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-museum-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "MCP server for license-verified search across open-access museum collections (The Met, Cleveland, AIC and more).",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary
Final piece before tagging \`v0.2.0\`.

\`package.json\` and \`package-lock.json\` move from \`0.1.0\` to \`0.2.0\`. README §Verification model has its version-anchored "v0.1 only emits CC0" wording softened to version-agnostic "currently only emits CC0" — same claim, no drift on future releases.

## What v0.2 includes (since v0.1.0)

**New museums:**
- Cleveland Museum of Art adapter (PR #7, #8)
- Art Institute of Chicago adapter (PR #9)

**New tools:**
- \`discover_random(region?, period?, not_artist?, museum?)\` — pick one random cached artwork under constraints (PR #10)
- \`list_traditions()\` — region/period inventory of the cache with per-museum counts (PR #11)

**Infrastructure:**
- Shared \`src/fetchers/helpers.ts\` (DRY across adapters)
- \`.github/ISSUE_TEMPLATE/museum-source.yml\` — non-developer contribution path (PR #12)
- README "Suggest a museum" section
- All review items closed across PRs

## Post-merge sequence
1. Tag \`v0.2.0\` on main and push the tag
2. Create GitHub Release with notes
3. \`npm publish --access public\` (Pramod, with 2FA)

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 122/122 pass
- [x] \`npm run build\` — clean
- [x] \`package.json\` version reads \`0.2.0\`
- [x] No README content uses now-stale version-anchored claims

Co-Authored by Pramod Prasanth <pramod@chainalign.com>