### PR TITLE
chore: add glama.json to claim ownership of Glama listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["cfpramod"]
+}


### PR DESCRIPTION
## Summary

- Adds \`glama.json\` at repo root per Glama's [ownership-claim mechanism](https://glama.ai/blog/2025-07-08-what-is-glamajson).
- Schema reference: https://glama.ai/mcp/schemas/server.json — single field, \`maintainers: [GitHub usernames]\`.
- Build / runtime / cmd config stays in Glama's UI per-release; this file is purely ownership.

## Why

Listing already exists at https://glama.ai/mcp/servers/cfpramod/open-museum-mcp. This formalizes claim so future config updates don't require re-authentication, and signals to Glama that the project author is the listing owner.

## Test plan
- [x] Valid JSON
- [x] Schema-conformant (single \`maintainers\` array of GitHub usernames)
- [ ] After merge: re-trigger claim flow on Glama; verify listing shows ownership