### PR TITLE
feat(search): year_min / year_max date-range filter on search_artworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Then point the MCP config at the built binary:
 
 | Tool | Description |
 |---|---|
-| `search_artworks(query, museum?, has_image?, limit?)` | Search across registered museums. Returns only records that pass the rights gate. |
+| `search_artworks(query, museum?, has_image?, limit?, year_min?, year_max?)` | Search across registered museums. Returns only records that pass the rights gate. Supports an inclusive date-range filter via `year_min` / `year_max` for queries like "Dutch genre painting 1640–1680" (BCE = negative integer). |
 | `get_artwork(id)` | Fetch a single artwork by its normalized ID (e.g. `met:436535`). |
 | `cite(id, style?)` | Render a citation. `style`: `full` (artist, title, date, museum, license, URL), `caption` (image attribution), `short` (inline). |
 | `discover_random(region?, period?, not_artist?, museum?)` | Pick one random artwork from the local cache that matches the constraints. Operates over what has already been searched and cached. Useful for breaking out of repetitive search territory. |

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,7 @@ import { metFetcher } from './fetchers/met.js';
 import { wikimediaFetcher } from './fetchers/wikimedia.js';
 import type { Fetcher } from './fetchers/types.js';
 import type { Artwork } from './types.js';
+import { filterByYearRange } from './yearFilter.js';
 
 const FETCHERS: Record<string, Fetcher> = {
   [metFetcher.code]: metFetcher,
@@ -64,6 +65,13 @@ const SearchInput = z.object({
   museum: z.string().optional(),
   has_image: z.boolean().default(true),
   limit: z.number().int().min(1).max(50).default(10),
+  // Optional date-range constraint. Either bound may be omitted. BCE is
+  // expressed as a negative integer (e.g. year_min: -500 for 500 BCE).
+  // The bounds gate the *result set*, not the upstream search call —
+  // each museum's free-text search runs unchanged, and we drop accepted
+  // records whose [yearStart, yearEnd] falls outside the window.
+  year_min: z.number().int().optional(),
+  year_max: z.number().int().optional(),
 });
 
 const GetInput = z.object({
@@ -124,7 +132,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     {
       name: 'search_artworks',
       description:
-        'Search across registered open-access museum collections. Returns artwork records that pass source-specific rights verification (ambiguous records excluded by default).',
+        'Search across registered open-access museum collections. Returns artwork records that pass source-specific rights verification (ambiguous records excluded by default). Supports an optional date-range filter for researcher queries like "Dutch genre painting 1640–1680".',
       inputSchema: {
         type: 'object',
         properties: {
@@ -140,6 +148,16 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
             description: 'Restrict to records with an image URL. Defaults to true. Note: some museums (e.g. The Met) only expose images-only search server-side.',
           },
           limit: { type: 'integer', minimum: 1, maximum: 50, default: 10 },
+          year_min: {
+            type: 'integer',
+            description:
+              'Optional inclusive lower bound on artwork creation year. Negative for BCE (e.g. -500 = 500 BCE). Records with no parseable date are excluded when any year bound is set.',
+          },
+          year_max: {
+            type: 'integer',
+            description:
+              'Optional inclusive upper bound on artwork creation year. Negative for BCE. Records with no parseable date are excluded when any year bound is set.',
+          },
         },
         required: ['query'],
       },
@@ -258,7 +276,8 @@ async function handleSearch(args: unknown) {
     .map((r) => r.artwork);
   const filtered = accepted.filter((a) => !input.has_image || Boolean(a.imageUrls.full));
   const deduped = dedupeWikimediaUploads(filtered);
-  const results = deduped.slice(0, input.limit);
+  const dated = filterByYearRange(deduped, input.year_min, input.year_max);
+  const results = dated.slice(0, input.limit);
 
   return {
     content: [

--- a/src/yearFilter.ts
+++ b/src/yearFilter.ts
@@ -1,0 +1,28 @@
+import type { Artwork } from './types.js';
+
+/**
+ * Filter artworks down to those whose date range overlaps `[yearMin, yearMax]`.
+ *
+ * Either bound may be `undefined`; both undefined returns the input untouched.
+ * Records with a null `yearStart` or `yearEnd` are excluded as soon as any
+ * bound is set: a date-range query is a research constraint, and a record
+ * we couldn't date can't honestly be claimed to satisfy it. (Future Wikidata
+ * enrichment in v0.7 will recover dates for many of these records.)
+ *
+ * Overlap is inclusive on both edges: an artwork with `yearStart === yearMax`
+ * or `yearEnd === yearMin` passes. BCE is encoded as negative years, so
+ * cross-era windows (e.g. -100 → 100) work without special-casing.
+ */
+export function filterByYearRange(
+  artworks: Artwork[],
+  yearMin: number | undefined,
+  yearMax: number | undefined,
+): Artwork[] {
+  if (yearMin === undefined && yearMax === undefined) return artworks;
+  return artworks.filter((a) => {
+    if (a.yearStart === null || a.yearEnd === null) return false;
+    if (yearMin !== undefined && a.yearEnd < yearMin) return false;
+    if (yearMax !== undefined && a.yearStart > yearMax) return false;
+    return true;
+  });
+}

--- a/tests/yearFilter.test.ts
+++ b/tests/yearFilter.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { filterByYearRange } from '../src/yearFilter.js';
+import type { Artwork } from '../src/types.js';
+
+function art(id: string, yearStart: number | null, yearEnd: number | null): Artwork {
+  return {
+    id,
+    museum: { code: 'met', name: 'Met', url: 'https://metmuseum.org' },
+    title: 'Untitled',
+    artist: { name: 'Anonymous', attributionType: 'anonymous' },
+    displayDate: '',
+    yearStart,
+    yearEnd,
+    medium: '',
+    region: null,
+    period: null,
+    imageUrls: { full: 'https://example.org/img.jpg' },
+    imageOpenAccess: true,
+    metadataOpenAccess: true,
+    license: {
+      type: 'PD',
+      rawValue: 'pd',
+      verificationSource: 'test',
+      verifiedAt: '2026-04-27',
+      confidence: 'high',
+    },
+    source: { apiUrl: 'https://example.org/api', pageUrl: 'https://example.org/page' },
+  };
+}
+
+describe('filterByYearRange', () => {
+  const sample = [
+    art('met:1', 1640, 1640), // inside
+    art('met:2', 1635, 1645), // overlaps lower edge
+    art('met:3', 1675, 1685), // overlaps upper edge
+    art('met:4', 1700, 1700), // outside (after)
+    art('met:5', 1500, 1500), // outside (before)
+    art('met:6', 1640, 1680), // exact span
+    art('met:7', null, null), // unknown date
+    art('met:8', 1600, 1700), // envelopes the window
+  ];
+
+  it('returns input unchanged when both bounds are undefined', () => {
+    const out = filterByYearRange(sample, undefined, undefined);
+    expect(out).toBe(sample);
+  });
+
+  it('filters to records that overlap [yearMin, yearMax]', () => {
+    // Researcher's canonical query: "Dutch genre painting 1640–1680".
+    // An artwork [s, e] passes when its range overlaps the window:
+    //   s <= yearMax AND e >= yearMin.
+    const out = filterByYearRange(sample, 1640, 1680);
+    expect(out.map((a) => a.id)).toEqual(['met:1', 'met:2', 'met:3', 'met:6', 'met:8']);
+  });
+
+  it('open-ended max (yearMin only) keeps everything from yearMin onward', () => {
+    const out = filterByYearRange(sample, 1640, undefined);
+    // Excludes met:5 (1500) — everything else has yearEnd >= 1640.
+    expect(out.map((a) => a.id)).toEqual(['met:1', 'met:2', 'met:3', 'met:4', 'met:6', 'met:8']);
+  });
+
+  it('open-ended min (yearMax only) keeps everything up to yearMax', () => {
+    const out = filterByYearRange(sample, undefined, 1680);
+    // Excludes met:4 (1700) — everything else has yearStart <= 1680.
+    expect(out.map((a) => a.id)).toEqual(['met:1', 'met:2', 'met:3', 'met:5', 'met:6', 'met:8']);
+  });
+
+  it('drops records with null yearStart or yearEnd when any bound is set', () => {
+    // Honest behaviour: a date-range filter is a research constraint;
+    // unverifiable records can't be claimed to match. Don't pollute results.
+    const onlyUnknown = [art('met:7', null, null)];
+    expect(filterByYearRange(onlyUnknown, 1640, 1680)).toEqual([]);
+    expect(filterByYearRange(onlyUnknown, 1640, undefined)).toEqual([]);
+    expect(filterByYearRange(onlyUnknown, undefined, 1680)).toEqual([]);
+  });
+
+  it('keeps null-year records when no bound is set (unconstrained search)', () => {
+    const onlyUnknown = [art('met:7', null, null)];
+    const out = filterByYearRange(onlyUnknown, undefined, undefined);
+    expect(out).toEqual(onlyUnknown);
+  });
+
+  it('handles BCE (negative years) and cross-era windows', () => {
+    const ancient = [
+      art('met:bce500', -500, -500),
+      art('met:bce100', -100, -100),
+      art('met:ce50', 50, 50),
+      art('met:ce300', 300, 300),
+    ];
+    // 100 BCE to 100 CE
+    const out = filterByYearRange(ancient, -100, 100);
+    expect(out.map((a) => a.id)).toEqual(['met:bce100', 'met:ce50']);
+  });
+
+  it('inclusive on both edges (yearStart === yearMax and yearEnd === yearMin pass)', () => {
+    // Edge inclusivity matters for researchers asking "1640-1680" and
+    // expecting 1640 and 1680 to both be in the set.
+    const edges = [
+      art('met:edge-low', 1640, 1640),
+      art('met:edge-high', 1680, 1680),
+    ];
+    expect(filterByYearRange(edges, 1640, 1680).map((a) => a.id)).toEqual([
+      'met:edge-low',
+      'met:edge-high',
+    ]);
+  });
+
+  it('preserves input order', () => {
+    const out = filterByYearRange(sample, 1500, 1700);
+    // Order in `sample` is met:1, met:2, met:3, met:4, met:5, met:6, met:8
+    // (met:7 dropped for null years).
+    expect(out.map((a) => a.id)).toEqual(['met:1', 'met:2', 'met:3', 'met:4', 'met:5', 'met:6', 'met:8']);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the canonical researcher query — "Dutch genre painting 1640–1680" — as a server-side filter on `search_artworks`. Either bound is optional; both omitted preserves current behavior.

This is the v0.3.1 step that unlocks the demo video example "Dutch genre painting between 1640 and 1680" without requiring the LLM to post-filter results in prose.

## Changes

- New `SearchInput` fields: `year_min` / `year_max` (signed integers; BCE = negative). Tool description and README updated to surface them.
- New `filterByYearRange` helper in `src/yearFilter.ts`: inclusive overlap (`yearStart <= yearMax && yearEnd >= yearMin`), drops null-year records whenever any bound is set (a research filter can't claim to satisfy a constraint we can't verify).
- Filter applies post-fetch in `handleSearch`, between rights/image filtering and the limit slice. The upstream search call is unchanged, so the cache key does not include the year bounds — different windows reuse the same cached id list.

## Test plan

- [x] `npm test` — 163 tests, 10 files (9 new tests added, all passing)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] Tests cover: overlap math, edge inclusivity (`yearMin === yearStart` and `yearMax === yearEnd` both pass), open-ended bounds, null-year handling under each bound configuration, BCE / cross-era windows, and order preservation.

## Notes for review

- The filter is client-side; a future v0.4 could push `year_min`/`year_max` down to upstream museum APIs that support it (Met `dateBegin`/`dateEnd`, AIC `date_start_max`/`date_end_min`, Cleveland `created_after`/`created_before`) for better overfetch hit rates. Out of scope here.
- Stacks cleanly on top of `main` and is independent of #20 (`feat/wikimedia-image-quality`); no conflict expected.

Co-Authored by Pramod Prasanth <pramod@chainalign.com>