### PR TITLE
chore: bump to v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.4.0] — 2026-04-27
+
+### Added
+
+- **Europeana adapter** (`europeana`). Federated access to ~30M records aggregated by Europeana from European cultural-heritage institutions, opt-in via free per-user `EUROPEANA_API_KEY`. The fetcher silently disables itself when the key is missing — the rest of the federation continues to work. Strict-default-deny rights gate accepts only CC0 and Public Domain Mark URIs; CC-BY, CC-BY-SA, CC-BY-NC, NoC-*, and InC are all rejected. URI vocabulary is checked across the entire `rights` array (multi-URI hybrid records require *every* entry in the accept set, preventing leak via "first match wins").
+- **Wikimedia Commons adapter** (`wikimedia`). Per-file federation of Commons; accepts `cc0`, `pd`, `pd-*`, `pdm`, and `pdm-*` license templates only. Ships category-based date-fallback parsing with an art-medium gate that filters out exhibition / catalogue / location categories. Surfaces image dimensions (`imageUrls.width`/`height`/`byteSize`) and parses the `Credit` extmetadata into `source.originalUrl` for upstream-museum links. Search-time deduplication collapses Wikimedia uploads sharing title and artist, keeping the largest by pixel area.
+- **Date-range filter** on `search_artworks`: `year_min` / `year_max` (signed integers; BCE = negative). Inclusive overlap; records with unparseable dates are excluded when any bound is set. Overfetch budget widens to 4× when a year bound is active to absorb post-fetch exclusions.
+- **Cite tool's `caption` style** for museum-publication conventions (formerly only `full` and `short`).
+- **CHANGELOG.md** (this file).
+
+### Changed
+
+- **Artwork schema additions** (additive, non-breaking). `ArtworkImages` gains optional `width`, `height`, `byteSize`. `ArtworkSource` gains optional `originalUrl`.
+- **ID regex relaxed** to support hierarchical IDs (Europeana's `9200338/BibliographicResource_…`). Backwards-compatible — every previously valid ID still matches. `..` path-traversal explicitly rejected.
+- **Date parser hardening**: tightened range and single-year regexes block accession/inventory-number false positives (`P.2017-0004`, `BM 1906.1220.0.533`, `4-2017` from "April 2017"), while still recovering valid years from prose containing those patterns. Year-plausibility bound (100–2200 CE) on the standard range path.
+- **Date parser performance**: dynasty-key sort and qualifier regex hoisted from per-call to module-load constants.
+- **Fetcher helpers consolidated**: `rejectFor` and `isValidPositiveInt` shared in `fetchers/helpers.ts`, replacing duplicate factories across Met, Cleveland, AIC, and Wikimedia.
+
+### Fixed
+
+- Met adapter no longer re-validates rights against an upstream filter that can be inconsistent with the per-object boolean.
+- Cite formatter handles anonymous works (`Unknown artist` in `caption`, empty artist segment in `full`).
+- Wikimedia title cleanup strips Wikidata Quick Statements metadata (`title QS:…`), multilingual language prefixes (`German: …`), and zero-padded file-numbering suffixes (` 02`, ` 099`).
+
+### Dependencies
+
+- Added: `dotenv` ^16 for `.env` loading (cwd `.env` and `~/.open-museum-mcp/.env`).
+
+## [0.2.0] — Previous release
+
+- Met, Cleveland, and AIC adapters with strict-default-deny rights gates.
+- Dynasty-aware date parsing covering Tang, Edo, Safavid, Mughal, and others.
+- `search_artworks`, `get_artwork`, `cite`, `discover_random`, and `list_traditions` tools.
+- `museum://{code}/{id}` MCP resources.
+
+[0.4.0]: https://github.com/cfpramod/open-museum-mcp/releases/tag/v0.4.0
+[0.2.0]: https://github.com/cfpramod/open-museum-mcp/releases/tag/v0.2.0

--- a/README.md
+++ b/README.md
@@ -216,11 +216,12 @@ Highlights:
 
 - v0.1: Met adapter, dynasty-aware date parser, license gate, `cite` tool, MCP resources.
 - v0.2: Cleveland and AIC adapters, `discover_random` with constraints, `list_traditions`.
-- v0.3: Wikimedia Commons adapter (per-record rights model; unlocks works whose home museums lack public APIs). **(here)**
+- v0.3: Wikimedia Commons adapter (per-record rights model; unlocks works whose home museums lack public APIs).
+- v0.4: Europeana adapter (federated European institutions, opt-in via API key); `year_min`/`year_max` date-range filter on `search_artworks`. **(here)**
 - v0.7: Wikidata enrichment (artist QIDs, movement, country, dedup across cache).
 - v0.8: Dominant-colour extraction across museums (`color: "#3a5f7d"` discovery via `sharp`).
 - v1.0: Artist-obscurity scoring (`object_count_total`, `museum_count`) for deliberate exploration of less-canonical work.
-- v2.0: Smithsonian, Rijksmuseum, Walters Art Museum, more European institutions.
+- v2.0: Smithsonian, Rijksmuseum direct integration, Walters Art Museum, more European institutions.
 
 ## Contributing a museum adapter
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-museum-mcp",
-  "version": "0.2.0",
-  "description": "MCP server for license-verified search across open-access museum collections (The Met, Cleveland, AIC and more).",
+  "version": "0.4.0",
+  "description": "MCP server for license-verified search across open-access museum collections (The Met, Cleveland, AIC, Wikimedia Commons, Europeana).",
   "type": "module",
   "main": "dist/server.js",
   "bin": {
@@ -34,9 +34,12 @@
     "museum",
     "open-access",
     "art",
+    "art-history",
     "metropolitan-museum",
     "cleveland-museum",
-    "art-institute-chicago"
+    "art-institute-chicago",
+    "wikimedia-commons",
+    "europeana"
   ],
   "author": "Pramod Prasanth",
   "license": "MIT",

--- a/src/server.ts
+++ b/src/server.ts
@@ -140,7 +140,7 @@ async function fetchAndCache(id: string): Promise<{ ok: true; artwork: Artwork }
 }
 
 const server = new Server(
-  { name: 'open-museum-mcp', version: '0.1.0' },
+  { name: 'open-museum-mcp', version: '0.4.0' },
   {
     capabilities: {
       tools: {},


### PR DESCRIPTION
## Summary

Releases the v0.3 (Wikimedia Commons) and v0.4 (Europeana adapter, date-range filter) work to npm. v0.3 was never published as a separate npm release; both ride into 0.4.0 together so the registry reflects what main actually contains.

## Changes

- `package.json`: 0.2.0 → 0.4.0; description and keywords expanded to mention the two new sources.
- `src/server.ts`: MCP server version literal aligned to 0.4.0.
- `README.md`: roadmap entry promoted to v0.4 with date-range-filter call-out; the **(here)** marker moves with it.
- `CHANGELOG.md` added (Keep a Changelog format), covering v0.4.0 in detail and v0.2.0 retrospectively.

## Test plan

- [x] `npm test` — 193/193 pass
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean (now stamps `open-museum-mcp@0.4.0`)

## Post-merge

After this merges, the manual steps to ship are:

1. `git tag v0.4.0 && git push origin v0.4.0`
2. `npm publish` (verify `npm whoami` first; pre-publish runs `prepare` → `build`)
3. `gh release create v0.4.0 --notes-from-tag` (or paste the CHANGELOG body)
4. Submit to `awesome-mcp-servers` and any registries we want for discovery

I won't run the publish step autonomously — that's the irreversible-public action that should be your call.

Co-Authored by Pramod Prasanth <pramod@chainalign.com>