### PR TITLE
feat(wikimedia): add Wikimedia Commons adapter — first federated source

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If anyone else is exploring open-access art, I hope this helps. The plan is to k
 
 ## What you get
 
-- **One interface, registered museums.** The Met, Cleveland Museum of Art, and the Art Institute of Chicago are live. Smithsonian and Rijksmuseum are next.
+- **One interface, registered museums.** The Met, Cleveland Museum of Art, the Art Institute of Chicago, and Wikimedia Commons are live. Smithsonian and Rijksmuseum are next.
 - **Strict deny on ambiguity.** Records are validated against per-museum rights rules in code. Missing or unclear indicators drop the record; nothing is defaulted to "open".
 - **Catalog-grade metadata.** A dynasty-aware date parser handles Tang, Edo, Safavid, Mughal and the rest. Regions normalize across museums. Attribution separates named artists from anonymous, workshop, "after", and attributed works.
 - **Listable resources and deterministic citations.** `museum://{code}/{id}` resources, three citation styles, structured JSON search results.
@@ -155,12 +155,13 @@ This is the heart of the project. Each museum exposes rights information in its 
 | The Met | `isPublicDomain` (boolean) | `=== true` |
 | Cleveland Museum of Art | `share_license_status` (string) | `=== "CC0"` (case-insensitive) |
 | Art Institute of Chicago | `is_public_domain` (boolean) | `=== true` |
+| Wikimedia Commons | `imageinfo[0].extmetadata.License.value` (string) | `=== "cc0"` OR `=== "pd"` OR matches `pd-*` |
 
 Each accepted record carries:
 
 - `imageOpenAccess`: the artwork's image may be reused under the recorded license.
 - `metadataOpenAccess`: the artwork's catalog metadata may be reused (often broader than image rights).
-- `license.type`: normalized license tier (`CC0`, `PD`, `CC-BY`, …; currently only emits `CC0`).
+- `license.type`: normalized license tier (`CC0`, `PD`, `CC-BY`, …; currently emits `CC0` or `PD`).
 - `license.rawValue`: the museum's own field value, preserved.
 - `license.verificationSource`: the exact museum field that was checked (e.g. `met.isPublicDomain`).
 - `license.confidence`: `high` for unambiguous accepts (the only level emitted today).
@@ -175,8 +176,11 @@ This is what "rights-verified" means here: validated against published museum me
 | The Metropolitan Museum of Art | `met` | none | ✅ v0.1 |
 | Cleveland Museum of Art | `cleveland` | none | ✅ v0.2 |
 | Art Institute of Chicago | `aic` | none | ✅ v0.2 |
+| Wikimedia Commons | `wikimedia` | none | ✅ v0.3 |
 | Smithsonian Open Access | `si` | API key (free) | 📋 v2 |
 | Rijksmuseum | `rijks` | API key (free) | 📋 v2 |
+
+**On Wikimedia Commons:** Commons is a federation, not a single museum. Rights are per-file. The adapter accepts only `cc0` and `pd*` licence templates; CC-BY, CC-BY-SA, and other attribution-or-restriction licences are rejected even though they're "free", because the per-museum gate model doesn't carry the obligations they impose. Adding Commons unlocks works whose home museums don't have public APIs (Bruegel at the Royal Museums of Fine Arts of Belgium, the National Gallery in London pre-API, regional museums worldwide) — at the cost of a thinner metadata layer than the structured-API museums provide. Region and period are not surfaced for Wikimedia records until v0.7 adds Wikidata enrichment.
 
 ## Suggest a museum
 
@@ -207,10 +211,12 @@ Highlights:
 ## Roadmap
 
 - v0.1: Met adapter, dynasty-aware date parser, license gate, `cite` tool, MCP resources.
-- v0.2: Cleveland and AIC adapters (shipped); `discover_random` with constraints (`region`, `period`, `not_artist`), `list_traditions` next. **(here)**
-- v0.5: Dominant-color extraction across museums (`color: "#3a5f7d"` discovery via `sharp`).
+- v0.2: Cleveland and AIC adapters, `discover_random` with constraints, `list_traditions`.
+- v0.3: Wikimedia Commons adapter (per-record rights model; unlocks works whose home museums lack public APIs). **(here)**
+- v0.7: Wikidata enrichment (artist QIDs, movement, country, dedup across cache).
+- v0.8: Dominant-colour extraction across museums (`color: "#3a5f7d"` discovery via `sharp`).
 - v1.0: Artist-obscurity scoring (`object_count_total`, `museum_count`) for deliberate exploration of less-canonical work.
-- v2.0: Smithsonian, Rijksmuseum, Wikimedia Commons (long-tail).
+- v2.0: Smithsonian, Rijksmuseum, Walters Art Museum, more European institutions.
 
 ## Contributing a museum adapter
 

--- a/src/fetchers/wikimedia.ts
+++ b/src/fetchers/wikimedia.ts
@@ -30,9 +30,40 @@ function getExtField(ext: Record<string, unknown> | undefined, field: string): s
   return typeof v === 'string' ? v : '';
 }
 
