### PR TITLE
feat(europeana): federated European-institutions adapter (opt-in via API key)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If anyone else is exploring open-access art, I hope this helps. The plan is to k
 
 ## What you get
 
-- **One interface, registered museums.** The Met, Cleveland Museum of Art, the Art Institute of Chicago, and Wikimedia Commons are live. Smithsonian and Rijksmuseum are next.
+- **One interface, registered museums.** The Met, Cleveland Museum of Art, the Art Institute of Chicago, Wikimedia Commons, and Europeana (federated European institutions, opt-in via API key) are live. Smithsonian and Rijksmuseum direct integrations are next.
 - **Strict deny on ambiguity.** Records are validated against per-museum rights rules in code. Missing or unclear indicators drop the record; nothing is defaulted to "open".
 - **Catalog-grade metadata.** A dynasty-aware date parser handles Tang, Edo, Safavid, Mughal and the rest. Regions normalize across museums. Attribution separates named artists from anonymous, workshop, "after", and attributed works.
 - **Listable resources and deterministic citations.** `museum://{code}/{id}` resources, three citation styles, structured JSON search results.
@@ -156,6 +156,7 @@ This is the heart of the project. Each museum exposes rights information in its 
 | Cleveland Museum of Art | `share_license_status` (string) | `=== "CC0"` (case-insensitive) |
 | Art Institute of Chicago | `is_public_domain` (boolean) | `=== true` |
 | Wikimedia Commons | `imageinfo[0].extmetadata.License.value` (string) | `=== "cc0"` OR `=== "pd"` OR matches `pd-*` |
+| Europeana | `rights[0]` (URI) | exact match on the CC0 or Public Domain Mark URI; everything else (CC-BY, CC-BY-SA, NoC, InC) is rejected |
 
 Each accepted record carries:
 
@@ -177,10 +178,13 @@ This is what "rights-verified" means here: validated against published museum me
 | Cleveland Museum of Art | `cleveland` | none | ✅ v0.2 |
 | Art Institute of Chicago | `aic` | none | ✅ v0.2 |
 | Wikimedia Commons | `wikimedia` | none | ✅ v0.3 |
+| Europeana | `europeana` | API key (free, per-user) | ✅ v0.4 |
 | Smithsonian Open Access | `si` | API key (free) | 📋 v2 |
 | Rijksmuseum | `rijks` | API key (free) | 📋 v2 |
 
 **On Wikimedia Commons:** Commons is a federation, not a single museum. Rights are per-file. The adapter accepts only `cc0` and `pd*` licence templates; CC-BY, CC-BY-SA, and other attribution-or-restriction licences are rejected even though they're "free", because the per-museum gate model doesn't carry the obligations they impose. Adding Commons unlocks works whose home museums don't have public APIs (Bruegel at the Royal Museums of Fine Arts of Belgium, the National Gallery in London pre-API, regional museums worldwide) — at the cost of a thinner metadata layer than the structured-API museums provide. Region and period are not surfaced for Wikimedia records until v0.7 adds Wikidata enrichment.
+
+**On Europeana:** Europeana aggregates tens of millions of records from European cultural-heritage institutions, with rights expressed as a URI from a fixed vocabulary (Europeana Rights Statements). The adapter accepts only the unambiguous public-domain URIs — CC0 (`creativecommons.org/publicdomain/zero/1.0/`) and the Public Domain Mark (`creativecommons.org/publicdomain/mark/1.0/`). Everything else (CC-BY, CC-BY-SA, CC-BY-NC, NoC-*, InC) is rejected on the same strict-default-deny grounds as the Wikimedia gate. Europeana requires a free per-user API key — register at [pro.europeana.eu/get-api](https://pro.europeana.eu/get-api) and set `EUROPEANA_API_KEY` either in your shell, in a project-root `.env`, or in `~/.open-museum-mcp/.env`. The fetcher silently disables itself when the key is missing (the rest of the federation continues to work).
 
 ## Suggest a museum
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
         "better-sqlite3": "^11.5.0",
+        "dotenv": "^17.4.2",
         "zod": "^3.23.8"
       },
       "bin": {
@@ -1375,6 +1376,18 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.4",
     "better-sqlite3": "^11.5.0",
+    "dotenv": "^17.4.2",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/src/fetchers/europeana.ts
+++ b/src/fetchers/europeana.ts
@@ -54,13 +54,16 @@ function pickLangAware(obj: unknown, langPreference: string[] = ['en', 'def']): 
 }
 
 // Europeana flat array helpers — many fields are returned as arrays even when
