### PR TITLE
fix(tools): close cold-start UX trap on discover_random and list_traditions

### DIFF
--- a/src/discoverSeed.ts
+++ b/src/discoverSeed.ts
@@ -1,0 +1,24 @@
+/**
+ * Cold-start helper for `discover_random`. When the cache has no records
+ * matching the user's constraints, the handler auto-seeds via
+ * `search_artworks` first — but only when the constraints carry enough
+ * signal to build a meaningful query. A bare `discover_random({})` call
+ * with no constraints would auto-seed against something generic ("art"),
+ * which is wasteful and surprising; in that case the handler returns a
+ * hint instead.
+ *
+ * Period is preferred over region when both are present (period queries
+ * tend to be more discriminating: "edo" returns ~all Edo material;
+ * "japan" returns more than just Edo). When both are present we include
+ * both — Met / Cleveland / AIC search engines handle multi-token queries
+ * sensibly enough that the conjunction is useful.
+ */
+export function buildSeedQueryFromConstraints(input: {
+  region?: string;
+  period?: string;
+}): string | null {
+  const parts: string[] = [];
+  if (input.period) parts.push(input.period);
+  if (input.region) parts.push(input.region);
+  return parts.length > 0 ? parts.join(' ') : null;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,7 @@ import { z } from 'zod';
 import { cite, type CiteStyle } from './cite.js';
 import { Cache } from './db.js';
 import { dedupeWikimediaUploads } from './dedupe.js';
+import { buildSeedQueryFromConstraints } from './discoverSeed.js';
 import { aicFetcher } from './fetchers/aic.js';
 import { clevelandFetcher } from './fetchers/cleveland.js';
 import { europeanaFetcher } from './fetchers/europeana.js';
@@ -215,7 +216,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     {
       name: 'discover_random',
       description:
-        'Pick one random artwork from the local cache that matches the given constraints. Useful for breaking out of repetitive search territory (e.g. surface a random Edo-period work to satisfy a no-back-to-back-European-pre-1900 pairing rule). Operates over what has already been searched and cached; returns an error if nothing matches, suggesting the caller seed the cache via search_artworks first.',
+        'Pick one random artwork from the local cache that matches the given constraints. Useful for breaking out of repetitive search territory (e.g. surface a random Edo-period work to satisfy a no-back-to-back-European-pre-1900 pairing rule). On a cold cache with `region` or `period` constraints provided, auto-seeds via a small search_artworks call derived from those constraints before sampling — so first-time use works without manually warming the cache. Without constraints, returns a hint to run search_artworks first.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -242,7 +243,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     {
       name: 'list_traditions',
       description:
-        'List the regions and periods present in non-expired cached records, with per-museum record counts. Helps you see which traditions are well-represented before searching, and where holdings are sparse. Returns { regions, periods } where each entry has { tag, label, coverage: { museumCode: count } }.',
+        'List the regions and periods present in non-expired cached records, with per-museum record counts. Helps you see which traditions are well-represented before searching, and where holdings are sparse. Returns { regions, periods } where each entry has { tag, label, coverage: { museumCode: count } }. On an empty cache, returns a hint to run search_artworks first — list_traditions is a meta-tool over what you have already collected, not a search trigger.',
       inputSchema: {
         type: 'object',
         properties: {},
@@ -330,15 +331,39 @@ async function handleDiscoverRandom(args: unknown) {
   if (input.museum && !FETCHERS[input.museum]) {
     return errorResult(`unknown museum: ${input.museum}`);
   }
-  const artwork = cache.getRandomObject({
+
+  const lookup = {
     region: input.region,
     period: input.period,
     notArtist: input.not_artist,
     museumCode: input.museum,
-  });
+  };
+
+  let artwork = cache.getRandomObject(lookup);
+
+  // Cold-start path: when the cache has nothing for these constraints AND the
+  // constraints carry enough signal to build a meaningful query, auto-seed
+  // by running a small search_artworks call first. Logged to stderr so
+  // operators can see the extra fetches happening on a fresh install.
+  if (!artwork) {
+    const seedQuery = buildSeedQueryFromConstraints(input);
+    if (seedQuery) {
+      console.error(
+        `[open-museum-mcp] discover_random: cache empty for these constraints; auto-seeding via search_artworks(query="${seedQuery}", museum=${input.museum ?? 'all'})`,
+      );
+      await handleSearch({
+        query: seedQuery,
+        limit: 10,
+        has_image: true,
+        museum: input.museum,
+      });
+      artwork = cache.getRandomObject(lookup);
+    }
+  }
+
   if (!artwork) {
     return errorResult(
-      'No cached artwork matches these constraints. Seed the cache with search_artworks first; discover_random samples from records you have already pulled.',
+      'No cached artwork matches these constraints. discover_random samples from records you have already collected — try search_artworks with a topic first (e.g. search_artworks({ query: "edo painting" })), then call discover_random again.',
     );
   }
   return { content: [{ type: 'text' as const, text: JSON.stringify(artwork, null, 2) }] };
@@ -346,6 +371,12 @@ async function handleDiscoverRandom(args: unknown) {
 
 function handleListTraditions() {
   const traditions = cache.listTraditions();
+  const isEmpty = traditions.regions.length === 0 && traditions.periods.length === 0;
+  if (isEmpty) {
+    return errorResult(
+      'Cache is empty. list_traditions summarizes the regions and periods across artworks you have already collected — there is nothing to list yet. Run search_artworks for a topic first (e.g. search_artworks({ query: "renaissance painting" }) or search_artworks({ query: "edo" })), then call list_traditions to see what coverage you have.',
+    );
+  }
   return { content: [{ type: 'text' as const, text: JSON.stringify(traditions, null, 2) }] };
 }
 

--- a/tests/discoverSeed.test.ts
+++ b/tests/discoverSeed.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { buildSeedQueryFromConstraints } from '../src/discoverSeed.js';
+
+describe('buildSeedQueryFromConstraints', () => {
+  it('returns null when neither region nor period is set', () => {
+    // No-constraints discover_random should NOT auto-seed — that would be a
+    // generic "art" search, wasteful and surprising. The handler surfaces a
+    // hint instead.
+    expect(buildSeedQueryFromConstraints({})).toBeNull();
+  });
+
+  it('returns the period alone when only period is set', () => {
+    expect(buildSeedQueryFromConstraints({ period: 'edo' })).toBe('edo');
+  });
+
+  it('returns the region alone when only region is set', () => {
+    expect(buildSeedQueryFromConstraints({ region: 'japan' })).toBe('japan');
+  });
+
+  it('returns "period region" when both are set (period first; it discriminates better)', () => {
+    expect(buildSeedQueryFromConstraints({ period: 'edo', region: 'japan' })).toBe('edo japan');
+  });
+
+  it('handles multi-word period values without re-quoting', () => {
+    // "tang dynasty" is a normal period tag; the seed query is just the
+    // tokens joined — let upstream search engines handle it.
+    expect(buildSeedQueryFromConstraints({ period: 'tang dynasty' })).toBe('tang dynasty');
+  });
+
+  it('handles multi-word region values', () => {
+    expect(buildSeedQueryFromConstraints({ region: 'south asia' })).toBe('south asia');
+  });
+});


### PR DESCRIPTION
## Summary

Reviewer feedback (twice over) flagged that both `discover_random` and `list_traditions` error out on a fresh install — they only operate on the local cache, but a user who tries them first hits a curt rejection and bounces. This PR closes the trap without introducing hidden network calls on a generic seed.

## Behavior changes

### `discover_random`

| Scenario | Before | After |
|---|---|---|
| Cold cache + period/region constraints | curt error | **auto-seeds** via `search_artworks(query=period+region, limit:10)`, then retries the cache lookup |
| Cold cache + no constraints | curt error | helpful error naming a concrete next step (`search_artworks({ query: "edo painting" })`) |
| Warm cache | unchanged | unchanged (fast path) |

Auto-seed is logged to stderr so first-call seeding is visible:
```
[open-museum-mcp] discover_random: cache empty for these constraints; auto-seeding via search_artworks(query="edo japan", museum=all)
```

I considered auto-seeding for the no-constraints case too, but rejected it: a generic "art" search would be wasteful (50 records on a query with no signal about what the user wants) and surprising (a tool called "discover random" silently triggering federation-wide fetches). The hint path is more honest.

### `list_traditions`

| Scenario | Before | After |
|---|---|---|
| Cold cache | silent `{ regions: [], periods: [] }` | `errorResult` with concrete hint |
| Populated cache | unchanged | unchanged |

`list_traditions` is a *meta-tool over what you have collected*, not a search trigger. Auto-seeding here would be wrong: the answer to "what traditions are in my cache" is genuinely "none" until the user runs a search. The fix is to make the empty response actionable rather than mute.

## Implementation

- New `src/discoverSeed.ts` exports `buildSeedQueryFromConstraints` as a pure function. Period is preferred over region when both are present (period queries discriminate better — "edo" returns ~all Edo material; "japan" returns more than just Edo). When both are present we include both — search engines handle the conjunction sensibly.
- 6 new tests in `tests/discoverSeed.test.ts` covering empty input, period-only, region-only, both, and multi-word values.
- Tool descriptions updated in `ListToolsRequestSchema` so LLM clients see the new behavior at tool-discovery time.

## Test plan

- [x] `npm test` — 199/199 pass (6 new)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] Manual reasoning verified: auto-seed runs once per cold call (the second `cache.getRandomObject` either finds something or surfaces the hint); no infinite loop; constraint-mapping correctness exercised by the tests

## Why this lands cleanly with #26

#26 (README pass) updates the tool descriptions in markdown. This PR updates the tool descriptions in code (`ListToolsRequestSchema`). They're independent — different file paths — and merge in either order without conflict.

Co-Authored by Pramod Prasanth <pramod@chainalign.com>