### PR TITLE
docs(readme): add one-click install for Claude Desktop, VS Code, Cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,17 @@ A search call returns license-verified results in one normalized shape:
 
 > **Want to see it work before installing?** [pramod.ch/open-museum-mcp](https://pramod.ch/open-museum-mcp) walks through the three core workflows with real records and citations.
 
-The package is on npm. The simplest setup is to add it directly to your MCP client config; `npx` will fetch and run it on first launch:
+### One-click
+
+For supported clients, no JSON, no Node, no npm — pick your client:
+
+- **Claude Desktop:** [Download `open-museum-mcp.mcpb`](https://github.com/cfpramod/open-museum-mcp/releases/latest/download/open-museum-mcp.mcpb) from the latest release and double-click it. Claude Desktop opens the bundle and installs the server in one step.
+- **VS Code:** [Install in VS Code](vscode:mcp/install?%7B%22name%22%3A%22open-museum-mcp%22%2C%22type%22%3A%22stdio%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22open-museum-mcp%22%5D%7D) — opens VS Code with the install dialog prefilled (requires the GitHub Copilot Chat extension).
+- **Cursor:** [Install in Cursor](cursor://anysphere.cursor-deeplink/mcp/install?name=open-museum-mcp&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIm9wZW4tbXVzZXVtLW1jcCJdfQ==) — same idea, Cursor-flavoured (MCP support is built in).
+
+### JSON config (any MCP client)
+
+For ChatGPT with MCP, Cline, Goose, Continue, Zed, or anything else: paste this into your client's MCP config and restart. `npx` fetches and runs the server on first launch.
 
 ```json
 {
@@ -100,8 +110,6 @@ The package is on npm. The simplest setup is to add it directly to your MCP clie
   }
 }
 ```
-
-That's it. Restart your MCP client and the tools below become available.
 
 ### From source (for contributors)
 


### PR DESCRIPTION
## Summary

Mirrors the install structure landing on the demo page (cfpramod/pramod-ch#45). The README now leads with three friction-free options before the JSON config — addresses real-user feedback that the JSON-only path was a sticking point.

- **Claude Desktop:** download link to `open-museum-mcp.mcpb` from `/releases/latest/download/` (stays correct across releases)
- **VS Code:** `vscode:mcp/install?...` URI with URL-encoded JSON
- **Cursor:** `cursor://anysphere.cursor-deeplink/mcp/install?...` URI with base64-encoded config
- **JSON config** kept for ChatGPT with MCP, Cline, Goose, Continue, Zed, and anything else

## Test plan

- [ ] GitHub renders the README cleanly (the `vscode:` and `cursor://` protocol links are common enough that GitHub doesn't strip them)
- [ ] Click each one-click link from a fresh checkout to verify the protocol handler fires (Claude Desktop / VS Code / Cursor each open with the right install affordance)
- [ ] Confirm CI green

## Out of scope

The Dependabot PRs (#41–#46) are reviewed but left to you to decide on; #44 (typescript 6), #45 (zod 4), and #46 (@types/node 25) all pass `npm run typecheck && npm test && npm run build` cleanly.

Co-Authored by Pramod Prasanth <pramod@chainalign.com>