-// they carry exactly one value.
+// they carry exactly one value. Numeric values (e.g. `year: [1642]` instead
+// of `["1642"]`) are stringified so downstream parsers see a consistent
+// shape regardless of upstream serialization quirks.
 function firstString(v: unknown): string {
-  if (Array.isArray(v)) {
-    const f = v.find((x) => typeof x === 'string');
-    return typeof f === 'string' ? f : '';
+  const arr = Array.isArray(v) ? v : [v];
+  for (const x of arr) {
+    if (typeof x === 'string' && x.length > 0) return x;
+    if (typeof x === 'number' && Number.isFinite(x)) return String(x);
   }
-  return typeof v === 'string' ? v : '';
+  return '';
 }
 
 function parseRecord(raw: Record<string, unknown>): {
@@ -130,7 +133,10 @@ export const europeanaFetcher: Fetcher = {
       url.searchParams.append('qf', 'TYPE:IMAGE');
     }
     url.searchParams.set('rows', String(limit));
-    url.searchParams.set('profile', 'minimal');
+    // profile=standard returns the description fields (dcDescription /
+    // dcDescriptionLangAware) and other EDM properties cite needs.
+    // Bandwidth cost is small relative to the gate-rejection ratio.
+    url.searchParams.set('profile', 'standard');
 
     const res = await fetch(url);
     if (!res.ok) throw new Error(`Europeana search failed: ${res.status}`);
@@ -153,7 +159,10 @@ export const europeanaFetcher: Fetcher = {
     url.searchParams.set('wskey', key);
     url.searchParams.set('query', `europeana_id:"/${path}"`);
     url.searchParams.set('rows', '1');
-    url.searchParams.set('profile', 'minimal');
+    // profile=standard returns the description fields (dcDescription /
+    // dcDescriptionLangAware) and other EDM properties cite needs.
+    // Bandwidth cost is small relative to the gate-rejection ratio.
+    url.searchParams.set('profile', 'standard');
     const res = await fetch(url);
     if (!res.ok) throw new Error(`Europeana get failed for ${id}: ${res.status}`);
     return res.json();

--- a/src/fetchers/europeana.ts
+++ b/src/fetchers/europeana.ts
@@ -1,0 +1,233 @@
+import { parseDisplayDate } from '../dateParser.js';
+import { validateEuropeanaLicense } from '../licenseGate.js';
+import { cleanArtistName, detectAttributionType, normalizeRegion } from '../mappings.js';
+import type { Artwork, ValidationResult } from '../types.js';
+import { asOptionalString, asString } from './helpers.js';
+import type { Fetcher, SearchOptions } from './types.js';
+
+const EUROPEANA_API = 'https://api.europeana.eu/record/v2';
+const EUROPEANA_PAGE = 'https://www.europeana.eu/en/item';
+
+// Europeana item IDs are hierarchical: a numeric dataset prefix plus a
+// per-item slug (`9200338/BibliographicResource_3000093834108`). We carry
+// the full path as the suffix of the project's `museum:id` convention.
+function reject(id: string, reason: string, rawSnapshot: unknown): ValidationResult {
+  return {
+    status: 'rejected',
+    rejection: { id, museumCode: 'europeana', reason, rawSnapshot },
+  };
+}
+
+// Europeana's API key is required and per-user; we read it lazily so the
+// fetcher module loads cleanly even when the key isn't set (server.ts
+// decides whether to register the fetcher based on key presence).
+function apiKey(): string {
+  return process.env.EUROPEANA_API_KEY ?? '';
+}
+
+// Strip the leading slash on Europeana IDs returned by the search API.
+// Example: `/9200338/Bibliographic...` → `9200338/Bibliographic...`.
+function normalizeEuropeanaId(raw: string): string {
+  return raw.replace(/^\/+/, '');
+}
+
+// Europeana lang-aware fields look like `{ "def": ["..."], "en": ["..."] }`.
+// Prefer English when available, fall back to first non-empty value.
+function pickLangAware(obj: unknown, langPreference: string[] = ['en', 'def']): string {
+  if (!obj || typeof obj !== 'object') return '';
+  const map = obj as Record<string, unknown>;
+  for (const lang of langPreference) {
+    const arr = map[lang];
+    if (Array.isArray(arr)) {
+      const v = arr.find((x) => typeof x === 'string' && x.length > 0);
+      if (typeof v === 'string') return v;
+    }
+  }
+  // Last-ditch: first string value found in any language slot.
+  for (const arr of Object.values(map)) {
+    if (Array.isArray(arr)) {
+      const v = arr.find((x) => typeof x === 'string' && x.length > 0);
+      if (typeof v === 'string') return v;
+    }
+  }
+  return '';
+}
+
+// Europeana flat array helpers — many fields are returned as arrays even when
+// they carry exactly one value.
+function firstString(v: unknown): string {
+  if (Array.isArray(v)) {
+    const f = v.find((x) => typeof x === 'string');
+    return typeof f === 'string' ? f : '';
+  }
+  return typeof v === 'string' ? v : '';
+}
+
+function parseRecord(raw: Record<string, unknown>): {
+  id: string;
+  title: string;
+  artist: string;
+  displayDate: string;
+  dataProvider: string;
+  country: string;
+  edmIsShownAt: string;
+  edmIsShownBy: string;
+  edmPreview: string;
+  rights: unknown;
+  description: string;
+} {
+  const id = normalizeEuropeanaId(asString(raw.id));
+  const title =
+    pickLangAware(raw.dcTitleLangAware) ||
+    firstString(raw.title) ||
+    firstString(raw.dcTitle);
+  const artist =
+    pickLangAware(raw.dcCreatorLangAware) ||
+    firstString(raw.dcCreator);
+  const displayDate =
+    firstString(raw.year) ||
+    firstString(raw.edmTimespanLabel) ||
+    firstString(raw.dcDate);
+  const dataProvider = firstString(raw.dataProvider);
+  const country = firstString(raw.country);
+  const edmIsShownAt = firstString(raw.edmIsShownAt);
+  const edmIsShownBy = firstString(raw.edmIsShownBy);
+  const edmPreview = firstString(raw.edmPreview);
+  const description =
+    pickLangAware(raw.dcDescriptionLangAware) ||
+    firstString(raw.dcDescription);
+  return {
+    id,
+    title,
+    artist,
+    displayDate,
+    dataProvider,
+    country,
+    edmIsShownAt,
+    edmIsShownBy,
+    edmPreview,
+    rights: raw.rights,
+    description,
+  };
+}
+
+export const europeanaFetcher: Fetcher = {
+  code: 'europeana',
+  name: 'Europeana',
+
+  async search(query: string, limit: number, options: SearchOptions = {}): Promise<string[]> {
+    const key = apiKey();
+    if (!key) throw new Error('Europeana: EUROPEANA_API_KEY not set');
+    const url = new URL(`${EUROPEANA_API}/search.json`);
+    url.searchParams.set('wskey', key);
+    url.searchParams.set('query', query);
+    // `reusability=open` is Europeana's umbrella for CC0 / PDM / CC-BY /
+    // CC-BY-SA. Our gate then drops the obligation-bearing licenses, so
+    // the remaining set is strictly CC0 + PDM.
+    url.searchParams.set('reusability', 'open');
+    if (options.hasImage !== false) {
+      // `qf=TYPE:IMAGE` keeps text/sound/video out of the candidate list.
+      url.searchParams.append('qf', 'TYPE:IMAGE');
+    }
+    url.searchParams.set('rows', String(limit));
+    url.searchParams.set('profile', 'minimal');
+
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`Europeana search failed: ${res.status}`);
+    const json = (await res.json()) as { items?: Array<{ id?: unknown }> };
+    const items = json.items ?? [];
+    return items
+      .map((it) => (typeof it.id === 'string' ? `europeana:${normalizeEuropeanaId(it.id)}` : null))
+      .filter((s): s is string => s !== null)
+      .slice(0, limit);
+  },
+
+  async getRaw(id: string): Promise<unknown> {
+    const key = apiKey();
+    if (!key) throw new Error('Europeana: EUROPEANA_API_KEY not set');
+    const path = id.replace(/^europeana:/, '');
+    // Use the search-by-id form rather than the per-record endpoint so the
+    // response shape matches the search hits we already know how to parse.
+    // `query=europeana_id:"/<id>"` uniquely targets one record.
+    const url = new URL(`${EUROPEANA_API}/search.json`);
+    url.searchParams.set('wskey', key);
+    url.searchParams.set('query', `europeana_id:"/${path}"`);
+    url.searchParams.set('rows', '1');
+    url.searchParams.set('profile', 'minimal');
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`Europeana get failed for ${id}: ${res.status}`);
+    return res.json();
+  },
+
+  normalize(raw: unknown): ValidationResult {
+    if (!raw || typeof raw !== 'object') {
+      return reject('europeana:unknown', 'europeana: response not an object', raw);
+    }
+    const wrap = raw as Record<string, unknown>;
+    // The search response wraps the record in `items: [...]`. The fixture
+    // shape and a direct record are both tolerated.
+    const items = Array.isArray(wrap.items) ? wrap.items : null;
+    const record =
+      items && items.length > 0 && typeof items[0] === 'object' && items[0]
+        ? (items[0] as Record<string, unknown>)
+        : (wrap as Record<string, unknown>);
+
+    const parsed = parseRecord(record);
+    const id = parsed.id ? `europeana:${parsed.id}` : 'europeana:unknown';
+
+    const decision = validateEuropeanaLicense(record);
+    if (!decision.accepted || !decision.license) {
+      return reject(id, decision.reason, raw);
+    }
+    if (!parsed.id) {
+      return reject(id, 'europeana: missing or non-string id', raw);
+    }
+
+    const dateRange = parseDisplayDate(parsed.displayDate);
+    const attributionType = detectAttributionType(parsed.artist);
+    const cleanName = cleanArtistName(parsed.artist);
+    const region = normalizeRegion(parsed.country);
+
+    const fullImage = parsed.edmIsShownBy || parsed.edmPreview;
+    const thumbnail = asOptionalString(parsed.edmPreview);
+
+    const artwork: Artwork = {
+      id,
+      museum: {
+        code: 'europeana',
+        name: parsed.dataProvider || 'Europeana',
+        url: 'https://www.europeana.eu',
+      },
+      title: (parsed.title || '(Untitled)').trim(),
+      artist: {
+        name: cleanName || 'Unknown',
+        nationality: undefined,
+        lifespan: undefined,
+        attributionType,
+      },
+      displayDate: parsed.displayDate,
+      yearStart: dateRange.yearStart,
+      yearEnd: dateRange.yearEnd,
+      medium: '',
+      region,
+      period: null,
+      imageUrls: {
+        full: fullImage,
+        thumbnail,
+      },
+      imageOpenAccess: decision.imageOpenAccess,
+      metadataOpenAccess: decision.metadataOpenAccess,
+      license: decision.license,
+      source: {
+        // The page URL is the canonical viewer; the API URL points back to
+        // the search-by-id form so a re-fetch reproduces this record.
+        apiUrl: `${EUROPEANA_API}/search.json?query=europeana_id:%22/${parsed.id}%22`,
+        pageUrl: `${EUROPEANA_PAGE}/${parsed.id}`,
+        originalUrl: parsed.edmIsShownAt || undefined,
+      },
+      description: asOptionalString(parsed.description),
+    };
+
+    return { status: 'accepted', artwork };
+  },
+};

--- a/src/licenseGate.ts
+++ b/src/licenseGate.ts
@@ -207,19 +207,40 @@ export const validateEuropeanaLicense: LicenseValidator = (raw) => {
     return reject('europeana: object missing or not an object');
   }
   const obj = raw as Record<string, unknown>;
-  // Europeana returns `rights` as an array of URI strings on each item.
-  const rightsArr = Array.isArray(obj.rights) ? obj.rights : [];
-  const first = rightsArr.find((v) => typeof v === 'string') as string | undefined;
-  if (!first) {
+  // Europeana's `rights` is conventionally a one-element array of URI strings,
+  // but EDM consumers occasionally serialize a single value as a bare string.
+  // Coerce both shapes into a uniform array before checking.
+  const rightsRaw = obj.rights;
+  const rightsArr = Array.isArray(rightsRaw)
+    ? rightsRaw
+    : typeof rightsRaw === 'string'
+      ? [rightsRaw]
+      : [];
+  const rightsStrs = rightsArr.filter((v): v is string => typeof v === 'string');
+  if (rightsStrs.length === 0) {
     return reject('europeana: rights field missing or non-string (strict default reject)');
   }
-  const normalized = stripUriProtocol(first);
-  if (normalized === EUROPEANA_CC0_URI) {
+  // Strict-default-deny: every URI on the record must be in the accept set.
+  // A "first match wins" check would leak hybrid records that carry one
+  // permissive URI plus one restrictive URI — exactly the failure mode
+  // strict-default-deny exists to prevent.
+  const normalizedAll = rightsStrs.map(stripUriProtocol);
+  const allAccepted = normalizedAll.every(
+    (u) => u === EUROPEANA_CC0_URI || u === EUROPEANA_PDM_URI,
+  );
+  if (!allAccepted) {
+    return reject(`europeana: rights=${rightsStrs[0]} (strict default reject)`);
+  }
+  // Both CC0 and PDM are in the accept set; classify by the first URI for
+  // the license tier. A record dual-marked CC0+PDM is genuinely public
+  // domain and gets the CC0 tier (the more specific dedication).
+  const isCc0 = normalizedAll[0] === EUROPEANA_CC0_URI;
+  if (isCc0) {
     return {
       accepted: true,
       license: {
         type: 'CC0',
-        rawValue: first,
+        rawValue: rightsStrs[0],
         verificationSource: 'europeana.rights',
         verifiedAt: nowIso(),
         confidence: 'high',
@@ -229,22 +250,19 @@ export const validateEuropeanaLicense: LicenseValidator = (raw) => {
       reason: 'europeana: rights=CC0',
     };
   }
-  if (normalized === EUROPEANA_PDM_URI) {
-    return {
-      accepted: true,
-      license: {
-        type: 'PD',
-        rawValue: first,
-        verificationSource: 'europeana.rights',
-        verifiedAt: nowIso(),
-        confidence: 'high',
-      },
-      imageOpenAccess: true,
-      metadataOpenAccess: true,
-      reason: 'europeana: rights=PDM',
-    };
-  }
-  return reject(`europeana: rights=${first} (strict default reject)`);
+  return {
+    accepted: true,
+    license: {
+      type: 'PD',
+      rawValue: rightsStrs[0],
+      verificationSource: 'europeana.rights',
+      verifiedAt: nowIso(),
+      confidence: 'high',
+    },
+    imageOpenAccess: true,
+    metadataOpenAccess: true,
+    reason: 'europeana: rights=PDM',
+  };
 };
 
 const VALIDATORS: Record<string, LicenseValidator> = {

--- a/src/licenseGate.ts
+++ b/src/licenseGate.ts
@@ -183,11 +183,76 @@ export const validateWikimediaLicense: LicenseValidator = (raw) => {
   return reject(`wikimedia: License=${license || 'missing'} (strict default reject)`);
 };
 
+// Europeana is a federation aggregating tens of millions of records from
+// European institutions. Rights are per-record, expressed as a URI from a
+// fixed vocabulary (Europeana Rights Statements). Live spike confirmed:
+//   - 7.9M records under CC0 globally
+//   - Switzerland: 11K CC0 / 81K CC-BY-SA / 25K InC / etc.
+// We accept ONLY the unambiguous public-domain URIs:
+//   - http://creativecommons.org/publicdomain/zero/1.0/   (CC0)
+//   - http://creativecommons.org/publicdomain/mark/1.0/   (Public Domain Mark)
+// Everything else (CC-BY, CC-BY-SA, CC-BY-NC, NoC-*, InC) is rejected on the
+// same strict-default-deny grounds as the Wikimedia gate. The two protocols
+// (http / https) are treated equivalently — the URI is a vocabulary key,
+// not a fetchable resource.
+const EUROPEANA_CC0_URI = 'creativecommons.org/publicdomain/zero/1.0/';
+const EUROPEANA_PDM_URI = 'creativecommons.org/publicdomain/mark/1.0/';
+
+function stripUriProtocol(s: string): string {
+  return s.replace(/^https?:\/\//, '').toLowerCase();
+}
+
+export const validateEuropeanaLicense: LicenseValidator = (raw) => {
+  if (!raw || typeof raw !== 'object') {
+    return reject('europeana: object missing or not an object');
+  }
+  const obj = raw as Record<string, unknown>;
+  // Europeana returns `rights` as an array of URI strings on each item.
+  const rightsArr = Array.isArray(obj.rights) ? obj.rights : [];
+  const first = rightsArr.find((v) => typeof v === 'string') as string | undefined;
+  if (!first) {
+    return reject('europeana: rights field missing or non-string (strict default reject)');
+  }
+  const normalized = stripUriProtocol(first);
+  if (normalized === EUROPEANA_CC0_URI) {
+    return {
+      accepted: true,
+      license: {
+        type: 'CC0',
+        rawValue: first,
+        verificationSource: 'europeana.rights',
+        verifiedAt: nowIso(),
+        confidence: 'high',
+      },
+      imageOpenAccess: true,
+      metadataOpenAccess: true,
+      reason: 'europeana: rights=CC0',
+    };
+  }
+  if (normalized === EUROPEANA_PDM_URI) {
+    return {
+      accepted: true,
+      license: {
+        type: 'PD',
+        rawValue: first,
+        verificationSource: 'europeana.rights',
+        verifiedAt: nowIso(),
+        confidence: 'high',
+      },
+      imageOpenAccess: true,
+      metadataOpenAccess: true,
+      reason: 'europeana: rights=PDM',
+    };
+  }
+  return reject(`europeana: rights=${first} (strict default reject)`);
+};
+
 const VALIDATORS: Record<string, LicenseValidator> = {
   met: validateMetLicense,
   cleveland: validateClevelandLicense,
   aic: validateAicLicense,
   wikimedia: validateWikimediaLicense,
+  europeana: validateEuropeanaLicense,
 };
 
 export function validateLicense(museumCode: string, raw: unknown): LicenseDecision {

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import {
   ListToolsRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
+import dotenv from 'dotenv';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { z } from 'zod';
@@ -15,11 +16,18 @@ import { Cache } from './db.js';
 import { dedupeWikimediaUploads } from './dedupe.js';
 import { aicFetcher } from './fetchers/aic.js';
 import { clevelandFetcher } from './fetchers/cleveland.js';
+import { europeanaFetcher } from './fetchers/europeana.js';
 import { metFetcher } from './fetchers/met.js';
 import { wikimediaFetcher } from './fetchers/wikimedia.js';
 import type { Fetcher } from './fetchers/types.js';
 import type { Artwork } from './types.js';
 import { filterByYearRange } from './yearFilter.js';
+
+// Load env vars before reading any keys. Cwd `.env` (developer flow) wins
+// over `~/.open-museum-mcp/.env` (production / MCP-client-launched flow);
+// dotenv ignores files that don't exist, so missing-file is not an error.
+dotenv.config();
+dotenv.config({ path: join(homedir(), '.open-museum-mcp', '.env') });
 
 const FETCHERS: Record<string, Fetcher> = {
   [metFetcher.code]: metFetcher,
@@ -28,13 +36,27 @@ const FETCHERS: Record<string, Fetcher> = {
   [wikimediaFetcher.code]: wikimediaFetcher,
 };
 
+// Europeana requires a per-user API key (free tier, 10K req/day). Only
+// register the fetcher when the key is present — otherwise leave it out
+// of the federation rather than crashing on every search call.
+if (process.env.EUROPEANA_API_KEY) {
+  FETCHERS[europeanaFetcher.code] = europeanaFetcher;
+} else {
+  console.error(
+    '[open-museum-mcp] EUROPEANA_API_KEY not set; Europeana fetcher disabled. Set it in ~/.open-museum-mcp/.env or your shell to enable.',
+  );
+}
+
 const CACHE_PATH = process.env.OMM_CACHE_PATH ?? join(homedir(), '.open-museum-mcp', 'cache.db');
 const cache = new Cache({ path: CACHE_PATH });
 
-// Museum IDs are positive integers (no leading zeros). Tightening the regex
-// here makes `met:000123` and `met:0` user errors rather than valid IDs that
-// produce duplicate cache rows.
-const ID_REGEX = /^[a-z]+:[1-9]\d*$/;
+// Museum IDs follow `<code>:<segment>(/<segment>)*`. Each segment is
+// alphanumeric, underscore, or hyphen. The four numeric-ID museums (Met,
+// Cleveland, AIC, Wikimedia) match a single all-digit segment; Europeana's
+// hierarchical IDs (`9200338/BibliographicResource_3000093834108`) match
+// multiple slash-separated segments. The negative lookahead blocks `..`
+// path-traversal attempts cleanly.
+const ID_REGEX = /^[a-z]+:(?!.*\.\.)[A-Za-z0-9_-]+(?:\/[A-Za-z0-9_-]+)*$/;
 
 // Cap concurrent fetches to one museum's API. The Met has no batch endpoint,
 // so a search of limit 50 fans out into up to 50 object fetches; without a
@@ -140,7 +162,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           museum: {
             type: 'string',
             description:
-              'Optional museum code. Currently registered: met, cleveland, aic, wikimedia (Commons).',
+              'Optional museum code. Currently registered: met, cleveland, aic, wikimedia (Commons), europeana (federated European institutions; requires EUROPEANA_API_KEY env var).',
           },
           has_image: {
             type: 'boolean',

--- a/tests/europeana.test.ts
+++ b/tests/europeana.test.ts
@@ -1,0 +1,128 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { europeanaFetcher } from '../src/fetchers/europeana.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function fixture(name: string): unknown {
+  return JSON.parse(readFileSync(join(here, 'fixtures', name), 'utf-8'));
+}
+
+describe('Europeana adapter normalization', () => {
+  it('accepts a CC0 record (Rijksmuseum Night Watch fixture)', () => {
+    const result = europeanaFetcher.normalize(fixture('europeana-accepted-cc0.json'));
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    const a = result.artwork;
+    expect(a.id).toBe('europeana:90402/SK_C_5');
+    expect(a.museum.code).toBe('europeana');
+    expect(a.museum.name).toBe('Rijksmuseum');
+    expect(a.title).toBe('The Night Watch');
+    expect(a.artist.name).toBe('Rembrandt van Rijn');
+    expect(a.artist.attributionType).toBe('named');
+    expect(a.license.type).toBe('CC0');
+    expect(a.license.rawValue).toBe('http://creativecommons.org/publicdomain/zero/1.0/');
+    expect(a.license.verificationSource).toBe('europeana.rights');
+    expect(a.imageOpenAccess).toBe(true);
+    expect(a.metadataOpenAccess).toBe(true);
+    expect(a.imageUrls.full).toContain('Night_Watch.jpg');
+    expect(a.imageUrls.thumbnail).toContain('thumbnail');
+    expect(a.source.pageUrl).toBe('https://www.europeana.eu/en/item/90402/SK_C_5');
+    expect(a.source.originalUrl).toBe('https://www.rijksmuseum.nl/nl/collectie/SK-C-5');
+    expect(a.yearStart).toBe(1642);
+    expect(a.yearEnd).toBe(1642);
+    expect(a.region).toBe('netherlands');
+    expect(a.description).toContain('militia company');
+  });
+
+  it('accepts a Public Domain Mark record (https URI variant)', () => {
+    // Tests two things: (1) PDM as a separate license tier, (2) the
+    // URI normaliser strips both http:// and https:// equivalently.
+    const result = europeanaFetcher.normalize(fixture('europeana-accepted-pdm.json'));
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.license.type).toBe('PD');
+    expect(result.artwork.license.rawValue).toContain('publicdomain/mark');
+    expect(result.artwork.id).toBe('europeana:2058616/object_KMSKB_2729');
+    expect(result.artwork.title).toBe('Landscape with the Fall of Icarus');
+  });
+
+  it('rejects CC-BY-SA (share-alike obligation; mirrors Wikimedia gate)', () => {
+    const result = europeanaFetcher.normalize(fixture('europeana-rejected-cc-by-sa.json'));
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.reason).toContain('strict default reject');
+    expect(result.rejection.reason).toContain('by-sa');
+    expect(result.rejection.id).toBe('europeana:123/aargauer_hodler_1');
+  });
+
+  it('rejects In-Copyright records (Swiss-museum reality check)', () => {
+    // Live spike found that flagship Swiss artists at flagship Swiss museums
+    // (e.g. Hodler at Aargauer Kunsthaus) carry InC rights, not CC0. Lock
+    // down that this case rejects cleanly.
+    const result = europeanaFetcher.normalize(fixture('europeana-rejected-in-copyright.json'));
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.reason).toContain('strict default reject');
+    expect(result.rejection.reason).toContain('rightsstatements.org/vocab/InC');
+  });
+
+  it('rejects records with no rights field at all', () => {
+    const result = europeanaFetcher.normalize(fixture('europeana-rejected-missing-rights.json'));
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.reason).toContain('rights field missing');
+  });
+
+  it('rejects garbage input', () => {
+    expect(europeanaFetcher.normalize(null).status).toBe('rejected');
+    expect(europeanaFetcher.normalize('not an object').status).toBe('rejected');
+    expect(europeanaFetcher.normalize(42).status).toBe('rejected');
+  });
+
+  it('rejects when items array is empty (no record found)', () => {
+    const result = europeanaFetcher.normalize({ items: [], totalResults: 0 });
+    // No record → falls through to validateEuropeanaLicense on the wrapper,
+    // which has no `rights` array, so the rejection reason is the missing-
+    // rights one. That's the right behavior (empty result = nothing to accept).
+    expect(result.status).toBe('rejected');
+  });
+
+  it('accepts a record passed as a direct item object (not wrapped in items[])', () => {
+    // For fixture authoring convenience and to tolerate alternate response
+    // shapes, an unwrapped item should normalise the same way.
+    const wrapped = fixture('europeana-accepted-cc0.json') as { items: unknown[] };
+    const result = europeanaFetcher.normalize(wrapped.items[0]);
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.id).toBe('europeana:90402/SK_C_5');
+  });
+
+  it('strips leading slash from Europeana IDs in the suffix', () => {
+    // Europeana returns IDs as `/9200338/Bibliographic...` with a leading
+    // slash. Our `museum:id` convention has no leading slash on the suffix.
+    const result = europeanaFetcher.normalize(fixture('europeana-accepted-cc0.json'));
+    if (result.status !== 'accepted') throw new Error('expected accepted');
+    expect(result.artwork.id).not.toMatch(/europeana:\//);
+    expect(result.artwork.id).toBe('europeana:90402/SK_C_5');
+  });
+
+  it('falls back across language preferences for title and creator', () => {
+    // Title has en + nl. Creator has only en. Both should resolve to en.
+    const result = europeanaFetcher.normalize(fixture('europeana-accepted-cc0.json'));
+    if (result.status !== 'accepted') throw new Error('expected accepted');
+    expect(result.artwork.title).toBe('The Night Watch'); // en preferred over nl
+    expect(result.artwork.artist.name).toBe('Rembrandt van Rijn');
+  });
+
+  it('parses year from `year` field when displayDate is sparse', () => {
+    // Europeana's `year` array carries the parsed year(s). Our date parser
+    // handles "1642" trivially; verify the wiring.
+    const result = europeanaFetcher.normalize(fixture('europeana-accepted-cc0.json'));
+    if (result.status !== 'accepted') throw new Error('expected accepted');
+    expect(result.artwork.yearStart).toBe(1642);
+    expect(result.artwork.yearEnd).toBe(1642);
+  });
+});

--- a/tests/europeana.test.ts
+++ b/tests/europeana.test.ts
@@ -125,4 +125,88 @@ describe('Europeana adapter normalization', () => {
     expect(result.artwork.yearStart).toBe(1642);
     expect(result.artwork.yearEnd).toBe(1642);
   });
+
+  it('rejects multi-URI rights when ANY entry is restrictive (strict-default-deny)', () => {
+    // Hardened rights gate: a hybrid record carrying CC0 plus an InC URI
+    // would have been silently accepted under a "first match wins" check.
+    // Strict-default-deny requires every URI to be in the accept set.
+    const mixedRights = {
+      items: [
+        {
+          id: '/1/mixed_rights_record',
+          rights: [
+            'http://creativecommons.org/publicdomain/zero/1.0/',
+            'http://rightsstatements.org/vocab/InC/1.0/',
+          ],
+          dcTitleLangAware: { en: ['Hybrid record'] },
+        },
+      ],
+    };
+    const result = europeanaFetcher.normalize(mixedRights);
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.reason).toContain('strict default reject');
+  });
+
+  it('accepts multi-URI rights when ALL entries are in the accept set', () => {
+    // Records that are dual-marked CC0 + PDM are genuinely public domain.
+    // The first URI determines the license tier (CC0 takes precedence).
+    const dualMarked = {
+      items: [
+        {
+          id: '/2/dual_marked_record',
+          rights: [
+            'http://creativecommons.org/publicdomain/zero/1.0/',
+            'http://creativecommons.org/publicdomain/mark/1.0/',
+          ],
+          dcTitleLangAware: { en: ['Dual-marked record'] },
+        },
+      ],
+    };
+    const result = europeanaFetcher.normalize(dualMarked);
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.license.type).toBe('CC0');
+  });
+
+  it('accepts a bare-string rights shape (some EDM serializers omit the array wrapper)', () => {
+    // Defensive: if Europeana ever returns rights as a plain string rather
+    // than a one-element array, the gate must still validate it. Otherwise
+    // we silently false-negative every record from that endpoint.
+    const bareStringRights = {
+      items: [
+        {
+          id: '/3/bare_string_rights',
+          rights: 'http://creativecommons.org/publicdomain/zero/1.0/',
+          dcTitleLangAware: { en: ['Bare-string-rights record'] },
+        },
+      ],
+    };
+    const result = europeanaFetcher.normalize(bareStringRights);
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.license.type).toBe('CC0');
+  });
+
+  it('coerces numeric year values to strings for the date parser', () => {
+    // Europeana sometimes returns `year: [1642]` (number) instead of
+    // `year: ["1642"]` (string). The fetcher must treat both shapes the
+    // same way; otherwise dates silently disappear from records that
+    // serialize numeric years.
+    const numericYear = {
+      items: [
+        {
+          id: '/4/numeric_year_record',
+          year: [1642],
+          rights: ['http://creativecommons.org/publicdomain/zero/1.0/'],
+          dcTitleLangAware: { en: ['Numeric-year record'] },
+        },
+      ],
+    };
+    const result = europeanaFetcher.normalize(numericYear);
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.yearStart).toBe(1642);
+    expect(result.artwork.yearEnd).toBe(1642);
+  });
 });

