### PR TITLE
feat: .mcpb desktop-extension bundle + node:sqlite migration (v0.5.0, closes #33)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [22, 24]
-    env:
-      NODE_OPTIONS: --experimental-sqlite
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 22]
+        node-version: [22, 24]
+    env:
+      NODE_OPTIONS: --experimental-sqlite
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release-mcpb.yml
+++ b/.github/workflows/release-mcpb.yml
@@ -1,0 +1,47 @@
+name: Build and attach .mcpb to release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to attach the .mcpb to (e.g. v0.4.1). Optional; defaults to the latest release.
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build:mcpb
+
+      - name: Resolve target tag
+        id: tag
+        run: |
+          if [ -n "${{ github.event.release.tag_name }}" ]; then
+            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          elif [ -n "${{ github.event.inputs.tag }}" ]; then
+            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            latest=$(gh release view --json tagName --jq .tagName)
+            echo "tag=$latest" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload .mcpb to release
+        run: gh release upload "${{ steps.tag.outputs.tag }}" open-museum-mcp.mcpb --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules/
 dist/
+mcpb-build/
+*.mcpb
 *.log
 .DS_Store
 ._*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] — 2026-04-27
+
+### Changed (breaking — runtime requirement)
+
+- **Migrated cache from `better-sqlite3` to Node's built-in `node:sqlite`.** Eliminates the native compilation/prebuild dependency entirely. The cache file format is unchanged (both implementations write standard SQLite files) so existing caches continue to work.
+- **Minimum Node version is now 22.5 (was 20).** `node:sqlite` is built-in starting Node 22.5, stable on Node 24+. On Node 22.x users must launch with `--experimental-sqlite` (npm scripts handle this automatically; for `npx -y open-museum-mcp` set `NODE_OPTIONS=--experimental-sqlite`). Node 24+ users need no flag.
+
+### Added
+
+- **Desktop Extension (`.mcpb`) bundle for one-click Claude Desktop install.** `manifest.json` at repo root + `npm run build:mcpb` produces `open-museum-mcp.mcpb`. CI workflow auto-attaches the bundle to GitHub releases. Cross-platform (no native dependencies anymore).
+
+### Why this release
+
+`better-sqlite3`'s prebuilt native binary is signed with a different macOS Team ID than Claude Desktop, which made the `.mcpb` install path unusable due to macOS Library Validation rejecting the `.node` library at load time. Switching to `node:sqlite` removes the native dependency entirely and unblocks the `.mcpb` runtime. As a side benefit, the bundle is now cross-platform (Mac / Linux / Windows) instead of macOS-only, install is faster (no native compile), and there are no more upstream prebuild gaps when new Node versions ship.
+
 ## [0.4.1] — 2026-04-27
 
 ### Fixed
@@ -46,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `search_artworks`, `get_artwork`, `cite`, `discover_random`, and `list_traditions` tools.
 - `museum://{code}/{id}` MCP resources.
 