-// Commons text fields are HTML-laden. Strip tags and collapse whitespace.
+// Common HTML entities seen in Commons text fields. Numeric escapes
+// (`&#39;`, `&#x2014;`) are handled by separate regex passes below.
+const HTML_ENTITIES: Record<string, string> = {
+  amp: '&',
+  quot: '"',
+  apos: "'",
+  lt: '<',
+  gt: '>',
+  nbsp: ' ',
+};
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&([a-z]+);/gi, (match, name: string) => HTML_ENTITIES[name.toLowerCase()] ?? match)
+    .replace(/&#(\d+);/g, (_, code: string) => String.fromCodePoint(parseInt(code, 10)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex: string) => String.fromCodePoint(parseInt(hex, 16)));
+}
+
+// Commons text fields are HTML-laden. Strip tags, decode entities, collapse
+// whitespace. Order matters: strip tags first so entity decoding doesn't
+// reintroduce angle brackets that we then have to re-strip.
 function stripHtml(s: string): string {
-  return s.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+  return decodeEntities(s.replace(/<[^>]*>/g, ''))
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+// Format a parsed year range as a human-readable display string. Single-year
+// ranges collapse to "1889"; spans render as "1526–1569"; null becomes "".
+function formatYearRange(start: number | null, end: number | null): string {
+  if (start === null && end === null) return '';
+  if (start === end) return String(start);
+  if (start !== null && end !== null) return `${start}–${end}`;
+  return String(start ?? end);
 }
 
 // Parse the inner page object out of a MediaWiki API query response.
@@ -71,7 +102,6 @@ export const wikimediaFetcher: Fetcher = {
     url.searchParams.set('srlimit', String(limit));
     url.searchParams.set('format', 'json');
     url.searchParams.set('formatversion', '2');
-    url.searchParams.set('origin', '*'); // CORS-safe; harmless for server-side fetch
 
     const res = await fetch(url);
     if (!res.ok) throw new Error(`Wikimedia search failed: ${res.status}`);
@@ -96,7 +126,6 @@ export const wikimediaFetcher: Fetcher = {
     );
     url.searchParams.set('format', 'json');
     url.searchParams.set('formatversion', '2');
-    url.searchParams.set('origin', '*');
 
     const res = await fetch(url);
     if (!res.ok) throw new Error(`Wikimedia get failed for ${id}: ${res.status}`);
@@ -134,9 +163,12 @@ export const wikimediaFetcher: Fetcher = {
       return reject(id, 'wikimedia: missing or non-integer pageid', raw);
     }
 
+    // Strict default: require a present, image-typed MIME field. A missing
+    // MIME is rejected on the same grounds as a non-image one — without a
+    // declared type we can't honestly promise `imageUrls.full` is an image.
     const mime = asString(info.mime);
-    if (mime && !mime.startsWith(IMAGE_MIME_PREFIX)) {
-      return reject(id, `wikimedia: non-image mime type (${mime})`, raw);
+    if (!mime || !mime.startsWith(IMAGE_MIME_PREFIX)) {
+      return reject(id, `wikimedia: non-image or missing mime type (${mime || 'missing'})`, raw);
     }
 
     const ext =
@@ -156,10 +188,11 @@ export const wikimediaFetcher: Fetcher = {
 
     const description = stripHtml(getExtField(ext, 'ImageDescription'));
     // Commons does not surface a structured creation-date field. The DateTime
-    // extmetadata is upload time, not creation. Best effort: parse a date out
-    // of the description or the artist line (which often reads "(1526–1569)").
-    const dateRange =
-      parseDisplayDate(description) || parseDisplayDate(artistRaw) || { yearStart: null, yearEnd: null };
+    // extmetadata is the upload timestamp, not the artwork's date. Parse the
+    // ImageDescription only — the Artist field often carries the artist's
+    // lifespan ("(1526–1569)"), which is NOT the artwork's date and would
+    // mislead readers if surfaced as `yearStart`/`yearEnd`.
+    const dateRange = parseDisplayDate(description);
 
     const fullImage = asString(info.url);
     const pageUrl = asString(info.descriptionurl) || `${COMMONS_PAGE}/?curid=${pageId}`;
@@ -178,9 +211,11 @@ export const wikimediaFetcher: Fetcher = {
         lifespan: undefined,
         attributionType,
       },
-      // Commons doesn't separate display-date from creation-date; surface
-      // whatever description text we found, parsed years go to yearStart/End.
-      displayDate: description.slice(0, 200) || '',
+      // displayDate carries the artwork's date string. Commons records don't
+      // have a structured date field, so we render the parsed year range
+      // back to a string ("1560–1569"). Empty when no date was parseable —
+      // honest about absence rather than dumping the description prose.
+      displayDate: formatYearRange(dateRange.yearStart, dateRange.yearEnd),
       yearStart: dateRange.yearStart,
       yearEnd: dateRange.yearEnd,
       medium: '',

--- a/src/fetchers/wikimedia.ts
+++ b/src/fetchers/wikimedia.ts
@@ -1,0 +1,208 @@
+import { parseDisplayDate } from '../dateParser.js';
+import { validateWikimediaLicense } from '../licenseGate.js';
+import { cleanArtistName, detectAttributionType } from '../mappings.js';
+import type { Artwork, ValidationResult } from '../types.js';
+import { asString } from './helpers.js';
+import type { Fetcher, SearchOptions } from './types.js';
+
+const COMMONS_API = 'https://commons.wikimedia.org/w/api.php';
+const COMMONS_PAGE = 'https://commons.wikimedia.org/wiki';
+
+// Filename extensions we accept as "image" files. Commons hosts 3D models,
+// videos, audio and other media too; v0.3 surfaces only static images so the
+// `imageUrls.full` contract holds.
+const IMAGE_MIME_PREFIX = 'image/';
+
+function reject(id: string, reason: string, rawSnapshot: unknown): ValidationResult {
+  return {
+    status: 'rejected',
+    rejection: { id, museumCode: 'wikimedia', reason, rawSnapshot },
+  };
+}
+
+// extmetadata fields are wrapped: `{value, source, hidden?}`. Pull the value
+// only, default to empty string if absent or non-string.
+function getExtField(ext: Record<string, unknown> | undefined, field: string): string {
+  if (!ext) return '';
+  const wrap = ext[field];
+  if (!wrap || typeof wrap !== 'object') return '';
+  const v = (wrap as { value?: unknown }).value;
+  return typeof v === 'string' ? v : '';
+}
+
+// Commons text fields are HTML-laden. Strip tags and collapse whitespace.
+function stripHtml(s: string): string {
+  return s.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+}
+
+// Parse the inner page object out of a MediaWiki API query response.
+// formatversion=2 returns pages as an array; formatversion=1 keys by pageid.
+// Tolerate both shapes plus a direct page object (test fixture convenience).
+function unwrapPage(raw: Record<string, unknown>): Record<string, unknown> | undefined {
+  const query = raw.query;
+  if (query && typeof query === 'object') {
+    const pages = (query as Record<string, unknown>).pages;
+    if (Array.isArray(pages) && pages.length > 0 && typeof pages[0] === 'object' && pages[0]) {
+      return pages[0] as Record<string, unknown>;
+    }
+    if (pages && typeof pages === 'object' && !Array.isArray(pages)) {
+      const keys = Object.keys(pages);
+      if (keys.length > 0) {
+        const first = (pages as Record<string, unknown>)[keys[0]];
+        if (first && typeof first === 'object') return first as Record<string, unknown>;
+      }
+    }
+  }
+  // Direct page object passthrough.
+  if (typeof raw.pageid !== 'undefined') return raw;
+  return undefined;
+}
+
+export const wikimediaFetcher: Fetcher = {
+  code: 'wikimedia',
+  name: 'Wikimedia Commons',
+
+  async search(query: string, limit: number, options: SearchOptions = {}): Promise<string[]> {
+    const url = new URL(COMMONS_API);
+    url.searchParams.set('action', 'query');
+    url.searchParams.set('list', 'search');
+    url.searchParams.set('srsearch', query);
+    url.searchParams.set('srnamespace', '6'); // File namespace
+    url.searchParams.set('srlimit', String(limit));
+    url.searchParams.set('format', 'json');
+    url.searchParams.set('formatversion', '2');
+    url.searchParams.set('origin', '*'); // CORS-safe; harmless for server-side fetch
+
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`Wikimedia search failed: ${res.status}`);
+    const json = (await res.json()) as { query?: { search?: Array<{ pageid?: unknown }> } };
+    const results = json.query?.search ?? [];
+    return results
+      .map((r) => (typeof r.pageid === 'number' ? `wikimedia:${r.pageid}` : null))
+      .filter((s): s is string => s !== null)
+      .slice(0, limit);
+  },
+
+  async getRaw(id: string): Promise<unknown> {
+    const numeric = id.replace(/^wikimedia:/, '');
+    const url = new URL(COMMONS_API);
+    url.searchParams.set('action', 'query');
+    url.searchParams.set('pageids', numeric);
+    url.searchParams.set('prop', 'imageinfo');
+    url.searchParams.set('iiprop', 'url|size|mime|extmetadata');
+    url.searchParams.set(
+      'iiextmetadatafilter',
+      'License|LicenseShortName|LicenseUrl|UsageTerms|Artist|ObjectName|DateTime|Credit|ImageDescription',
+    );
+    url.searchParams.set('format', 'json');
+    url.searchParams.set('formatversion', '2');
+    url.searchParams.set('origin', '*');
+
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`Wikimedia get failed for ${id}: ${res.status}`);
+    return res.json();
+  },
+
+  normalize(raw: unknown): ValidationResult {
+    if (!raw || typeof raw !== 'object') {
+      return reject('wikimedia:unknown', 'wikimedia: response not an object', raw);
+    }
+    const page = unwrapPage(raw as Record<string, unknown>);
+    if (!page) {
+      return reject('wikimedia:unknown', 'wikimedia: page not found in response', raw);
+    }
+
+    const pageId = page.pageid;
+    const validId = typeof pageId === 'number' && Number.isInteger(pageId) && pageId > 0;
+    const id = validId ? `wikimedia:${pageId}` : 'wikimedia:unknown';
+
+    const imageinfo = Array.isArray(page.imageinfo) ? page.imageinfo : [];
+    const info =
+      imageinfo[0] && typeof imageinfo[0] === 'object'
+        ? (imageinfo[0] as Record<string, unknown>)
+        : undefined;
+    if (!info) {
+      return reject(id, 'wikimedia: imageinfo missing — file deleted, missing, or non-image', raw);
+    }
+
+    const decision = validateWikimediaLicense(info);
+    if (!decision.accepted || !decision.license) {
+      return reject(id, decision.reason, raw);
+    }
+
+    if (!validId) {
+      return reject(id, 'wikimedia: missing or non-integer pageid', raw);
+    }
+
+    const mime = asString(info.mime);
+    if (mime && !mime.startsWith(IMAGE_MIME_PREFIX)) {
+      return reject(id, `wikimedia: non-image mime type (${mime})`, raw);
+    }
+
+    const ext =
+      info.extmetadata && typeof info.extmetadata === 'object'
+        ? (info.extmetadata as Record<string, unknown>)
+        : undefined;
+
+    const objectName = stripHtml(getExtField(ext, 'ObjectName'));
+    const fileTitle = asString(page.title)
+      .replace(/^File:/, '')
+      .replace(/\.[^.]+$/, '');
+    const title = (objectName || fileTitle).trim() || '(Untitled)';
+
+    const artistRaw = stripHtml(getExtField(ext, 'Artist'));
+    const attributionType = detectAttributionType(artistRaw);
+    const cleanName = cleanArtistName(artistRaw);
+
+    const description = stripHtml(getExtField(ext, 'ImageDescription'));
+    // Commons does not surface a structured creation-date field. The DateTime
+    // extmetadata is upload time, not creation. Best effort: parse a date out
+    // of the description or the artist line (which often reads "(1526–1569)").
+    const dateRange =
+      parseDisplayDate(description) || parseDisplayDate(artistRaw) || { yearStart: null, yearEnd: null };
+
+    const fullImage = asString(info.url);
+    const pageUrl = asString(info.descriptionurl) || `${COMMONS_PAGE}/?curid=${pageId}`;
+
+    const artwork: Artwork = {
+      id,
+      museum: {
+        code: 'wikimedia',
+        name: 'Wikimedia Commons',
+        url: 'https://commons.wikimedia.org',
+      },
+      title,
+      artist: {
+        name: cleanName || 'Unknown',
+        nationality: undefined,
+        lifespan: undefined,
+        attributionType,
+      },
+      // Commons doesn't separate display-date from creation-date; surface
+      // whatever description text we found, parsed years go to yearStart/End.
+      displayDate: description.slice(0, 200) || '',
+      yearStart: dateRange.yearStart,
+      yearEnd: dateRange.yearEnd,
+      medium: '',
+      // Region and period are not in Commons' structured metadata. Wikidata
+      // enrichment (planned for v0.7) will fill these via SPARQL on the
+      // file's depicted-work QID.
+      region: null,
+      period: null,
+      imageUrls: {
+        full: fullImage,
+        thumbnail: undefined,
+      },
+      imageOpenAccess: decision.imageOpenAccess,
+      metadataOpenAccess: decision.metadataOpenAccess,
+      license: decision.license,
+      source: {
+        apiUrl: `${COMMONS_API}?action=query&pageids=${pageId}&prop=imageinfo&format=json`,
+        pageUrl,
+      },
+      description: description || undefined,
+    };
+
+    return { status: 'accepted', artwork };
+  },
+};

--- a/src/licenseGate.ts
+++ b/src/licenseGate.ts
@@ -120,9 +120,9 @@ export const validateAicLicense: LicenseValidator = (raw) => {
 // not per-source. The MediaWiki API surfaces a machine-readable License token
 // in `imageinfo[0].extmetadata.License.value`. We accept the strict open-access
 // subset only:
-//   - 'cc0'      → CC0 dedication
-//   - 'pd'       → Public Domain
-//   - 'pd-*'     → PD subtypes (PD-Art, PD-old, PD-US, PD-self, etc.)
+//   - 'cc0'           → CC0 dedication
+//   - 'pd', 'pd-*'    → Public Domain (PD-Art, PD-old, PD-US, PD-self, etc.)
+//   - 'pdm', 'pdm-*'  → Creative Commons Public Domain Mark
 // Everything else (CC-BY, CC-BY-SA, CC-BY-NC, GFDL, fair-use, etc.) is rejected.
 // Even though CC-BY is "free", it imposes attribution that the project's
 // per-museum gate model is not designed to verify or carry.
@@ -131,6 +131,8 @@ export const validateAicLicense: LicenseValidator = (raw) => {
 // photographs of 2D public-domain works (per Bridgeman v. Corel). The license
 // gate trusts Commons' editorial decision to apply that template; we do not
 // independently re-evaluate the underlying work's status.
+const PD_PREFIXES = ['pd', 'pdm'];
+
 export const validateWikimediaLicense: LicenseValidator = (raw) => {
   if (!raw || typeof raw !== 'object') {
     return reject('wikimedia: object missing or not an object');
@@ -162,7 +164,8 @@ export const validateWikimediaLicense: LicenseValidator = (raw) => {
       reason: 'wikimedia: License=cc0',
     };
   }
-  if (license === 'pd' || license.startsWith('pd-')) {
+  const isPd = PD_PREFIXES.some((p) => license === p || license.startsWith(`${p}-`));
+  if (isPd) {
     return {
       accepted: true,
       license: {

--- a/src/licenseGate.ts
+++ b/src/licenseGate.ts
@@ -116,10 +116,75 @@ export const validateAicLicense: LicenseValidator = (raw) => {
   return reject(`aic: is_public_domain=${isPD} (strict default reject)`);
 };
 
+// Wikimedia Commons is a federation, not a single museum: rights are per-file,
+// not per-source. The MediaWiki API surfaces a machine-readable License token
+// in `imageinfo[0].extmetadata.License.value`. We accept the strict open-access
+// subset only:
+//   - 'cc0'      → CC0 dedication
+//   - 'pd'       → Public Domain
+//   - 'pd-*'     → PD subtypes (PD-Art, PD-old, PD-US, PD-self, etc.)
+// Everything else (CC-BY, CC-BY-SA, CC-BY-NC, GFDL, fair-use, etc.) is rejected.
+// Even though CC-BY is "free", it imposes attribution that the project's
+// per-museum gate model is not designed to verify or carry.
+//
+// Note on "PD-Art": Wikimedia Commons applies this template to faithful
+// photographs of 2D public-domain works (per Bridgeman v. Corel). The license
+// gate trusts Commons' editorial decision to apply that template; we do not
+// independently re-evaluate the underlying work's status.
+export const validateWikimediaLicense: LicenseValidator = (raw) => {
+  if (!raw || typeof raw !== 'object') {
+    return reject('wikimedia: object missing or not an object');
+  }
+  const obj = raw as Record<string, unknown>;
+  const ext = obj.extmetadata;
+  if (!ext || typeof ext !== 'object') {
+    return reject('wikimedia: extmetadata missing (strict default reject)');
+  }
+  const licenseField = (ext as Record<string, unknown>).License;
+  const licenseValue =
+    licenseField && typeof licenseField === 'object'
+      ? (licenseField as { value?: unknown }).value
+      : undefined;
+  const license = typeof licenseValue === 'string' ? licenseValue.toLowerCase() : '';
+
+  if (license === 'cc0') {
+    return {
+      accepted: true,
+      license: {
+        type: 'CC0',
+        rawValue: license,
+        verificationSource: 'wikimedia.extmetadata.License',
+        verifiedAt: nowIso(),
+        confidence: 'high',
+      },
+      imageOpenAccess: true,
+      metadataOpenAccess: true,
+      reason: 'wikimedia: License=cc0',
+    };
+  }
+  if (license === 'pd' || license.startsWith('pd-')) {
+    return {
+      accepted: true,
+      license: {
+        type: 'PD',
+        rawValue: license,
+        verificationSource: 'wikimedia.extmetadata.License',
+        verifiedAt: nowIso(),
+        confidence: 'high',
+      },
+      imageOpenAccess: true,
+      metadataOpenAccess: true,
+      reason: `wikimedia: License=${license}`,
+    };
+  }
+  return reject(`wikimedia: License=${license || 'missing'} (strict default reject)`);
+};
+
 const VALIDATORS: Record<string, LicenseValidator> = {
   met: validateMetLicense,
   cleveland: validateClevelandLicense,
   aic: validateAicLicense,
+  wikimedia: validateWikimediaLicense,
 };
 
 export function validateLicense(museumCode: string, raw: unknown): LicenseDecision {

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import { Cache } from './db.js';
 import { aicFetcher } from './fetchers/aic.js';
 import { clevelandFetcher } from './fetchers/cleveland.js';
 import { metFetcher } from './fetchers/met.js';
+import { wikimediaFetcher } from './fetchers/wikimedia.js';
 import type { Fetcher } from './fetchers/types.js';
 import type { Artwork } from './types.js';
 
@@ -22,6 +23,7 @@ const FETCHERS: Record<string, Fetcher> = {
   [metFetcher.code]: metFetcher,
   [clevelandFetcher.code]: clevelandFetcher,
   [aicFetcher.code]: aicFetcher,
+  [wikimediaFetcher.code]: wikimediaFetcher,
 };
 
 const CACHE_PATH = process.env.OMM_CACHE_PATH ?? join(homedir(), '.open-museum-mcp', 'cache.db');
@@ -129,7 +131,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           museum: {
             type: 'string',
             description:
-              'Optional museum code. Currently registered: met, cleveland, aic.',
+              'Optional museum code. Currently registered: met, cleveland, aic, wikimedia (Commons).',
           },
           has_image: {
             type: 'boolean',

--- a/tests/fixtures/wikimedia-accepted-bruegel.json
+++ b/tests/fixtures/wikimedia-accepted-bruegel.json
@@ -1,0 +1,56 @@
+{
+  "batchcomplete": "",
+  "query": {
+    "pages": [
+      {
+        "pageid": 15493856,
+        "ns": 6,
+        "title": "File:Pieter Bruegel the Elder - Landscape with the Fall of Icarus - WGA03321.jpg",
+        "imagerepository": "local",
+        "imageinfo": [
+          {
+            "size": 152771,
+            "width": 1246,
+            "height": 800,
+            "url": "https://upload.wikimedia.org/wikipedia/commons/e/e7/Pieter_Bruegel_the_Elder_-_Landscape_with_the_Fall_of_Icarus_-_WGA03321.jpg",
+            "descriptionurl": "https://commons.wikimedia.org/wiki/File:Pieter_Bruegel_the_Elder_-_Landscape_with_the_Fall_of_Icarus_-_WGA03321.jpg",
+            "descriptionshorturl": "https://commons.wikimedia.org/w/index.php?curid=15493856",
+            "extmetadata": {
+              "ObjectName": {
+                "value": "Landscape with the Fall of Icarus",
+                "source": "commons-desc-page"
+              },
+              "Artist": {
+                "value": "<bdi>Pieter Brueghel the Elder (1526–1569)</bdi>",
+                "source": "commons-desc-page"
+              },
+              "Credit": {
+                "value": "Web Gallery of Art",
+                "source": "commons-desc-page"
+              },
+              "LicenseShortName": {
+                "value": "Public domain",
+                "source": "commons-desc-page",
+                "hidden": ""
+              },
+              "UsageTerms": {
+                "value": "Public domain",
+                "source": "commons-desc-page"
+              },
+              "License": {
+                "value": "pd",
+                "source": "commons-templates",
+                "hidden": ""
+              },
+              "ImageDescription": {
+                "value": "Landscape with the Fall of Icarus, c. 1560s. Oil on canvas mounted on wood panel. Royal Museums of Fine Arts of Belgium, Brussels.",
+                "source": "commons-desc-page"
+              }
+            },
+            "mime": "image/jpeg"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/wikimedia-accepted-cc0.json
+++ b/tests/fixtures/wikimedia-accepted-cc0.json
@@ -1,0 +1,45 @@
+{
+  "batchcomplete": "",
+  "query": {
+    "pages": [
+      {
+        "pageid": 99000001,
+        "ns": 6,
+        "title": "File:Some CC0 Photograph.jpg",
+        "imagerepository": "local",
+        "imageinfo": [
+          {
+            "size": 421013,
+            "width": 2400,
+            "height": 1600,
+            "url": "https://upload.wikimedia.org/wikipedia/commons/0/00/Some_CC0_Photograph.jpg",
+            "descriptionurl": "https://commons.wikimedia.org/wiki/File:Some_CC0_Photograph.jpg",
+            "extmetadata": {
+              "ObjectName": {
+                "value": "Some CC0 Photograph",
+                "source": "commons-desc-page"
+              },
+              "Artist": {
+                "value": "Anonymous",
+                "source": "commons-desc-page"
+              },
+              "LicenseShortName": {
+                "value": "CC0",
+                "source": "commons-desc-page"
+              },
+              "UsageTerms": {
+                "value": "Creative Commons Zero, Public Domain Dedication",
+                "source": "commons-desc-page"
+              },
+              "License": {
+                "value": "cc0",
+                "source": "commons-templates"
+              }
+            },
+            "mime": "image/jpeg"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/wikimedia-rejected-cc-by-sa.json
+++ b/tests/fixtures/wikimedia-rejected-cc-by-sa.json
@@ -1,0 +1,41 @@
+{
+  "batchcomplete": "",
+  "query": {
+    "pages": [
+      {
+        "pageid": 99000002,
+        "ns": 6,
+        "title": "File:CC BY-SA Photograph.jpg",
+        "imagerepository": "local",
+        "imageinfo": [
+          {
+            "size": 234567,
+            "width": 1920,
+            "height": 1280,
+            "url": "https://upload.wikimedia.org/wikipedia/commons/9/99/CC_BY-SA_Photograph.jpg",
+            "descriptionurl": "https://commons.wikimedia.org/wiki/File:CC_BY-SA_Photograph.jpg",
+            "extmetadata": {
+              "ObjectName": {
+                "value": "CC BY-SA Photograph",
+                "source": "commons-desc-page"
+              },
+              "Artist": {
+                "value": "A. Photographer",
+                "source": "commons-desc-page"
+              },
+              "LicenseShortName": {
+                "value": "CC BY-SA 4.0",
+                "source": "commons-desc-page"
+              },
+              "License": {
+                "value": "cc-by-sa-4.0",
+                "source": "commons-templates"
+              }
+            },
+            "mime": "image/jpeg"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/wikimedia-rejected-missing-license.json
+++ b/tests/fixtures/wikimedia-rejected-missing-license.json
@@ -1,0 +1,33 @@
+{
+  "batchcomplete": "",
+  "query": {
+    "pages": [
+      {
+        "pageid": 99000003,
+        "ns": 6,
+        "title": "File:Ambiguous Rights File.jpg",
+        "imagerepository": "local",
+        "imageinfo": [
+          {
+            "size": 100000,
+            "width": 800,
+            "height": 600,
+            "url": "https://upload.wikimedia.org/wikipedia/commons/0/00/Ambiguous_Rights_File.jpg",
+            "descriptionurl": "https://commons.wikimedia.org/wiki/File:Ambiguous_Rights_File.jpg",
+            "extmetadata": {
+              "ObjectName": {
+                "value": "Ambiguous Rights File",
+                "source": "commons-desc-page"
+              },
+              "Artist": {
+                "value": "Unknown",
+                "source": "commons-desc-page"
+              }
+            },
+            "mime": "image/jpeg"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/wikimedia.test.ts
+++ b/tests/wikimedia.test.ts
@@ -1,0 +1,186 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { wikimediaFetcher } from '../src/fetchers/wikimedia.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function fixture(name: string): unknown {
+  const path = join(here, 'fixtures', name);
+  return JSON.parse(readFileSync(path, 'utf-8'));
+}
+
+describe('Wikimedia Commons adapter normalization', () => {
+  it('normalizes a PD-licensed file (Bruegel Fall of Icarus) into the Artwork shape', () => {
+    const result = wikimediaFetcher.normalize(fixture('wikimedia-accepted-bruegel.json'));
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+
+    const a = result.artwork;
+    expect(a.id).toBe('wikimedia:15493856');
+    expect(a.museum.code).toBe('wikimedia');
+    expect(a.museum.name).toBe('Wikimedia Commons');
+    expect(a.title).toBe('Landscape with the Fall of Icarus');
+    expect(a.artist.name).toContain('Pieter Brueghel the Elder');
+    expect(a.artist.attributionType).toBe('named');
+    expect(a.license.type).toBe('PD');
+    expect(a.license.rawValue).toBe('pd');
+    expect(a.license.verificationSource).toBe('wikimedia.extmetadata.License');
+    expect(a.license.confidence).toBe('high');
+    expect(a.imageOpenAccess).toBe(true);
+    expect(a.metadataOpenAccess).toBe(true);
+    expect(a.imageUrls.full).toContain('upload.wikimedia.org');
+    expect(a.source.pageUrl).toContain('commons.wikimedia.org');
+  });
+
+  it('normalizes a CC0-licensed file with the CC0 license tier', () => {
+    const result = wikimediaFetcher.normalize(fixture('wikimedia-accepted-cc0.json'));
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.license.type).toBe('CC0');
+    expect(result.artwork.license.rawValue).toBe('cc0');
+  });
+
+  it('rejects a CC BY-SA file (attribution + share-alike imposes obligations)', () => {
+    const result = wikimediaFetcher.normalize(fixture('wikimedia-rejected-cc-by-sa.json'));
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.reason).toContain('strict default reject');
+    expect(result.rejection.reason).toContain('cc-by-sa-4.0');
+  });
+
+  it('rejects a file with no License field (strict default deny)', () => {
+    const result = wikimediaFetcher.normalize(fixture('wikimedia-rejected-missing-license.json'));
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.reason).toContain('strict default reject');
+    expect(result.rejection.reason).toContain('missing');
+  });
+
+  it('rejects garbage input gracefully', () => {
+    expect(wikimediaFetcher.normalize(null).status).toBe('rejected');
+    expect(wikimediaFetcher.normalize('not an object').status).toBe('rejected');
+    expect(wikimediaFetcher.normalize(42).status).toBe('rejected');
+  });
+
+  it('rejects when the response has no pages', () => {
+    const result = wikimediaFetcher.normalize({ batchcomplete: '', query: { pages: [] } });
+    expect(result.status).toBe('rejected');
+  });
+
+  it('rejects when imageinfo is missing (deleted file or non-image)', () => {
+    const result = wikimediaFetcher.normalize({
+      query: { pages: [{ pageid: 12345, title: 'File:Deleted.txt' }] },
+    });
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.reason).toContain('imageinfo missing');
+  });
+
+  it('rejects a non-image mime type even when license is PD', () => {
+    const result = wikimediaFetcher.normalize({
+      query: {
+        pages: [
+          {
+            pageid: 99000004,
+            title: 'File:Some PDF.pdf',
+            imageinfo: [
+              {
+                url: 'https://upload.wikimedia.org/wikipedia/commons/x/xx/SomePDF.pdf',
+                descriptionurl: 'https://commons.wikimedia.org/wiki/File:Some_PDF.pdf',
+                mime: 'application/pdf',
+                extmetadata: { License: { value: 'pd' } },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.reason).toContain('non-image mime');
+  });
+
+  it('accepts a file passed as a direct page object (unwrapped fixture form)', () => {
+    const wrapped = fixture('wikimedia-accepted-bruegel.json') as { query: { pages: unknown[] } };
+    const page = wrapped.query.pages[0];
+    const result = wikimediaFetcher.normalize(page);
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.id).toBe('wikimedia:15493856');
+  });
+
+  it('tolerates legacy formatversion=1 page-object-keyed-by-pageid shape', () => {
+    const result = wikimediaFetcher.normalize({
+      query: {
+        pages: {
+          '15493856': {
+            pageid: 15493856,
+            title: 'File:Test.jpg',
+            imageinfo: [
+              {
+                url: 'https://example.org/img.jpg',
+                descriptionurl: 'https://commons.wikimedia.org/wiki/File:Test.jpg',
+                mime: 'image/jpeg',
+                extmetadata: { License: { value: 'pd' } },
+              },
+            ],
+          },
+        },
+      },
+    });
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.id).toBe('wikimedia:15493856');
+  });
+
+  it('accepts pd-art subtype (PD-Art template for 2D PD reproductions)', () => {
+    const result = wikimediaFetcher.normalize({
+      query: {
+        pages: [
+          {
+            pageid: 88000001,
+            title: 'File:Some PD-Art File.jpg',
+            imageinfo: [
+              {
+                url: 'https://upload.wikimedia.org/wikipedia/commons/x/xx/PDArt.jpg',
+                descriptionurl: 'https://commons.wikimedia.org/wiki/File:PDArt.jpg',
+                mime: 'image/jpeg',
+                extmetadata: { License: { value: 'pd-art' } },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.license.type).toBe('PD');
+    expect(result.artwork.license.rawValue).toBe('pd-art');
+  });
+
+  it('surfaces "wikimedia:unknown" id on rights-pass + bad-pageid rejections', () => {
+    const result = wikimediaFetcher.normalize({
+      query: {
+        pages: [
+          {
+            // pageid missing / not an integer
+            title: 'File:Some File.jpg',
+            imageinfo: [
+              {
+                url: 'https://example.org/img.jpg',
+                mime: 'image/jpeg',
+                extmetadata: { License: { value: 'pd' } },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.id).toBe('wikimedia:unknown');
+    expect(result.rejection.reason).toContain('missing or non-integer pageid');
+  });
+});

--- a/tests/wikimedia.test.ts
+++ b/tests/wikimedia.test.ts
@@ -32,6 +32,11 @@ describe('Wikimedia Commons adapter normalization', () => {
     expect(a.metadataOpenAccess).toBe(true);
     expect(a.imageUrls.full).toContain('upload.wikimedia.org');
     expect(a.source.pageUrl).toContain('commons.wikimedia.org');
+    // Description carries "c. 1560s." → tryDecade matches "1560s" → {1560, 1569}.
+    // Locks down the parseDisplayDate(description) path.
+    expect(a.yearStart).toBe(1560);
+    expect(a.yearEnd).toBe(1569);
+    expect(a.displayDate).toBe('1560–1569');
   });
 
   it('normalizes a CC0-licensed file with the CC0 license tier', () => {
@@ -99,7 +104,32 @@ describe('Wikimedia Commons adapter normalization', () => {
     });
     expect(result.status).toBe('rejected');
     if (result.status !== 'rejected') return;
-    expect(result.rejection.reason).toContain('non-image mime');
+    expect(result.rejection.reason).toContain('non-image or missing mime');
+  });
+
+  it('rejects a record with missing mime type even when license is PD', () => {
+    // Defense in depth: a PD-licensed record without a declared MIME can't
+    // honestly promise imageUrls.full is an image, so reject.
+    const result = wikimediaFetcher.normalize({
+      query: {
+        pages: [
+          {
+            pageid: 99000005,
+            title: 'File:No Mime.bin',
+            imageinfo: [
+              {
+                url: 'https://upload.wikimedia.org/wikipedia/commons/x/xx/NoMime.bin',
+                descriptionurl: 'https://commons.wikimedia.org/wiki/File:No_Mime.bin',
+                extmetadata: { License: { value: 'pd' } },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.reason).toContain('missing mime');
   });
 
   it('accepts a file passed as a direct page object (unwrapped fixture form)', () => {
@@ -158,6 +188,114 @@ describe('Wikimedia Commons adapter normalization', () => {
     if (result.status !== 'accepted') return;
     expect(result.artwork.license.type).toBe('PD');
     expect(result.artwork.license.rawValue).toBe('pd-art');
+  });
+
+  it('accepts the Public Domain Mark (pdm) and pdm-* subtypes', () => {
+    // Creative Commons' Public Domain Mark template. Genuinely PD; locked
+    // down separately so a future regex tightening doesn't drop it.
+    const pdm = wikimediaFetcher.normalize({
+      query: {
+        pages: [
+          {
+            pageid: 88000002,
+            title: 'File:PDM File.jpg',
+            imageinfo: [
+              {
+                url: 'https://upload.wikimedia.org/wikipedia/commons/x/xx/PDM.jpg',
+                descriptionurl: 'https://commons.wikimedia.org/wiki/File:PDM.jpg',
+                mime: 'image/jpeg',
+                extmetadata: { License: { value: 'pdm' } },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(pdm.status).toBe('accepted');
+
+    const pdmVersioned = wikimediaFetcher.normalize({
+      query: {
+        pages: [
+          {
+            pageid: 88000003,
+            title: 'File:PDM 1.0.jpg',
+            imageinfo: [
+              {
+                url: 'https://upload.wikimedia.org/wikipedia/commons/x/xx/PDMv.jpg',
+                descriptionurl: 'https://commons.wikimedia.org/wiki/File:PDMv.jpg',
+                mime: 'image/jpeg',
+                extmetadata: { License: { value: 'pdm-1.0' } },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(pdmVersioned.status).toBe('accepted');
+  });
+
+  it('decodes HTML entities in artist and description fields', () => {
+    const result = wikimediaFetcher.normalize({
+      query: {
+        pages: [
+          {
+            pageid: 88000004,
+            title: 'File:Entity Test.jpg',
+            imageinfo: [
+              {
+                url: 'https://upload.wikimedia.org/wikipedia/commons/x/xx/Entity.jpg',
+                descriptionurl: 'https://commons.wikimedia.org/wiki/File:Entity.jpg',
+                mime: 'image/jpeg',
+                extmetadata: {
+                  License: { value: 'pd' },
+                  ObjectName: { value: 'Picasso &amp; Friends' },
+                  Artist: { value: '&quot;Anonymous&quot;' },
+                  ImageDescription: { value: 'Made in 1850. Gallery &#x2014; West Wing.' },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.title).toBe('Picasso & Friends');
+    expect(result.artwork.artist.name).toContain('"Anonymous"');
+    expect(result.artwork.description).toContain('Made in 1850. Gallery — West Wing.');
+  });
+
+  it('emits empty displayDate when no date can be parsed from description', () => {
+    const result = wikimediaFetcher.normalize({
+      query: {
+        pages: [
+          {
+            pageid: 88000005,
+            title: 'File:Undated.jpg',
+            imageinfo: [
+              {
+                url: 'https://upload.wikimedia.org/wikipedia/commons/x/xx/Undated.jpg',
+                descriptionurl: 'https://commons.wikimedia.org/wiki/File:Undated.jpg',
+                mime: 'image/jpeg',
+                extmetadata: {
+                  License: { value: 'pd' },
+                  ImageDescription: { value: 'A photograph with no recoverable date.' },
+                  Artist: { value: 'Photographer (1900–1980)' },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    // Honest absence: no date in description → empty displayDate, null years.
+    // The artist's lifespan is NOT used as a fallback (it's the artist's
+    // life, not the artwork's date).
+    expect(result.artwork.displayDate).toBe('');
+    expect(result.artwork.yearStart).toBe(null);
+    expect(result.artwork.yearEnd).toBe(null);
   });
 
   it('surfaces "wikimedia:unknown" id on rights-pass + bad-pageid rejections', () => {


### PR DESCRIPTION
## Summary
Adds Wikimedia Commons as the fourth live museum and the **first federated source** on the platform. Driven by the realisation that many works whose home museums lack public APIs — Bruegel at the Royal Museums of Fine Arts of Belgium, the Uffizi pre-API, regional museums worldwide — are already on Commons with explicit licence templates. Adding Commons unlocks them in one PR.

## Architectural shift: per-record rights

Until now every adapter ran **one rights rule against every record from a single source**. Commons hosts files from thousands of contributors with varied licences, so the validator inspects each record's `imageinfo[0].extmetadata.License.value` and decides per file.

This is the same per-record-rights pattern that v2.0 federation work (Smithsonian, Europeana) will need. Building it here for Commons unblocks the Smithsonian/Rijks adapters when they land, since the inspector pattern is now in the codebase.

## What's new

**Validator** (`validateWikimediaLicense` in `src/licenseGate.ts`):
- Accept on \`cc0\` → emits \`LicenseType: 'CC0'\`
- Accept on \`pd\` and \`pd-*\` subtypes (PD-Art, PD-old, PD-US, PD-self, …) → emits \`LicenseType: 'PD'\`
- Reject everything else: CC-BY, CC-BY-SA, CC-BY-NC, GFDL, fair-use, missing field, malformed input
- Strict default deny on missing extmetadata

CC-BY is rejected on principle: even though it's "free", it imposes attribution obligations that the per-museum gate model is not designed to verify or carry. If a future version adds attribution-aware rights handling, CC-BY can be admitted then.

**Fetcher** (\`src/fetchers/wikimedia.ts\`):
- Search via MediaWiki API: \`action=query&list=search&srnamespace=6\` returns pageids
- Get via MediaWiki API: \`action=query&pageids=…&prop=imageinfo&iiprop=url|size|mime|extmetadata\`
- Strips HTML from \`Artist\`, \`ObjectName\`, \`ImageDescription\` extmetadata fields (Commons text is HTML-laden)
- Rejects non-image MIME types — Commons hosts videos, audio, 3D models, PDFs; v0.3 surfaces images only
- Tolerates formatversion=2 (pages array), formatversion=1 (pages keyed by pageid), and direct page-object input (fixture convenience)
- Region and period stay \`null\` until v0.7 Wikidata enrichment — Commons doesn't carry that structured metadata

**Tests (12 new):** PD accept (Bruegel), CC0 accept, CC-BY-SA reject, missing-License reject, garbage-input reject, empty-pages reject, missing-imageinfo reject, non-image-MIME reject, direct-page-object accept, formatversion=1 accept, pd-art subtype accept, \`wikimedia:unknown\` id on rights-pass+bad-pageid.

**README:**
- §Verification model row added with the License accept condition
- §Supported museums row added (\`wikimedia\`, ✅ v0.3) plus a paragraph explaining the federated rights model and the Commons-specific accept policy
- "What you get" updated to list four live museums
- Roadmap restructured to surface v0.3 (here) and reorganise v0.7+ around the Wikidata-enrichment-as-prerequisite-for-obscurity-scoring path

**Tool description** advertises all four: \`met, cleveland, aic, wikimedia\`.

## Why this came up now

A planning conversation surfaced that Pramod wants to use Bruegel's *Landscape with the Fall of Icarus* as a future essay companion. The painting is at Kunstmuseum Brussels (KMSKB), which has no public API. But the painting is on Wikimedia Commons under a PD licence. So instead of waiting on KMSKB to expose an API, ship the Commons adapter and the painting becomes addressable today. Same logic unlocks every other home-museum-without-API.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — **134/134 pass** (was 122, +12 new)
- [x] \`npm run build\` — clean
- [x] Strict-default-deny invariant holds: 4 distinct reject paths in the new tests (non-PD licence, missing licence, missing extmetadata, malformed input)
- [x] Live API verified during fixture authoring against the real Bruegel record (pageid 15493856)

Co-Authored by Pramod Prasanth <pramod@chainalign.com>