--- a/tests/fixtures/europeana-accepted-cc0.json
+++ b/tests/fixtures/europeana-accepted-cc0.json
@@ -1,0 +1,30 @@
+{
+  "apikey": "FAKEKEY",
+  "success": true,
+  "requestNumber": 1,
+  "itemsCount": 1,
+  "totalResults": 1,
+  "items": [
+    {
+      "id": "/90402/SK_C_5",
+      "completeness": 10,
+      "country": ["Netherlands"],
+      "dataProvider": ["Rijksmuseum"],
+      "year": ["1642"],
+      "edmIsShownAt": ["https://www.rijksmuseum.nl/nl/collectie/SK-C-5"],
+      "edmIsShownBy": ["https://upload.wikimedia.org/example/Night_Watch.jpg"],
+      "edmPreview": ["https://api.europeana.eu/thumbnail/example.jpg"],
+      "rights": ["http://creativecommons.org/publicdomain/zero/1.0/"],
+      "dcTitleLangAware": {
+        "en": ["The Night Watch"],
+        "nl": ["De Nachtwacht"]
+      },
+      "dcCreatorLangAware": {
+        "en": ["Rembrandt van Rijn"]
+      },
+      "dcDescriptionLangAware": {
+        "en": ["Group portrait of the militia company of district II under the command of Captain Frans Banninck Cocq."]
+      }
+    }
+  ]
+}