+[0.5.0]: https://github.com/cfpramod/open-museum-mcp/releases/tag/v0.5.0
 [0.4.1]: https://github.com/cfpramod/open-museum-mcp/releases/tag/v0.4.1
 [0.4.0]: https://github.com/cfpramod/open-museum-mcp/releases/tag/v0.4.0
 [0.2.0]: https://github.com/cfpramod/open-museum-mcp/releases/tag/v0.2.0

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,82 @@
+{
+  "manifest_version": "0.2",
+  "name": "open-museum-mcp",
+  "display_name": "Open Museum",
+  "version": "0.4.1",
+  "description": "License-verified federated search across open-access museum collections.",
+  "long_description": "Federated MCP search across major open-access museum collections — currently The Met, Cleveland Museum of Art, Art Institute of Chicago, Wikimedia Commons, and Europeana, with more being added. Records pass per-museum rights verification (strict-default-deny on ambiguous license signals) and ship with citation output in `full`, `caption`, and `short` formats — paste-ready for papers, slide decks, and inline references.",
+  "author": {
+    "name": "Pramod Prasanth",
+    "url": "https://pramod.ch"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cfpramod/open-museum-mcp"
+  },
+  "homepage": "https://pramod.ch/open-museum-mcp",
+  "documentation": "https://github.com/cfpramod/open-museum-mcp#readme",
+  "support": "https://github.com/cfpramod/open-museum-mcp/issues",
+  "license": "MIT",
+  "keywords": [
+    "museum",
+    "art",
+    "art-history",
+    "open-access",
+    "cc0",
+    "public-domain",
+    "citation",
+    "metropolitan-museum",
+    "cleveland-museum",
+    "art-institute-chicago",
+    "wikimedia-commons",
+    "europeana"
+  ],
+  "server": {
+    "type": "node",
+    "entry_point": "dist/server.js",
+    "mcp_config": {
+      "command": "node",
+      "args": ["${__dirname}/dist/server.js"],
+      "env": {
+        "EUROPEANA_API_KEY": "${user_config.europeana_api_key}"
+      }
+    }
+  },
+  "tools": [
+    {
+      "name": "search_artworks",
+      "description": "Search across registered museums. Returns records that pass the rights gate. Supports date-range filter (BCE = negative integer)."
+    },
+    {
+      "name": "get_artwork",
+      "description": "Fetch a single artwork by its normalized ID (e.g. met:436535)."
+    },
+    {
+      "name": "cite",
+      "description": "Render a citation. Styles: full, caption, short."
+    },
+    {
+      "name": "discover_random",
+      "description": "Random artwork suggestion, optionally constrained by region or period."
+    },
+    {
+      "name": "list_traditions",
+      "description": "Meta-tool over already-collected results — list dynasties / regions present in the local cache."
+    }
+  ],
+  "user_config": {
+    "europeana_api_key": {
+      "type": "string",
+      "title": "Europeana API Key",
+      "description": "Optional. Free key from https://pro.europeana.eu/page/get-api enables the Europeana adapter (~30M records aggregated from European cultural-heritage institutions). Without a key, Europeana silently disables and the other adapters work normally.",
+      "sensitive": true,
+      "required": false
+    }
+  },
+  "compatibility": {
+    "platforms": ["darwin"],
+    "runtimes": {
+      "node": ">=20"
+    }
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "open-museum-mcp",
   "display_name": "Open Museum",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "License-verified federated search across open-access museum collections.",
   "long_description": "Federated MCP search across major open-access museum collections — currently The Met, Cleveland Museum of Art, Art Institute of Chicago, Wikimedia Commons, and Europeana, with more being added. Records pass per-museum rights verification (strict-default-deny on ambiguous license signals) and ship with citation output in `full`, `caption`, and `short` formats — paste-ready for papers, slide decks, and inline references.",
   "author": {
@@ -74,9 +74,9 @@
     }
   },
   "compatibility": {
-    "platforms": ["darwin"],
+    "platforms": ["darwin", "linux", "win32"],
     "runtimes": {
-      "node": ">=20"
+      "node": ">=22.5"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "open-museum-mcp",
-  "version": "0.2.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-museum-mcp",
-      "version": "0.2.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
-        "better-sqlite3": "^11.5.0",
         "dotenv": "^17.4.2",
         "zod": "^3.23.8"
       },
@@ -18,14 +17,13 @@
         "open-museum-mcp": "dist/server.js"
       },
       "devDependencies": {
-        "@types/better-sqlite3": "^7.6.11",
-        "@types/node": "^22.10.0",
+        "@types/node": "^24.0.0",
         "tsx": "^4.19.2",
         "typescript": "^5.7.2",
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.5"
       }
     },
     "node_modules/@emnapi/core": {
@@ -874,16 +872,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@types/better-sqlite3": {
-      "version": "7.6.13",
-      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
-      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -910,13 +898,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
-      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1088,57 +1076,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/better-sqlite3": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
-      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -1161,30 +1098,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bytes": {
@@ -1234,12 +1147,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
@@ -1336,30 +1243,6 @@
         }
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1373,6 +1256,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -1419,15 +1303,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -1447,9 +1322,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1551,15 +1426,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/expect-type": {
@@ -1673,12 +1539,6 @@
         }
       }
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
-    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -1717,12 +1577,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1797,12 +1651,6 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -1885,36 +1733,10 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ip-address": {
@@ -1948,9 +1770,9 @@
       "license": "ISC"
     },
     "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -2294,33 +2116,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2346,12 +2141,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
