### PR TITLE
fix: suppress dotenv stdout that bricks MCP transport (v0.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] — 2026-04-27
+
+### Fixed
+
+- **Critical: dotenv stdout output corrupts MCP stdio transport.** `dotenv@17` emits a `◇ injected env from .env` log line on `dotenv.config()` by default. MCP servers communicate over stdio JSON-RPC, so any non-protocol stdout writes break the client's parser — Claude Desktop and other MCP clients raised `Unexpected token '◇' ... is not valid JSON` and failed to load the server on launch when a `.env` file was present (notably the production path `~/.open-museum-mcp/.env`). Both `dotenv.config()` calls now pass `{ quiet: true }`. Affected all of v0.4.0; users on 0.4.0 should upgrade.
+
 ## [0.4.0] — 2026-04-27
 
 ### Added
@@ -40,5 +46,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `search_artworks`, `get_artwork`, `cite`, `discover_random`, and `list_traditions` tools.
 - `museum://{code}/{id}` MCP resources.
 
+[0.4.1]: https://github.com/cfpramod/open-museum-mcp/releases/tag/v0.4.1
 [0.4.0]: https://github.com/cfpramod/open-museum-mcp/releases/tag/v0.4.0
 [0.2.0]: https://github.com/cfpramod/open-museum-mcp/releases/tag/v0.2.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-museum-mcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "MCP server for license-verified search across open-access museum collections (The Met, Cleveland, AIC, Wikimedia Commons, Europeana).",
   "type": "module",
   "main": "dist/server.js",

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,8 +27,11 @@ import { filterByYearRange } from './yearFilter.js';
 // Load env vars before reading any keys. Cwd `.env` (developer flow) wins
 // over `~/.open-museum-mcp/.env` (production / MCP-client-launched flow);
 // dotenv ignores files that don't exist, so missing-file is not an error.
-dotenv.config();
-dotenv.config({ path: join(homedir(), '.open-museum-mcp', '.env') });
+// `quiet: true` suppresses dotenv's "◇ injected env" stdout chatter, which
+// otherwise corrupts the MCP stdio transport (any non-JSON-RPC stdout
+// breaks the client's parser).
+dotenv.config({ quiet: true });
+dotenv.config({ quiet: true, path: join(homedir(), '.open-museum-mcp', '.env') });
 
 const FETCHERS: Record<string, Fetcher> = {
   [metFetcher.code]: metFetcher,


### PR DESCRIPTION
## Summary

- `dotenv@17` writes `◇ injected env from .env` to **stdout** on `config()`, which corrupts the MCP stdio JSON-RPC stream the moment a user has a `.env` file (common since v0.4 added `EUROPEANA_API_KEY`).
- Claude Desktop and other MCP clients fail the server's launch with `Unexpected token '◇'... is not valid JSON`. v0.4.0 is unusable for affected users.
- Fix: pass `{ quiet: true }` to both `dotenv.config()` calls in `src/server.ts`. Verified server boots with empty stdout when `~/.open-museum-mcp/.env` exists.
- Tagging as v0.4.1 once merged.

## Test plan
- [x] `npm test` — 199/199 green
- [x] Boot server with `~/.open-museum-mcp/.env` present, capture stdout — empty (was `◇ injected env from .env (1)` before)
- [ ] After publish, restart Claude Desktop and confirm `open-museum` server loads

Co-Authored by Pramod Prasanth <pramod@chainalign.com>