### PR TITLE
chore: shared reject + ID-validation helpers; hoist tryDynasty work

### DIFF
--- a/src/dateParser.ts
+++ b/src/dateParser.ts
@@ -19,6 +19,15 @@ const flatDynasties: Record<string, [number, number]> = (() => {
   return out;
 })();
 
+// Pre-sort once at module load: longest keys first so multi-word periods
+// ("three kingdoms", "delhi sultanate") match before any prefix overlap with
+// shorter keys. Re-sorting on every tryDynasty call was wasted work.
+const FLAT_DYNASTY_KEYS_LONGEST_FIRST = Object.keys(flatDynasties).sort(
+  (a, b) => b.length - a.length,
+);
+
+const QUALIFIER_RE = /\b(early|mid|middle|late)\b/;
+
 const ROMAN: Record<string, number> = {
   i: 1, ii: 2, iii: 3, iv: 4, v: 5, vi: 6, vii: 7, viii: 8, ix: 9, x: 10,
   xi: 11, xii: 12, xiii: 13, xiv: 14, xv: 15, xvi: 16, xvii: 17, xviii: 18,
@@ -243,27 +252,24 @@ function tryCentury(s: string): DateRange | null {
 
 function tryDynasty(s: string): DateRange | null {
   const lower = s.toLowerCase();
-  const sorted = Object.keys(flatDynasties).sort((a, b) => b.length - a.length);
-  for (const period of sorted) {
-    if (lower.includes(period)) {
-      const [start, end] = flatDynasties[period];
-      const qual = lower.match(/\b(early|mid|middle|late)\b/);
-      const qualifier = qual ? qual[1] : undefined;
-      const span = end - start;
-      if (qualifier === 'early') {
-        return { yearStart: start, yearEnd: start + Math.floor(span / 3) };
-      }
-      if (qualifier === 'mid' || qualifier === 'middle') {
-        return {
-          yearStart: start + Math.floor(span / 3),
-          yearEnd: end - Math.floor(span / 3),
-        };
-      }
-      if (qualifier === 'late') {
-        return { yearStart: end - Math.floor(span / 3), yearEnd: end };
-      }
-      return { yearStart: start, yearEnd: end };
+  const qualifier = lower.match(QUALIFIER_RE)?.[1];
+  for (const period of FLAT_DYNASTY_KEYS_LONGEST_FIRST) {
+    if (!lower.includes(period)) continue;
+    const [start, end] = flatDynasties[period];
+    const span = end - start;
+    if (qualifier === 'early') {
+      return { yearStart: start, yearEnd: start + Math.floor(span / 3) };
     }
+    if (qualifier === 'mid' || qualifier === 'middle') {
+      return {
+        yearStart: start + Math.floor(span / 3),
+        yearEnd: end - Math.floor(span / 3),
+      };
+    }
+    if (qualifier === 'late') {
+      return { yearStart: end - Math.floor(span / 3), yearEnd: end };
+    }
+    return { yearStart: start, yearEnd: end };
   }
   return null;
 }

--- a/src/fetchers/aic.ts
+++ b/src/fetchers/aic.ts
@@ -2,7 +2,13 @@ import { parseDisplayDate } from '../dateParser.js';
 import { validateAicLicense } from '../licenseGate.js';
 import { cleanArtistName, detectAttributionType, normalizeRegion } from '../mappings.js';
 import type { Artwork, ValidationResult } from '../types.js';
-import { asFiniteNumber, asOptionalString, asString } from './helpers.js';
+import {
+  asFiniteNumber,
+  asOptionalString,
+  asString,
+  isValidPositiveInt,
+  rejectFor,
+} from './helpers.js';
 import type { Fetcher, SearchOptions } from './types.js';
 
 const AIC_API = 'https://api.artic.edu/api/v1';
@@ -27,12 +33,8 @@ const AIC_FIELDS = [
   'image_id',
 ].join(',');
 
-function reject(id: string, reason: string, rawSnapshot: unknown): ValidationResult {
-  return {
-    status: 'rejected',
-    rejection: { id, museumCode: 'aic', reason, rawSnapshot },
-  };
-}
+const reject = (id: string, reason: string, rawSnapshot: unknown): ValidationResult =>
+  rejectFor('aic', id, reason, rawSnapshot);
 
 // AIC's `artist_display` format mirrors Cleveland's: "Name (Nationality,
 // birthYear–deathYear)". The structured `artist_title` field gives us the
@@ -106,8 +108,7 @@ export const aicFetcher: Fetcher = {
     const r = inner as Record<string, unknown>;
 
     const objectId = r.id;
-    const validId =
-      typeof objectId === 'number' && Number.isInteger(objectId) && objectId > 0;
+    const validId = isValidPositiveInt(objectId);
     const id = validId ? `aic:${objectId}` : 'aic:unknown';
 
     const decision = validateAicLicense(inner);

--- a/src/fetchers/cleveland.ts
+++ b/src/fetchers/cleveland.ts
@@ -2,17 +2,19 @@ import { parseDisplayDate } from '../dateParser.js';
 import { validateClevelandLicense } from '../licenseGate.js';
 import { cleanArtistName, detectAttributionType, normalizeRegion } from '../mappings.js';
 import type { Artwork, ValidationResult } from '../types.js';
-import { asFiniteNumber, asOptionalString, asString } from './helpers.js';
+import {
+  asFiniteNumber,
+  asOptionalString,
+  asString,
+  isValidPositiveInt,
+  rejectFor,
+} from './helpers.js';
 import type { Fetcher, SearchOptions } from './types.js';
 
 const CLEVELAND_API = 'https://openaccess-api.clevelandart.org/api';
 
-function reject(id: string, reason: string, rawSnapshot: unknown): ValidationResult {
-  return {
-    status: 'rejected',
-    rejection: { id, museumCode: 'cleveland', reason, rawSnapshot },
-  };
-}
+const reject = (id: string, reason: string, rawSnapshot: unknown): ValidationResult =>
+  rejectFor('cleveland', id, reason, rawSnapshot);
 
 // Cleveland's creator description format is "Name (Nationality, birthYear–deathYear)"
 // e.g. "Vincent van Gogh (Dutch, 1853–1890)". The structured fields
@@ -77,8 +79,7 @@ export const clevelandFetcher: Fetcher = {
     const r = inner as Record<string, unknown>;
 
     const objectId = r.id;
-    const validId =
-      typeof objectId === 'number' && Number.isInteger(objectId) && objectId > 0;
+    const validId = isValidPositiveInt(objectId);
     const id = validId ? `cleveland:${objectId}` : 'cleveland:unknown';
 
     const decision = validateClevelandLicense(inner);

--- a/src/fetchers/helpers.ts
+++ b/src/fetchers/helpers.ts
@@ -7,6 +7,8 @@
  * helpers express the most-common narrowings once.
  */
 
+import type { ValidationResult } from '../types.js';
+
 /** Returns the string value, or "" for any non-string input. */
 export function asString(v: unknown): string {
   return typeof v === 'string' ? v : '';
@@ -20,4 +22,30 @@ export function asOptionalString(v: unknown): string | undefined {
 /** Returns finite number, or null for NaN/Infinity/non-number. */
 export function asFiniteNumber(v: unknown): number | null {
   return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+/**
+ * True when `v` is a valid museum-side artwork ID: a positive integer.
+ * Every adapter's `normalize()` makes this exact check before assembling
+ * an `<museum>:<id>` string, so it lives here once.
+ */
+export function isValidPositiveInt(v: unknown): v is number {
+  return typeof v === 'number' && Number.isInteger(v) && v > 0;
+}
+
+/**
+ * Build a rejection `ValidationResult` with consistent shape across
+ * fetchers. Replaces three identical 6-line factories that used to live
+ * in cleveland / aic / wikimedia, plus inline rejection blocks in met.
+ */
+export function rejectFor(
+  museumCode: string,
+  id: string,
+  reason: string,
+  rawSnapshot: unknown,
+): ValidationResult {
+  return {
+    status: 'rejected',
+    rejection: { id, museumCode, reason, rawSnapshot },
+  };
 }

--- a/src/fetchers/met.ts
+++ b/src/fetchers/met.ts
@@ -2,7 +2,7 @@ import { parseDisplayDate } from '../dateParser.js';
 import { validateMetLicense } from '../licenseGate.js';
 import { cleanArtistName, detectAttributionType, normalizeRegion } from '../mappings.js';
 import type { Artwork, ValidationResult } from '../types.js';
-import { asOptionalString, asString } from './helpers.js';
+import { asOptionalString, asString, isValidPositiveInt, rejectFor } from './helpers.js';
 import type { Fetcher, SearchOptions } from './types.js';
 
 const MET_API = 'https://collectionapi.metmuseum.org/public/collection/v1';
@@ -35,47 +35,23 @@ export const metFetcher: Fetcher = {
 
   normalize(raw: unknown): ValidationResult {
     if (!raw || typeof raw !== 'object') {
-      return {
-        status: 'rejected',
-        rejection: {
-          id: 'met:unknown',
-          museumCode: 'met',
-          reason: 'response not an object',
-          rawSnapshot: raw,
-        },
-      };
+      return rejectFor('met', 'met:unknown', 'response not an object', raw);
     }
     const r = raw as Record<string, unknown>;
     const objectID = r.objectID;
     // Met IDs are always positive integers. Anything else flunks ID_REGEX
     // downstream; emit a placeholder so the rejection still carries a stable
     // (and obviously bogus) id for logs.
-    const validId = typeof objectID === 'number' && Number.isInteger(objectID) && objectID > 0;
+    const validId = isValidPositiveInt(objectID);
     const id = validId ? `met:${objectID}` : 'met:unknown';
 
     const decision = validateMetLicense(raw);
     if (!decision.accepted || !decision.license) {
-      return {
-        status: 'rejected',
-        rejection: {
-          id,
-          museumCode: 'met',
-          reason: decision.reason,
-          rawSnapshot: raw,
-        },
-      };
+      return rejectFor('met', id, decision.reason, raw);
     }
 
     if (!validId) {
-      return {
-        status: 'rejected',
-        rejection: {
-          id,
-          museumCode: 'met',
-          reason: 'met: missing or non-integer objectID',
-          rawSnapshot: raw,
-        },
-      };
+      return rejectFor('met', id, 'met: missing or non-integer objectID', raw);
     }
 
     const displayDate = asString(r.objectDate);

--- a/src/fetchers/wikimedia.ts
+++ b/src/fetchers/wikimedia.ts
@@ -2,7 +2,7 @@ import { parseDisplayDate } from '../dateParser.js';
 import { validateWikimediaLicense } from '../licenseGate.js';
 import { cleanArtistName, detectAttributionType } from '../mappings.js';
 import type { Artwork, ValidationResult } from '../types.js';
-import { asFiniteNumber, asString } from './helpers.js';
+import { asFiniteNumber, asString, isValidPositiveInt, rejectFor } from './helpers.js';
 import type { Fetcher, SearchOptions } from './types.js';
 
 const COMMONS_API = 'https://commons.wikimedia.org/w/api.php';
@@ -13,12 +13,8 @@ const COMMONS_PAGE = 'https://commons.wikimedia.org/wiki';
 // `imageUrls.full` contract holds.
 const IMAGE_MIME_PREFIX = 'image/';
 
-function reject(id: string, reason: string, rawSnapshot: unknown): ValidationResult {
-  return {
-    status: 'rejected',
-    rejection: { id, museumCode: 'wikimedia', reason, rawSnapshot },
-  };
-}
+const reject = (id: string, reason: string, rawSnapshot: unknown): ValidationResult =>
+  rejectFor('wikimedia', id, reason, rawSnapshot);
 
 // extmetadata fields are wrapped: `{value, source, hidden?}`. Pull the value
 // only, default to empty string if absent or non-string.
@@ -26,8 +22,7 @@ function getExtField(ext: Record<string, unknown> | undefined, field: string): s
   if (!ext) return '';
   const wrap = ext[field];
   if (!wrap || typeof wrap !== 'object') return '';
-  const v = (wrap as { value?: unknown }).value;
-  return typeof v === 'string' ? v : '';
+  return asString((wrap as { value?: unknown }).value);
 }
 
 // Common HTML entities seen in Commons text fields. Numeric escapes
@@ -240,7 +235,7 @@ export const wikimediaFetcher: Fetcher = {
     }
 
     const pageId = page.pageid;
-    const validId = typeof pageId === 'number' && Number.isInteger(pageId) && pageId > 0;
+    const validId = isValidPositiveInt(pageId);
     const id = validId ? `wikimedia:${pageId}` : 'wikimedia:unknown';
 
     const imageinfo = Array.isArray(page.imageinfo) ? page.imageinfo : [];


### PR DESCRIPTION
## Summary

Output of running `/simplify` across `src/` after the v0.3 work landed. Three real wins, no behaviour change, 169/169 tests still pass.

## Changes

**1. `rejectFor` + `isValidPositiveInt` in `src/fetchers/helpers.ts`**

Three identical 6-line `reject()` factories (cleveland, aic, wikimedia) and three inline rejection blocks in `met.ts` collapse into one shared helper. Same for the four copies of `typeof x === 'number' && Number.isInteger(x) && x > 0` ID validation. Each fetcher keeps a one-line local `reject` alias for readability — calling `rejectFor` under the hood.

**2. `wikimedia.getExtField` uses `asString`**

The inline narrow `typeof v === 'string' ? v : ''` was a verbatim duplicate of the helper imported one line away.

**3. `tryDynasty` perf**

`Object.keys(flatDynasties).sort(...)` was running on every `parseDisplayDate` call, re-sorting dozens of keys. Hoisted to module-load constant `FLAT_DYNASTY_KEYS_LONGEST_FIRST`. The qualifier regex was also being matched inside the per-period loop despite being a property of the input string — hoisted to module scope (`QUALIFIER_RE`), matched once.

## Deliberately skipped

The `/simplify` review surfaced several other findings that aren't wins under this project's conventions ("don't introduce abstractions beyond what the task requires," "three similar lines is better than a premature abstraction"):

- Lifespan formatting helper for met/cleveland (only 2 callers)
- Cleveland/AIC artist-display parser unification (different return shapes)
- `aggregateByTag` SQL "duplication" — intentional per the comment that preserves the README §Security claim ("zero string-concatenated SQL paths")
- Stringly-typed museum codes (only 4 — premature union)
- `withConcurrency` `next++` pattern (safe under JS event loop)
- `JSON.parse` memoization on cache reads (v0.4+ optimization, not simplification)

## Test plan

- [x] `npm test` — 169/169 pass
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] All four fetcher fixtures (Met, Cleveland, AIC, Wikimedia accepted + rejected) still produce the expected `ValidationResult` shape

Co-Authored by Pramod Prasanth <pramod@chainalign.com>