### PR TITLE
fix(dateParser): word-boundary anchoring on dynasty matches (closes #21)

### DIFF
--- a/src/dateParser.ts
+++ b/src/dateParser.ts
@@ -26,6 +26,14 @@ const FLAT_DYNASTY_KEYS_LONGEST_FIRST = Object.keys(flatDynasties).sort(
   (a, b) => b.length - a.length,
 );
 
+// Parallel array of word-boundary regexes — one per dynasty key. Pre-compiled
+// at module load so tryDynasty doesn't pay regex-construction cost per call.
+// Word-boundary anchoring (`\b`) prevents false-positives like "Hanka" hitting
+// the "han" key, "Tangerine" hitting "tang", etc. (#21).
+const FLAT_DYNASTY_REGEXES_LONGEST_FIRST = FLAT_DYNASTY_KEYS_LONGEST_FIRST.map(
+  (key) => new RegExp(`\\b${key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i'),
+);
+
 const QUALIFIER_RE = /\b(early|mid|middle|late)\b/;
 
 const ROMAN: Record<string, number> = {
@@ -253,8 +261,9 @@ function tryCentury(s: string): DateRange | null {
 function tryDynasty(s: string): DateRange | null {
   const lower = s.toLowerCase();
   const qualifier = lower.match(QUALIFIER_RE)?.[1];
-  for (const period of FLAT_DYNASTY_KEYS_LONGEST_FIRST) {
-    if (!lower.includes(period)) continue;
+  for (let i = 0; i < FLAT_DYNASTY_KEYS_LONGEST_FIRST.length; i++) {
+    if (!FLAT_DYNASTY_REGEXES_LONGEST_FIRST[i].test(lower)) continue;
+    const period = FLAT_DYNASTY_KEYS_LONGEST_FIRST[i];
     const [start, end] = flatDynasties[period];
     const span = end - start;
     if (qualifier === 'early') {

--- a/tests/dateParser.test.ts
+++ b/tests/dateParser.test.ts
@@ -165,6 +165,25 @@ describe('parseDisplayDate', () => {
       expect(r.yearStart).toBe(1860);
       expect(r.yearEnd).toBe(1860);
     });
+
+    // Regression for #21: substring match against dynasty keys yielded
+    // false positives ("Hanka" → Han, "tangerine" → Tang). Word-boundary
+    // anchoring should reject these without dropping legitimate matches.
+    it('does not match "Hanka" as Han dynasty (#21)', () => {
+      expect(parseDisplayDate('Hanka')).toEqual({ yearStart: null, yearEnd: null });
+    });
+
+    it('does not match "tangerine" as Tang dynasty (#21)', () => {
+      expect(parseDisplayDate('tangerine')).toEqual({ yearStart: null, yearEnd: null });
+    });
+
+    it('does not match "Edofuji" as Edo period (#21)', () => {
+      expect(parseDisplayDate('Edofuji')).toEqual({ yearStart: null, yearEnd: null });
+    });
+
+    it('still matches "Han dynasty" with word boundaries (#21)', () => {
+      expect(parseDisplayDate('Han dynasty')).toEqual({ yearStart: -206, yearEnd: 220 });
+    });
   });
 
   describe('failures', () => {


### PR DESCRIPTION
Closes #21.

## Summary

Substring-based dynasty matching (\`lower.includes(period)\`) yielded false positives across the project's catalogue:
- \"Hanka\" matched Han dynasty
- \"tangerine\" matched Tang dynasty
- \"Edofuji\" matched Edo period

Switched to word-boundary regex anchoring. One regex per dynasty key is pre-compiled at module load (parallel array to \`FLAT_DYNASTY_KEYS_LONGEST_FIRST\`), so \`tryDynasty\` pays zero per-call construction cost. Regex meta-characters in keys are escaped defensively even though the current dynasty table is plain ASCII + space + hyphen.

## Test plan

- [x] \`npm test\` — 203/203 green (199 baseline + 4 new regression cases)
- New regression tests under \"dynasties and periods\":
  - \"Hanka\" → null (was Han dynasty)
  - \"tangerine\" → null (was Tang dynasty)
  - \"Edofuji\" → null (was Edo period)
  - \"Han dynasty\" → -206..220 (still matches)

Co-Authored by Pramod Prasanth <pramod@chainalign.com>