--- a/tests/fixtures/europeana-accepted-pdm.json
+++ b/tests/fixtures/europeana-accepted-pdm.json
@@ -1,0 +1,25 @@
+{
+  "apikey": "FAKEKEY",
+  "success": true,
+  "itemsCount": 1,
+  "totalResults": 1,
+  "items": [
+    {
+      "id": "/2058616/object_KMSKB_2729",
+      "completeness": 9,
+      "country": ["Belgium"],
+      "dataProvider": ["Royal Museums of Fine Arts of Belgium"],
+      "year": ["c. 1560"],
+      "edmIsShownAt": ["https://example.org/object/2729"],
+      "edmIsShownBy": ["https://example.org/img/2729.jpg"],
+      "edmPreview": ["https://api.europeana.eu/thumb/2729.jpg"],
+      "rights": ["https://creativecommons.org/publicdomain/mark/1.0/"],
+      "dcTitleLangAware": {
+        "en": ["Landscape with the Fall of Icarus"]
+      },
+      "dcCreatorLangAware": {
+        "en": ["Pieter Bruegel the Elder"]
+      }
+    }
+  ]
+}

--- a/tests/fixtures/europeana-rejected-cc-by-sa.json
+++ b/tests/fixtures/europeana-rejected-cc-by-sa.json
@@ -1,0 +1,23 @@
+{
+  "apikey": "FAKEKEY",
+  "success": true,
+  "itemsCount": 1,
+  "totalResults": 1,
+  "items": [
+    {
+      "id": "/123/aargauer_hodler_1",
+      "country": ["Switzerland"],
+      "dataProvider": ["Aargauer Kunsthaus"],
+      "year": ["1908"],
+      "edmIsShownAt": ["https://aargauerkunsthaus.ch/example/hodler"],
+      "edmPreview": ["https://api.europeana.eu/thumb/hodler.jpg"],
+      "rights": ["http://creativecommons.org/licenses/by-sa/4.0/"],
+      "dcTitleLangAware": {
+        "de": ["Der Tag"]
+      },
+      "dcCreatorLangAware": {
+        "de": ["Ferdinand Hodler"]
+      }
+    }
+  ]
+}

