### PR TITLE
docs(readme): add Compatibility, Release cadence, Changelog; v0.5 in roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,14 @@ Highlights:
 - `artist.attributionType` distinguishes `named` / `anonymous` / `workshop` / `after` / `attributed` / `circle` / `follower`.
 - `imageOpenAccess` is held distinct from `metadataOpenAccess` because museums frequently publish open metadata for objects whose images are not openly licensed.
 
+### Compatibility
+
+`Artwork` field semantics are stable. New versions may add fields or tools, but won't repurpose or remove existing ones within a major version.
+
+- **Backward-compatible.** New server versions may add fields to `Artwork`, add new tools, or add new optional arguments. A v0.5 client calling a v0.6 server will continue to work; it just ignores fields it doesn't know.
+- **Forward-compatible.** A v0.6 client calling an older v0.5 server will get records that lack v0.6-only fields, but the records it does get will validate against the older client's schema.
+- **SemVer.** While in v0.x, MINOR bumps may include backward-incompatible changes (per the [SemVer spec](https://semver.org/) for pre-1.0 versions). From v1.0 onwards, only MAJOR bumps may break compatibility.
+
 ## Non-goals
 
 - **Not a full art-history ontology.** The dynasty and region tables cover the most-encountered cases; they are not exhaustive iconographic taxonomies.
@@ -266,12 +274,21 @@ Highlights:
 
 - v0.1: Met adapter, dynasty-aware date parser, license gate, `cite` tool, MCP resources.
 - v0.2: Cleveland and AIC adapters, `discover_random` with constraints, `list_traditions`.
-- v0.3: Wikimedia Commons adapter (per-record rights model; unlocks works whose home museums lack public APIs).
-- v0.4: Europeana adapter (federated European institutions, opt-in via API key); `year_min`/`year_max` date-range filter on `search_artworks`. **(here)**
+- v0.3: Wikimedia Commons adapter (per-record rights model; covers works whose home museums lack public APIs).
+- v0.4: Europeana adapter (federated European institutions, opt-in via API key); `year_min`/`year_max` date-range filter on `search_artworks`.
+- v0.5: `.mcpb` Desktop Extension bundle (one-click Claude Desktop install); migration to Node 22+ `node:sqlite` (no native compile required). **(here)**
 - v0.7: Wikidata enrichment (artist QIDs, movement, country, dedup across cache).
 - v0.8: Dominant-colour extraction across museums (`color: "#3a5f7d"` discovery via `sharp`).
 - v1.0: Artist-obscurity scoring (`object_count_total`, `museum_count`) for deliberate exploration of less-canonical work.
 - v2.0: Smithsonian, Rijksmuseum direct integration, Walters Art Museum, more European institutions.
+
+### Release cadence
+
+This is a side project. New releases ship when one of three things happens: my own work needs a feature, a new museum is wired in, or a contributor's PR is merged. There is no fixed cadence. I do commit to reviewing and merging contributor PRs promptly.
+
+### Changelog
+
+[Releases](https://github.com/cfpramod/open-museum-mcp/releases) lists what shipped in each version, with notes.
 
 ## Contributing a museum adapter
 


### PR DESCRIPTION
## Summary

Three structural additions to the README, informed by the engineering-practice books I'm reading right now (Riccomini & Ryaboy's *The Missing README*, Ch 8 and 11; Kleppmann & Riccomini's *DDIA* 2e, Ch 4 on encoding and schema evolution). Each one closes a gap a reader of those chapters would notice on this repo.

### What changed

- **`### Compatibility`** under `## Schema`. Explicit backward and forward compatibility statement, plus SemVer-in-v0.x clarification so users know that pre-1.0 MINOR bumps may include breaking changes (per the SemVer spec for prerelease versions) and that from v1.0 onwards only MAJOR may. Implements *Missing README* Ch 11's "Keep API Changes Compatible" / "Version APIs" recommendations.
- **`### Release cadence`** under `## Roadmap`. Honest framing: side project, releases driven by my own requirements, new museums, or contributor PRs landing. Explicit commitment: I'll review and merge contributor PRs promptly. Implements *Missing README* Ch 8's "Be Transparent About Release Schedules".
- **`### Changelog`** under `## Roadmap`. One-line pointer at the GitHub Releases page so users can find prior-version notes without digging. Implements *Missing README* Ch 8's "Publish Changelogs and Release Notes".

### Also

- Roadmap: added a `v0.5` entry (`.mcpb` Desktop Extension + `node:sqlite` migration) and moved the `**(here)**` marker from v0.4 to v0.5.
- The v0.3 roadmap bullet had a stray "unlocks" (banned phrase from the writing-quality skill, missed in PR #47's sweep). Replaced with "covers".

### Coordination with PR #47

PR #47 still has the writing-cleanup pass on the install section. The two PRs touch different lines so they shouldn't conflict on rebase. If #47 lands first, this branch will pick up the em-dash and other fixes for line 235 cleanly. If this lands first, #47 rebases without conflict.

## Test plan

- [ ] Render the README on the PR page and eyeball: does the Compatibility block read clearly? Does the Release cadence framing land?
- [ ] Confirm CI green
- [ ] Verify the [Releases](https://github.com/cfpramod/open-museum-mcp/releases) link in the Changelog section resolves to the actual releases page

Co-Authored by Pramod Prasanth <pramod@chainalign.com>