### PR TITLE
fix(readme): use YouTube's auto-generated thumbnail

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Met, Cleveland Museum of Art, the Art Institute of Chicago, Wikimedia Common
 
 **See it in action first → [pramod.ch/open-museum-mcp](https://pramod.ch/open-museum-mcp)** — three worked examples (cross-tradition pairing, date-windowed scan, counterpoint discovery), real records, real citations, no install required.
 
-[![Watch the 60-second walkthrough on YouTube — install, ask in plain English, citations form on screen](docs/walkthrough-thumbnail.jpg)](https://www.youtube.com/watch?v=Nmk22Nbzk40)
+[![Watch the 60-second walkthrough on YouTube — install, ask in plain English, citations form on screen](https://img.youtube.com/vi/Nmk22Nbzk40/maxresdefault.jpg)](https://www.youtube.com/watch?v=Nmk22Nbzk40)
 
 ## Who this is for
 


### PR DESCRIPTION
## Summary

- Was sourcing the thumbnail from \`docs/walkthrough-thumbnail.jpg\` — a local asset that didn't match the actual YouTube preview.
- Switching to \`https://img.youtube.com/vi/Nmk22Nbzk40/maxresdefault.jpg\` so the README and the YouTube page show the same image, and so any future thumbnail change on YouTube auto-propagates.

## Followup question

\`docs/walkthrough-thumbnail.jpg\` (180KB) is now an orphan asset. Options:
- Remove it (one-line cleanup PR)
- Keep it for some other use (social cards, demo page, etc.)

Decide separately; not bundling that change into this PR.

## Test plan
- [x] \`maxresdefault.jpg\` returns 200
- [ ] After merge, GitHub README renders the YouTube preview image