--- a/tests/fixtures/europeana-rejected-in-copyright.json
+++ b/tests/fixtures/europeana-rejected-in-copyright.json
@@ -1,0 +1,15 @@
+{
+  "apikey": "FAKEKEY",
+  "success": true,
+  "itemsCount": 1,
+  "totalResults": 1,
+  "items": [
+    {
+      "id": "/456/inc_record",
+      "country": ["Switzerland"],
+      "dataProvider": ["Some Museum"],
+      "rights": ["http://rightsstatements.org/vocab/InC/1.0/"],
+      "dcTitleLangAware": { "en": ["Some Work"] }
+    }
+  ]
+}

--- a/tests/fixtures/europeana-rejected-missing-rights.json
+++ b/tests/fixtures/europeana-rejected-missing-rights.json
@@ -1,0 +1,14 @@
+{
+  "apikey": "FAKEKEY",
+  "success": true,
+  "itemsCount": 1,
+  "totalResults": 1,
+  "items": [
+    {
+      "id": "/789/missing_rights",
+      "country": ["Germany"],
+      "dataProvider": ["Some Provider"],
+      "dcTitleLangAware": { "en": ["Untitled Record"] }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds Europeana as the fifth registered museum source. Federation through Europeana brings ~7.9M global CC0 records and unlocks Rijksmuseum content via aggregation even before a direct Rijksmuseum integration ships.

## Architecture

- **`src/fetchers/europeana.ts`** — Fetcher using the v2 search API with `reusability=open` server-side filter, then per-record strict-default-deny at the rights gate.
- **`validateEuropeanaLicense` in `src/licenseGate.ts`** — accepts ONLY the unambiguous public-domain URIs: `creativecommons.org/publicdomain/zero/1.0/` (CC0) and `creativecommons.org/publicdomain/mark/1.0/` (PDM). Mirrors the Wikimedia gate's strictness — CC-BY, CC-BY-SA, CC-BY-NC, NoC-*, InC all rejected. Treats `http://` and `https://` as equivalent (the URI is a vocabulary key, not a fetchable resource).
- **`EUROPEANA_API_KEY`** env var. Fetcher silently disables itself when key is missing; rest of federation keeps working. `dotenv` added as a dep. Loads from `./.env` (dev) and `~/.open-museum-mcp/.env` (prod / MCP-client-launched).
- **ID regex relaxed** — Europeana IDs are hierarchical (`9200338/BibliographicResource_3000093834108`), not bare positive integers. New regex matches `<code>:<segment>(/<segment>)*` with alphanumeric/underscore/hyphen segments and explicit `..` path-traversal rejection. Backwards-compatible: every existing ID still matches.

## Tests

11 new tests under `tests/europeana.test.ts`:

- Accepted CC0 (Rijksmuseum Night Watch fixture)
- Accepted PDM with `https://` URI variant (URI normalization test)
- Rejected CC-BY-SA (Hodler at Aargauer Kunsthaus — share-alike obligation)
- Rejected In-Copyright (Swiss-museum reality check)
- Rejected missing-rights field
- Garbage input
- Language-aware title fallback (en preferred over nl)
- ID slash-prefix stripping
- Year parsing from `year` field
- Direct-record (unwrapped) input shape

**189/189 tests pass across 12 files. Typecheck clean. Build clean.**

## Live smoke confirmed

Real queries against Europeana with the strict gate:

```
=== Rembrandt Night Watch ===
  · CC-BY-SA × 2 correctly rejected
  ✓ europeana:2024903/photography_…_KU_Leuven_… | PD | 1642 | Catholic University of Leuven

=== Bruegel Icarus ===
  · CC-BY-SA × 1 rejected
  ✓ europeana:15508/DG1955_41 | PD | River landscape with Daedalus and Icarus | The Albertina Museum
  ✓ europeana:15508/DG1955_40 | PD | (variant) | The Albertina Museum

=== Hokusai ===
  ✓ × 3 records from Rijksmuseum (PD), reached via the Europeana federation
```

## Spike findings worth knowing

- Switzerland: 136K total records, but only **11K CC0** (the rest are CC-BY-SA or In-Copyright).
- Swiss art museums (Aargauer Kunsthaus, etc.) keep flagship works **In-Copyright** on Europeana. So Europeana does **not** replace direct integrations with Kunstmuseum Basel / Zürich / Beyeler — those still need outreach (issues #14, #15, #16).
- The big content win is non-Swiss: Rijksmuseum, Albertina, KU Leuven, plus Swedish / Norwegian / Danish collections.

I'll open a tracking issue with these spike findings so we don't accidentally rebuild this question in 6 months.

## Test plan

- [x] `npm test` — 189/189 pass
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] Live smoke against Europeana with real key — accepts/rejects as designed across 3 query domains
- [x] README updated: verification table, Supported museums table, dedicated "On Europeana" note with API-key setup instructions

Co-Authored by Pramod Prasanth <pramod@chainalign.com>