-    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -2359,18 +2148,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/object-assign": {
@@ -2491,9 +2268,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {
@@ -2519,33 +2296,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2557,16 +2307,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
       }
     },
     "node_modules/qs": {
@@ -2606,35 +2346,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/require-from-string": {
@@ -2706,43 +2417,11 @@
         "node": ">= 18"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
-    },
-    "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -2895,51 +2574,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2972,52 +2606,6 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -3100,18 +2688,6 @@
         "fsevents": "~2.3.3"
       }
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -3141,9 +2717,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3155,12 +2731,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/cfpramod/open-museum-mcp#readme",
   "scripts": {
     "build": "tsc",
+    "build:mcpb": "node scripts/build-mcpb.mjs",
     "dev": "tsx src/server.ts",
     "prepare": "npm run build",
     "test": "vitest run",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-museum-mcp",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "MCP server for license-verified search across open-access museum collections (The Met, Cleveland, AIC, Wikimedia Commons, Europeana).",
   "type": "module",
   "main": "dist/server.js",
@@ -23,10 +23,10 @@
   "scripts": {
     "build": "tsc",
     "build:mcpb": "node scripts/build-mcpb.mjs",
-    "dev": "tsx src/server.ts",
+    "dev": "NODE_OPTIONS=--experimental-sqlite tsx src/server.ts",
     "prepare": "npm run build",
-    "test": "vitest run",
-    "test:watch": "vitest",
+    "test": "NODE_OPTIONS=--experimental-sqlite vitest run",
+    "test:watch": "NODE_OPTIONS=--experimental-sqlite vitest",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [
@@ -45,17 +45,15 @@
   "author": "Pramod Prasanth",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22.5"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.4",
-    "better-sqlite3": "^11.5.0",
     "dotenv": "^17.4.2",
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.11",
-    "@types/node": "^22.10.0",
+    "@types/node": "^24.0.0",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2",
     "vitest": "^4.1.5"

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process';
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = resolve(__dirname, '..');
+const stagingDir = join(rootDir, 'mcpb-build');
+const outputPath = join(rootDir, 'open-museum-mcp.mcpb');
+
+const run = (cmd, cwd = rootDir) => {
+  console.log(`\n$ ${cmd}`);
+  execSync(cmd, { cwd, stdio: 'inherit' });
+};
+
+const pkg = JSON.parse(readFileSync(join(rootDir, 'package.json'), 'utf8'));
+const manifest = JSON.parse(readFileSync(join(rootDir, 'manifest.json'), 'utf8'));
+
+if (manifest.version !== pkg.version) {
+  console.error(
+    `manifest.json version (${manifest.version}) does not match package.json version (${pkg.version}). Bump manifest.json before packing.`,
+  );
+  process.exit(1);
+}
+
+if (existsSync(stagingDir)) rmSync(stagingDir, { recursive: true, force: true });
+if (existsSync(outputPath)) rmSync(outputPath);
+
+mkdirSync(stagingDir, { recursive: true });
+
+run('npm run build');
+
+cpSync(join(rootDir, 'dist'), join(stagingDir, 'dist'), { recursive: true });
+cpSync(join(rootDir, 'manifest.json'), join(stagingDir, 'manifest.json'));
+cpSync(join(rootDir, 'README.md'), join(stagingDir, 'README.md'));
+cpSync(join(rootDir, 'LICENSE'), join(stagingDir, 'LICENSE'));
+
+const stagingPkg = {
+  name: pkg.name,
+  version: pkg.version,
+  type: pkg.type,
+  main: pkg.main,
+  bin: pkg.bin,
+  dependencies: pkg.dependencies,
+  engines: pkg.engines,
+};
+writeFileSync(join(stagingDir, 'package.json'), JSON.stringify(stagingPkg, null, 2));
+
+run('npm install --omit=dev --no-package-lock --no-audit --no-fund', stagingDir);
+
+run(`npx -y @anthropic-ai/mcpb@2 pack ${stagingDir} ${outputPath}`);
+
+rmSync(stagingDir, { recursive: true, force: true });
+
+const stats = execSync(`ls -lh ${outputPath}`).toString().trim();
+console.log(`\nBuilt: ${stats}`);

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,6 +1,6 @@
-import Database from 'better-sqlite3';
 import { chmodSync, mkdirSync, existsSync } from 'node:fs';
 import { dirname } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
 import type { Artwork, Tradition } from './types.js';
 
 const OBJECT_TTL_DAYS = 90;
@@ -50,14 +50,14 @@ export interface DiscoverFilter {
  * no string-concatenated SQL paths.
  */
 export class Cache {
-  private db: Database.Database;
+  private db: DatabaseSync;
 
   constructor(config: CacheConfig) {
     if (!existsSync(dirname(config.path))) {
       mkdirSync(dirname(config.path), { recursive: true, mode: 0o700 });
     }
     const fileExisted = existsSync(config.path);
-    this.db = new Database(config.path);
+    this.db = new DatabaseSync(config.path);
     if (!fileExisted) {
       // Tighten file mode immediately on creation so the cache (which can
       // include rights metadata, snapshots of museum responses, etc.) isn't
@@ -68,7 +68,7 @@ export class Cache {
         // Best-effort; non-fatal on filesystems that don't support chmod.
       }
     }
-    this.db.pragma('journal_mode = WAL');
+    this.db.exec('PRAGMA journal_mode = WAL');
     this.init();
     this.pruneExpired();
   }
@@ -316,7 +316,10 @@ export class Cache {
   pruneExpired(): { objects: number; queries: number } {
     const objects = this.db.prepare(`DELETE FROM objects WHERE cached_at < ?`).run(this.objectsCutoff());
     const queries = this.db.prepare(`DELETE FROM query_cache WHERE cached_at < ?`).run(this.queriesCutoff());
-    return { objects: objects.changes, queries: queries.changes };
+    // node:sqlite types `RunResult.changes` as `number | bigint`; cast to
+    // number since our row counts never overflow 32-bit (the prune query
+    // is bounded by what fits in the local cache file).
+    return { objects: Number(objects.changes), queries: Number(queries.changes) };
   }
 
   private isExpired(isoTimestamp: string, ttlDays: number): boolean {

--- a/src/server.ts
+++ b/src/server.ts
@@ -144,7 +144,7 @@ async function fetchAndCache(id: string): Promise<{ ok: true; artwork: Artwork }
 }
 
 const server = new Server(
-  { name: 'open-museum-mcp', version: '0.4.0' },
+  { name: 'open-museum-mcp', version: '0.5.0' },
   {
     capabilities: {
       tools: {},

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1,7 +1,7 @@
-import Database from 'better-sqlite3';
 import { mkdtempSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { Cache } from '../src/db.js';
 import type { Artwork } from '../src/types.js';
@@ -83,7 +83,7 @@ describe('Cache', () => {
     cache.close();
 
     // Directly age the row past the 90-day TTL.
-    const db = new Database(path);
+    const db = new DatabaseSync(path);
     const longAgo = new Date(Date.now() - 91 * 24 * 60 * 60 * 1000).toISOString();
     db.prepare('UPDATE objects SET cached_at = ? WHERE id = ?').run(longAgo, 'met:1');
     db.close();
@@ -100,7 +100,7 @@ describe('Cache', () => {
     expect(cache.getQuery('q:foo')).toEqual(['met:1', 'met:2']);
     cache.close();
 
-    const db = new Database(path);
+    const db = new DatabaseSync(path);
     const longAgo = new Date(Date.now() - 15 * 24 * 60 * 60 * 1000).toISOString();
     db.prepare('UPDATE query_cache SET cached_at = ? WHERE cache_key = ?').run(longAgo, 'q:foo');
     db.close();
@@ -115,7 +115,7 @@ describe('Cache', () => {
     cache.upsertObject(makeArtwork('met:1'));
     cache.close();
 
-    const db = new Database(path);
+    const db = new DatabaseSync(path);
     db.prepare('UPDATE objects SET full_record = ? WHERE id = ?').run('{not json', 'met:1');
     db.close();
 
@@ -131,7 +131,7 @@ describe('Cache', () => {
     cache.putQuery('q:a', ['met:1']);
     cache.close();
 
-    const db = new Database(path);
+    const db = new DatabaseSync(path);
     const longAgo = new Date(Date.now() - 91 * 24 * 60 * 60 * 1000).toISOString();
     db.prepare('UPDATE objects SET cached_at = ? WHERE id = ?').run(longAgo, 'met:1');
     db.prepare('UPDATE query_cache SET cached_at = ?').run(longAgo);
@@ -250,7 +250,7 @@ describe('Cache.getRandomObject', () => {
 
   it('skips expired rows', () => {
     cache.close();
-    const db = new Database(path);
+    const db = new DatabaseSync(path);
     const longAgo = new Date(Date.now() - 91 * 24 * 60 * 60 * 1000).toISOString();
     db.prepare('UPDATE objects SET cached_at = ?').run(longAgo);
     db.close();
@@ -389,7 +389,7 @@ describe('Cache.listTraditions', () => {
   it('skips expired rows', () => {
     cache.upsertObject(makeArtwork('met:1', { region: 'china', period: 'tang dynasty' }));
     cache.close();
-    const db = new Database(path);
+    const db = new DatabaseSync(path);
     const longAgo = new Date(Date.now() - 91 * 24 * 60 * 60 * 1000).toISOString();
     db.prepare('UPDATE objects SET cached_at = ?').run(longAgo);
     db.close();


### PR DESCRIPTION
Closes #33.

## Summary

Ships v0.5.0:
1. \`.mcpb\` (Desktop Extension) bundle for one-click install in Claude Desktop
2. Migrated cache from \`better-sqlite3\` → built-in \`node:sqlite\` to unblock the \`.mcpb\` runtime

The migration was discovered mid-PR: the initial \`.mcpb\` build worked but Claude Desktop failed to load the server due to macOS Library Validation rejecting better-sqlite3's native binary (signed with a different Team ID than Anthropic's). Migrating to \`node:sqlite\` removes the native dependency entirely.

## What's in this PR

### \`.mcpb\` infrastructure
- **\`manifest.json\`** at repo root — bundle metadata, the five tools, optional sensitive \`EUROPEANA_API_KEY\` user-config (so the bundle works without one).
- **\`scripts/build-mcpb.mjs\`** — staging build that compiles \`dist/\`, installs production-only deps, runs \`mcpb pack\`.
- **npm script \`build:mcpb\`** — local one-shot build.
- **\`.github/workflows/release-mcpb.yml\`** — auto-attaches the \`.mcpb\` to GitHub releases on publish, plus \`workflow_dispatch\` for manual attachment to existing releases.

### node:sqlite migration
- **\`src/db.ts\`** — better-sqlite3 → node:sqlite. API differences:
  - \`db.pragma('X = Y')\` → \`db.exec('PRAGMA X = Y')\`
  - \`RunResult.changes\` is \`number | bigint\` (cast at the boundary).
- **\`tests/db.test.ts\`** — same import swap.
- **\`package.json\`** — drops \`better-sqlite3\` + \`@types/better-sqlite3\`; \`engines.node\` bumped from \`>=20\` to \`>=22.5\`; npm scripts use \`NODE_OPTIONS=--experimental-sqlite\` so dev/test work on Node 22.
- **\`.github/workflows/ci.yml\`** — Node matrix \`[20, 22]\` → \`[22, 24]\`.
- **\`CHANGELOG.md\`** — 0.5.0 entry with the migration rationale.

## Why this release

\`better-sqlite3\`'s prebuilt \`.node\` binary is signed with a different macOS Team ID than Claude Desktop. macOS Library Validation in Anthropic's hardened runtime refuses to load it:

\`\`\`
dlopen(...better_sqlite3.node, 0x0001): code signature ... not valid
for use in process: mapping process and mapped file (non-platform)
have different Team IDs
\`\`\`

We can't bypass that from our side. \`node:sqlite\` (Node 22.5+) has no native binary to load, so it sidesteps the entire signing problem.

## Side benefits beyond unblocking the .mcpb

- **.mcpb is now cross-platform.** \`compatibility.platforms\` goes from \`["darwin"]\` back to \`["darwin","linux","win32"]\` — no native binaries to ship per platform.
- **Bundle size halves**: 6.7MB → 3.0MB (unpacked 21.8MB → 9.6MB), entirely from removing better-sqlite3's prebuilt binary and unused C source.
- **No more upstream prebuild gaps** when new Node versions ship (the issue that bit Glama's first build attempt on Node 25).
- **Faster install** on cold cache (no native compile fallback path).

## Runtime requirement bump

Minimum Node moves from \`>=20\` to \`>=22.5\`. \`node:sqlite\` is stable on Node 24+, experimental on 22.5–23.x:
- Claude Desktop (.mcpb): bundles Node 24, no flag needed
- \`npx -y open-museum-mcp\` on Node 24+: works
- \`npx -y open-museum-mcp\` on Node 22: requires \`NODE_OPTIONS=--experimental-sqlite\` (README update follow-up)
- npm scripts (test, dev) bake in the flag so local dev works on 22

## Test plan

- [x] \`npm test\` — 199/199 green
- [x] \`npm run build:mcpb\` — produces 3.0MB bundle
- [x] \`npx mcpb validate manifest.json\` — schema valid
- [x] Local server boot with \`node --experimental-sqlite dist/server.js\` — clean stdout
- [x] **Live install test**: drag-and-drop \`open-museum-mcp.mcpb\` into Claude Desktop → install dialog → restart → tool call returned a Tang dynasty phoenix-head ewer (met:460652) with caption citation. First successful .mcpb install path for this project.
- [ ] After merge: trigger \`workflow_dispatch\` with tag \`v0.5.0\` to attach the \`.mcpb\` once that release is cut.

## Follow-ups (not in this PR)

- README: add \`.mcpb\` install path as primary for non-coders, document the \`NODE_OPTIONS\` workaround for Node 22 users on the npx path
- Demo page CTA at pramod.ch/open-museum-mcp linking to \`releases/latest/download/open-museum-mcp.mcpb\`
- Trim bundle size further via \`.mcpbignore\` (low-priority polish)

Co-Authored by Pramod Prasanth <pramod@chainalign.com>