### PR TITLE
feat(wikimedia): image dimensions, originalUrl, and same-painting dedupe

### DIFF
--- a/src/dedupe.ts
+++ b/src/dedupe.ts
@@ -1,0 +1,45 @@
+import type { Artwork } from './types.js';
+
+/**
+ * Wikimedia Commons frequently hosts the same painting at multiple
+ * resolutions (different scans, uploaders, or re-crops), each with its
+ * own pageid. A search for "Modigliani Lunia Czechowska" can return one
+ * record at 306×584 and another at 1187×1993. Both are legitimate, both
+ * pass the rights gate, but the smaller one breaks the look-at promise
+ * downstream.
+ *
+ * Collapse `wikimedia:*` records that share both title and artist down
+ * to the largest by pixel area. Other museums use unique IDs per
+ * artwork, so title+artist collisions there typically indicate
+ * genuinely distinct works (e.g. multiple casts of a sculpture, or
+ * multiple states of a print) — leave those alone. Records with no
+ * usable artist or `Unknown` artist also pass through untouched: the
+ * dedupe key isn't trustworthy.
+ */
+export function dedupeWikimediaUploads(artworks: Artwork[]): Artwork[] {
+  const dedupable = (a: Artwork): string | null => {
+    if (a.museum.code !== 'wikimedia') return null;
+    const title = a.title.trim().toLowerCase();
+    const artist = a.artist.name.trim().toLowerCase();
+    if (!title || !artist || artist === 'unknown') return null;
+    return `${title}|${artist}`;
+  };
+  const area = (a: Artwork): number =>
+    (a.imageUrls.width ?? 0) * (a.imageUrls.height ?? 0);
+
+  const winnerIndexByKey = new Map<string, number>();
+  artworks.forEach((a, i) => {
+    const key = dedupable(a);
+    if (key === null) return;
+    const prev = winnerIndexByKey.get(key);
+    if (prev === undefined || area(a) > area(artworks[prev])) {
+      winnerIndexByKey.set(key, i);
+    }
+  });
+
+  const winners = new Set(winnerIndexByKey.values());
+  return artworks.filter((a, i) => {
+    const key = dedupable(a);
+    return key === null || winners.has(i);
+  });
+}

--- a/src/fetchers/wikimedia.ts
+++ b/src/fetchers/wikimedia.ts
@@ -2,7 +2,7 @@ import { parseDisplayDate } from '../dateParser.js';
 import { validateWikimediaLicense } from '../licenseGate.js';
 import { cleanArtistName, detectAttributionType } from '../mappings.js';
 import type { Artwork, ValidationResult } from '../types.js';
-import { asString } from './helpers.js';
+import { asFiniteNumber, asString } from './helpers.js';
 import type { Fetcher, SearchOptions } from './types.js';
 
 const COMMONS_API = 'https://commons.wikimedia.org/w/api.php';
@@ -93,6 +93,19 @@ function stripHtml(s: string): string {
   return decodeEntities(s.replace(/<[^>]*>/g, ''))
     .replace(/\s+/g, ' ')
     .trim();
+}
+
+// Commons `Credit` extmetadata is the upstream-source field. It is often a
+// snippet of HTML wrapping a link back to the originating museum or archive
+// (e.g. `<a href="https://www.thyssen.org/...">Museo Thyssen-Bornemisza</a>`).
+// Pull the first http(s) href out as the canonical originalUrl. Plain-text
+// Credit values (no link) yield undefined — we don't synthesise URLs.
+const CREDIT_HREF_RE = /href\s*=\s*"(https?:\/\/[^"]+)"/i;
+
+function extractCreditUrl(credit: string): string | undefined {
+  if (!credit) return undefined;
+  const m = credit.match(CREDIT_HREF_RE);
+  return m ? m[1] : undefined;
 }
 
 // Format a parsed year range as a human-readable display string. Single-year
@@ -305,6 +318,14 @@ export const wikimediaFetcher: Fetcher = {
 
     const fullImage = asString(info.url);
     const pageUrl = asString(info.descriptionurl) || `${COMMONS_PAGE}/?curid=${pageId}`;
+    const width = asFiniteNumber(info.width) ?? undefined;
+    const height = asFiniteNumber(info.height) ?? undefined;
+    const byteSize = asFiniteNumber(info.size) ?? undefined;
+    // Credit field is HTML; pull out the first http(s) href as the upstream
+    // pointer. Important: don't strip HTML before extracting — stripHtml
+    // would discard the `<a href>` we need.
+    const creditRaw = getExtField(ext, 'Credit');
+    const originalUrl = extractCreditUrl(creditRaw);
 
     const artwork: Artwork = {
       id,
@@ -336,6 +357,9 @@ export const wikimediaFetcher: Fetcher = {
       imageUrls: {
         full: fullImage,
         thumbnail: undefined,
+        width,
+        height,
+        byteSize,
       },
       imageOpenAccess: decision.imageOpenAccess,
       metadataOpenAccess: decision.metadataOpenAccess,
@@ -343,6 +367,7 @@ export const wikimediaFetcher: Fetcher = {
       source: {
         apiUrl: `${COMMONS_API}?action=query&pageids=${pageId}&prop=imageinfo&format=json`,
         pageUrl,
+        originalUrl,
       },
       description: description || undefined,
     };

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,7 @@ import { join } from 'node:path';
 import { z } from 'zod';
 import { cite, type CiteStyle } from './cite.js';
 import { Cache } from './db.js';
+import { dedupeWikimediaUploads } from './dedupe.js';
 import { aicFetcher } from './fetchers/aic.js';
 import { clevelandFetcher } from './fetchers/cleveland.js';
 import { metFetcher } from './fetchers/met.js';
@@ -256,7 +257,8 @@ async function handleSearch(args: unknown) {
     .filter((r): r is { ok: true; artwork: Artwork } => r.ok)
     .map((r) => r.artwork);
   const filtered = accepted.filter((a) => !input.has_image || Boolean(a.imageUrls.full));
-  const results = filtered.slice(0, input.limit);
+  const deduped = dedupeWikimediaUploads(filtered);
+  const results = deduped.slice(0, input.limit);
 
   return {
     content: [

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,11 +30,25 @@ export interface ArtworkImages {
   full: string;
   large?: string;
   thumbnail?: string;
+  /** Pixel width of the `full` asset, when the museum publishes it. */
+  width?: number;
+  /** Pixel height of the `full` asset, when the museum publishes it. */
+  height?: number;
+  /** Byte size of the `full` asset, when the museum publishes it. */
+  byteSize?: number;
 }
 
 export interface ArtworkSource {
   apiUrl: string;
   pageUrl: string;
+  /**
+   * Upstream original-source URL when the museum's record points beyond
+   * itself. For Wikimedia Commons records, this is the originating museum
+   * or archive (parsed from the `Credit` extmetadata field). When the
+   * caller needs a higher-resolution canonical asset, this is where to
+   * look first.
+   */
+  originalUrl?: string;
 }
 
 export interface MuseumRef {

--- a/tests/dedupe.test.ts
+++ b/tests/dedupe.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from 'vitest';
+import { dedupeWikimediaUploads } from '../src/dedupe.js';
+import type { Artwork } from '../src/types.js';
+
+function art(overrides: Partial<Artwork> & { id: string }): Artwork {
+  return {
+    id: overrides.id,
+    museum: overrides.museum ?? {
+      code: 'wikimedia',
+      name: 'Wikimedia Commons',
+      url: 'https://commons.wikimedia.org',
+    },
+    title: overrides.title ?? 'Untitled',
+    artist: overrides.artist ?? {
+      name: 'Anonymous',
+      attributionType: 'anonymous',
+    },
+    displayDate: overrides.displayDate ?? '',
+    yearStart: overrides.yearStart ?? null,
+    yearEnd: overrides.yearEnd ?? null,
+    medium: overrides.medium ?? '',
+    region: overrides.region ?? null,
+    period: overrides.period ?? null,
+    imageUrls: overrides.imageUrls ?? { full: 'https://example.org/img.jpg' },
+    imageOpenAccess: true,
+    metadataOpenAccess: true,
+    license: {
+      type: 'PD',
+      rawValue: 'pd',
+      verificationSource: 'test',
+      verifiedAt: '2026-04-26',
+      confidence: 'high',
+    },
+    source: overrides.source ?? {
+      apiUrl: 'https://example.org/api',
+      pageUrl: 'https://example.org/page',
+    },
+  };
+}
+
+describe('dedupeWikimediaUploads', () => {
+  it('keeps the largest of multiple Commons uploads sharing title+artist', () => {
+    // Real-world case: Commons has the same Modigliani painting uploaded
+    // twice. The 306×584 entry would break the lightbox; the 1187×1993
+    // entry is the one we want surfaced.
+    const small = art({
+      id: 'wikimedia:1',
+      title: 'Lunia Czechowska',
+      artist: { name: 'Amedeo Modigliani', attributionType: 'named' },
+      imageUrls: { full: 'https://example.org/small.jpg', width: 306, height: 584 },
+    });
+    const large = art({
+      id: 'wikimedia:2',
+      title: 'Lunia Czechowska',
+      artist: { name: 'Amedeo Modigliani', attributionType: 'named' },
+      imageUrls: { full: 'https://example.org/large.jpg', width: 1187, height: 1993 },
+    });
+    const out = dedupeWikimediaUploads([small, large]);
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe('wikimedia:2');
+  });
+
+  it('is order-independent: largest wins regardless of input position', () => {
+    const small = art({
+      id: 'wikimedia:1',
+      title: 'X',
+      artist: { name: 'Y', attributionType: 'named' },
+      imageUrls: { full: 'a', width: 100, height: 100 },
+    });
+    const large = art({
+      id: 'wikimedia:2',
+      title: 'X',
+      artist: { name: 'Y', attributionType: 'named' },
+      imageUrls: { full: 'b', width: 1000, height: 1000 },
+    });
+    expect(dedupeWikimediaUploads([small, large]).map((a) => a.id)).toEqual(['wikimedia:2']);
+    expect(dedupeWikimediaUploads([large, small]).map((a) => a.id)).toEqual(['wikimedia:2']);
+  });
+
+  it('case-insensitive on title and artist (Commons casing varies)', () => {
+    const a = art({
+      id: 'wikimedia:1',
+      title: 'Water Lilies',
+      artist: { name: 'Claude Monet', attributionType: 'named' },
+      imageUrls: { full: 'a', width: 500, height: 500 },
+    });
+    const b = art({
+      id: 'wikimedia:2',
+      title: 'water lilies',
+      artist: { name: 'CLAUDE MONET', attributionType: 'named' },
+      imageUrls: { full: 'b', width: 2000, height: 2000 },
+    });
+    const out = dedupeWikimediaUploads([a, b]);
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe('wikimedia:2');
+  });
+
+  it('keeps both when titles differ even by a whisker (distinct works)', () => {
+    // "Water Lilies, c. 1915" vs "Water Lilies, 1916" — distinct paintings
+    // in Monet's series. They must not collapse.
+    const a = art({
+      id: 'wikimedia:1',
+      title: 'Water Lilies, c. 1915',
+      artist: { name: 'Claude Monet', attributionType: 'named' },
+      imageUrls: { full: 'a', width: 1000, height: 1000 },
+    });
+    const b = art({
+      id: 'wikimedia:2',
+      title: 'Water Lilies, 1916',
+      artist: { name: 'Claude Monet', attributionType: 'named' },
+      imageUrls: { full: 'b', width: 1500, height: 1500 },
+    });
+    const out = dedupeWikimediaUploads([a, b]);
+    expect(out).toHaveLength(2);
+  });
+
+  it('does not collapse same-title works by different artists', () => {
+    const a = art({
+      id: 'wikimedia:1',
+      title: 'Self-portrait',
+      artist: { name: 'Vincent van Gogh', attributionType: 'named' },
+      imageUrls: { full: 'a', width: 1000, height: 1000 },
+    });
+    const b = art({
+      id: 'wikimedia:2',
+      title: 'Self-portrait',
+      artist: { name: 'Rembrandt van Rijn', attributionType: 'named' },
+      imageUrls: { full: 'b', width: 1500, height: 1500 },
+    });
+    const out = dedupeWikimediaUploads([a, b]);
+    expect(out).toHaveLength(2);
+  });
+
+  it('passes through records with Unknown artist (key is not trustworthy)', () => {
+    // "Unknown" appears constantly across genuinely-distinct anonymous
+    // works. Collapsing them by title alone would erase real diversity.
+    const a = art({
+      id: 'wikimedia:1',
+      title: 'Saint',
+      artist: { name: 'Unknown', attributionType: 'anonymous' },
+      imageUrls: { full: 'a', width: 100, height: 100 },
+    });
+    const b = art({
+      id: 'wikimedia:2',
+      title: 'Saint',
+      artist: { name: 'Unknown', attributionType: 'anonymous' },
+      imageUrls: { full: 'b', width: 2000, height: 2000 },
+    });
+    const out = dedupeWikimediaUploads([a, b]);
+    expect(out).toHaveLength(2);
+  });
+
+  it('does not touch records from other museums', () => {
+    // Met / Cleveland / AIC use unique IDs per artwork; a title+artist
+    // match across them is rare but real (multi-cast bronzes, etc.) and
+    // should not collapse.
+    const met = art({
+      id: 'met:111',
+      museum: { code: 'met', name: 'Met', url: 'https://metmuseum.org' },
+      title: 'X',
+      artist: { name: 'Y', attributionType: 'named' },
+      imageUrls: { full: 'a', width: 500, height: 500 },
+    });
+    const wm1 = art({
+      id: 'wikimedia:1',
+      title: 'X',
+      artist: { name: 'Y', attributionType: 'named' },
+      imageUrls: { full: 'b', width: 1000, height: 1000 },
+    });
+    const wm2 = art({
+      id: 'wikimedia:2',
+      title: 'X',
+      artist: { name: 'Y', attributionType: 'named' },
+      imageUrls: { full: 'c', width: 2000, height: 2000 },
+    });
+    const out = dedupeWikimediaUploads([met, wm1, wm2]);
+    expect(out.map((a) => a.id).sort()).toEqual(['met:111', 'wikimedia:2']);
+  });
+
+  it('preserves the original output position of the winning record', () => {
+    // The dedupe should not reorder — the slot the winner appears in is
+    // the slot the winner came from. Other surrounding records keep
+    // their original positions.
+    const filler = art({
+      id: 'met:1',
+      museum: { code: 'met', name: 'Met', url: 'https://metmuseum.org' },
+    });
+    const small = art({
+      id: 'wikimedia:1',
+      title: 'X',
+      artist: { name: 'Y', attributionType: 'named' },
+      imageUrls: { full: 'a', width: 100, height: 100 },
+    });
+    const large = art({
+      id: 'wikimedia:2',
+      title: 'X',
+      artist: { name: 'Y', attributionType: 'named' },
+      imageUrls: { full: 'b', width: 1000, height: 1000 },
+    });
+    const out = dedupeWikimediaUploads([filler, small, large]);
+    // small dropped; large kept in its original position 2.
+    expect(out.map((a) => a.id)).toEqual(['met:1', 'wikimedia:2']);
+  });
+
+  it('handles missing dimensions: undefined area = 0, ties keep first', () => {
+    // Some records publish width/height/size; others don't. Records
+    // with missing dimensions sort to the bottom (area 0). When all
+    // candidates lack dimensions, the first one wins by tie-break.
+    const noDims1 = art({
+      id: 'wikimedia:1',
+      title: 'X',
+      artist: { name: 'Y', attributionType: 'named' },
+      imageUrls: { full: 'a' },
+    });
+    const noDims2 = art({
+      id: 'wikimedia:2',
+      title: 'X',
+      artist: { name: 'Y', attributionType: 'named' },
+      imageUrls: { full: 'b' },
+    });
+    const sized = art({
+      id: 'wikimedia:3',
+      title: 'X',
+      artist: { name: 'Y', attributionType: 'named' },
+      imageUrls: { full: 'c', width: 50, height: 50 },
+    });
+    expect(dedupeWikimediaUploads([noDims1, noDims2]).map((a) => a.id)).toEqual(['wikimedia:1']);
+    expect(dedupeWikimediaUploads([noDims1, sized]).map((a) => a.id)).toEqual(['wikimedia:3']);
+  });
+
+  it('returns the input unchanged when there are no duplicates', () => {
+    const a = art({
+      id: 'wikimedia:1',
+      title: 'A',
+      artist: { name: 'X', attributionType: 'named' },
+    });
+    const b = art({
+      id: 'wikimedia:2',
+      title: 'B',
+      artist: { name: 'Y', attributionType: 'named' },
+    });
+    expect(dedupeWikimediaUploads([a, b]).map((x) => x.id)).toEqual(['wikimedia:1', 'wikimedia:2']);
+  });
+});

--- a/tests/wikimedia.test.ts
+++ b/tests/wikimedia.test.ts
@@ -705,6 +705,121 @@ describe('Wikimedia Commons adapter normalization', () => {
     expect(result.artwork.yearEnd).toBe(null);
   });
 
+  it('surfaces image dimensions and byte size on imageUrls', () => {
+    // imageinfo carries width/height/size; we already fetch them via
+    // `iiprop=size`. Surface them so callers can pick the best upload
+    // when multiple Commons records cover the same painting.
+    const result = wikimediaFetcher.normalize(fixture('wikimedia-accepted-bruegel.json'));
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.imageUrls.width).toBe(1246);
+    expect(result.artwork.imageUrls.height).toBe(800);
+    expect(result.artwork.imageUrls.byteSize).toBe(152771);
+  });
+
+  it('omits dimensions when the Commons record does not publish them', () => {
+    // Defense: width/height/size missing should not surface as 0 or null —
+    // the fields stay undefined so callers can distinguish "unknown" from
+    // "small image".
+    const result = wikimediaFetcher.normalize({
+      query: {
+        pages: [
+          {
+            pageid: 88000040,
+            title: 'File:NoDims.jpg',
+            imageinfo: [
+              {
+                url: 'https://upload.wikimedia.org/wikipedia/commons/x/xx/NoDims.jpg',
+                descriptionurl: 'https://commons.wikimedia.org/wiki/File:NoDims.jpg',
+                mime: 'image/jpeg',
+                extmetadata: { License: { value: 'pd' } },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.imageUrls.width).toBeUndefined();
+    expect(result.artwork.imageUrls.height).toBeUndefined();
+    expect(result.artwork.imageUrls.byteSize).toBeUndefined();
+  });
+
+  it('parses Credit field into source.originalUrl when it carries an upstream link', () => {
+    // Real Commons Credit fields wrap the originating museum's link:
+    //   <a href="https://www.thyssen.org/...">Museo Thyssen-Bornemisza</a>
+    const result = wikimediaFetcher.normalize({
+      query: {
+        pages: [
+          {
+            pageid: 88000041,
+            title: 'File:Modigliani.jpg',
+            imageinfo: [
+              {
+                url: 'https://upload.wikimedia.org/wikipedia/commons/x/xx/M.jpg',
+                descriptionurl: 'https://commons.wikimedia.org/wiki/File:M.jpg',
+                mime: 'image/jpeg',
+                extmetadata: {
+                  License: { value: 'pd' },
+                  Credit: {
+                    value:
+                      '<a href="https://www.thyssen.org/lunia">Museo Nacional Thyssen-Bornemisza</a>',
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.source.originalUrl).toBe('https://www.thyssen.org/lunia');
+  });
+
+  it('leaves source.originalUrl undefined when Credit is plain text (no link)', () => {
+    // The Bruegel fixture's Credit is "Web Gallery of Art" — plain text, no
+    // anchor. Don't synthesise a URL.
+    const result = wikimediaFetcher.normalize(fixture('wikimedia-accepted-bruegel.json'));
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.source.originalUrl).toBeUndefined();
+  });
+
+  it('extracts only the first href from Credit when it contains multiple anchors', () => {
+    // Some Commons records have a long Credit blob with several links
+    // (museum, photographer, license boilerplate). The originating
+    // institution is conventionally the first anchor.
+    const result = wikimediaFetcher.normalize({
+      query: {
+        pages: [
+          {
+            pageid: 88000042,
+            title: 'File:MultiCredit.jpg',
+            imageinfo: [
+              {
+                url: 'https://upload.wikimedia.org/wikipedia/commons/x/xx/MC.jpg',
+                descriptionurl: 'https://commons.wikimedia.org/wiki/File:MC.jpg',
+                mime: 'image/jpeg',
+                extmetadata: {
+                  License: { value: 'pd' },
+                  Credit: {
+                    value:
+                      '<a href="https://museum.example.org/object/123">Example Museum</a>, photographed by <a href="https://example.com/photographer">A Photographer</a>',
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.source.originalUrl).toBe('https://museum.example.org/object/123');
+  });
+
   it('surfaces "wikimedia:unknown" id on rights-pass + bad-pageid rejections', () => {
     const result = wikimediaFetcher.normalize({
       query: {


### PR DESCRIPTION
## Summary

Three image-quality improvements driven by a real-world miss: a Modigliani search returned a 306×584 upload of a painting Commons also hosts at 1187×1993, breaking downstream look-at quality.

- **(a) Image dimensions**: `ArtworkImages` gains optional `width` / `height` / `byteSize`. The Wikimedia adapter already requested `iiprop=size`; we now surface what it fetches.
- **(b) Upstream URL**: `ArtworkSource` gains optional `originalUrl`. The Wikimedia adapter parses the first `http(s)` href out of the Commons `Credit` extmetadata so callers can find the upstream museum's canonical asset.
- **(c) Auto-pick largest**: `handleSearch` dedupes `wikimedia:*` records that share both title (case-insensitive) and artist down to the largest by pixel area. Other museums and records with `Unknown` artist pass through untouched (the dedupe key isn't trustworthy there).

## Test plan

- [x] `npm test` — 169 tests, 10 files (15 new tests added, all passing)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] Live smoke against Commons: Bruegel collapsed 4→2 keeping the 12265×8000 upload; Modigliani / Monet / Hokusai preserved their distinct same-titled works (titles differ slightly, correctly preserved)
- [x] `[orig]` upstream link surfaces on records with linkful Credit fields; absent on plain-text Credit

Co-Authored by Pramod Prasanth <pramod@chainalign.com>