### PR TITLE
docs: OSS hardening (governance, support, citation, funding, wordmark)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,10 @@
+# This file controls the "Sponsor" button on the repository. It routes to the
+# maintainer (Pramod Prasanth; see MAINTAINERS.md).
+#
+# Nothing is active yet: every target line below is commented out, so no Sponsor
+# button renders until a target is confirmed. For the `github:` line to produce a
+# button, GitHub Sponsors must also be enabled on the maintainer's account.
+#
+# TODO(Pramod): confirm the funding target, then uncomment exactly one line.
+# github: cfpramod
+# custom: ["https://..."]

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ coverage/
 # Local-only Claude Code project guidance — kept out of the OSS repo
 CLAUDE.md
 
+# Local-only session state (Claude Code handover notes) — not part of the OSS repo
+session-states/
+

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,21 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it using these metadata."
+title: open-museum-mcp
+abstract: "An MCP server that federates open-access museum collections behind a strict-default-deny rights gate, exposing search, retrieval, and citation tools to AI clients."
+type: software
+authors:
+  - given-names: Pramod
+    family-names: Prasanth
+    orcid: "https://orcid.org/0009-0005-9402-9393"
+repository-code: "https://github.com/cfpramod/open-museum-mcp"
+url: "https://github.com/cfpramod/open-museum-mcp"
+license: MIT
+version: 0.5.0
+date-released: "2026-04-27"
+keywords:
+  - mcp
+  - model-context-protocol
+  - museums
+  - open-access
+  - public-domain
+  - cultural-heritage

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,30 @@
+# Governance
+
+This document describes how decisions get made in open-museum-mcp. It is deliberately short, because the project is small.
+
+## Current model
+
+open-museum-mcp is maintained by a single person (see [MAINTAINERS.md](MAINTAINERS.md)). The maintainer reviews and merges pull requests, cuts releases, and owns the rights-gate policy that is the core of the project.
+
+This is a side project. New releases ship when one of three things happens: the maintainer's own work needs a feature, a new museum is wired in, or a contributor's PR is merged. There is no fixed cadence. The maintainer does commit to reviewing and merging contributor PRs promptly.
+
+## How decisions are made
+
+- **Pull requests.** Anyone can open one. The maintainer reviews for correctness, test coverage, and fit with the conventions in [CONTRIBUTING.md](CONTRIBUTING.md). Adapter and rights-gate changes get the closest review, because license correctness is the property the project exists to protect.
+- **Rights-gate policy.** The strict-default-deny posture in `src/licenseGate.ts` is not up for negotiation. A change that could let a non-open-access record through is treated as a P0 regression, not a feature. When a museum's rights model is genuinely two-tier, the project expresses that explicitly rather than relaxing the default. See the rules in CONTRIBUTING.md.
+- **Releases.** The maintainer tags versions following [Semantic Versioning](https://semver.org/) and records every release in [CHANGELOG.md](CHANGELOG.md).
+- **Breaking changes.** These require a major or minor bump as SemVer dictates, a CHANGELOG entry that states the migration, and a clear reason in the PR.
+
+## How governance broadens
+
+If the project attracts regular contributors, governance widens to match. A contributor who has landed several well-reviewed PRs, shown sound judgement on rights questions, and stayed active over time may be invited to become a maintainer with merge rights. The criteria are:
+
+- A track record of merged, high-quality contributions (adapters, fixes, or docs).
+- Demonstrated care with the rights gate, the part of the codebase where mistakes are most costly.
+- Sustained engagement, not a single burst.
+
+When a second maintainer joins, this document is updated to describe shared decision-making (for example, a second review on rights-gate changes, and a tie-break rule). Until then, the model above stands.
+
+## Code of conduct
+
+All participation is governed by the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,25 @@
+# Maintainers
+
+| Maintainer | GitHub | Role |
+|---|---|---|
+| Pramod Prasanth | [@cfpramod](https://github.com/cfpramod) | Lead maintainer |
+
+## Scope of responsibility
+
+The maintainer:
+
+- Reviews and merges pull requests, with the closest review reserved for adapters and the rights gate.
+- Owns the strict-default-deny rights policy in `src/licenseGate.ts` and keeps the validators aligned with the README's verification table.
+- Cuts releases, tags them under [Semantic Versioning](https://semver.org/), and writes the [CHANGELOG](CHANGELOG.md) entry.
+- Triages issues and museum-source requests.
+- Handles security reports per [SECURITY.md](SECURITY.md).
+
+## Contact
+
+- **General and contribution questions:** open a GitHub issue, or see [SUPPORT.md](SUPPORT.md) for routing.
+- **Security and rights-gate vulnerabilities:** use [GitHub Security Advisories](https://github.com/cfpramod/open-museum-mcp/security/advisories/new), not a public issue.
+- **Code of Conduct reports:** email the maintainer at pramod.prasanth@gmail.com, as stated in the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Becoming a maintainer
+
+The path to maintainer, and how decision-making broadens as the project grows, is described in [GOVERNANCE.md](GOVERNANCE.md).

--- a/README.md
+++ b/README.md
@@ -286,6 +286,10 @@ Highlights:
 
 This is a side project. New releases ship when one of three things happens: my own work needs a feature, a new museum is wired in, or a contributor's PR is merged. There is no fixed cadence. I do commit to reviewing and merging contributor PRs promptly.
 
+### Project status
+
+This is actively maintained as of the latest release. Because it is a side project, if active maintenance ever stops I will archive the repository and say so here, rather than leave it looking live. The published npm package, the adapters, and the `Artwork` schema remain usable either way, and the code is MIT-licensed, so anyone is free to fork and continue it. Governance and the path for new maintainers are described in [GOVERNANCE.md](GOVERNANCE.md).
+
 ### Changelog
 
 [Releases](https://github.com/cfpramod/open-museum-mcp/releases) lists what shipped in each version, with notes.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,19 @@
+# Support
+
+Thanks for using open-museum-mcp. Here is where to go for each kind of question.
+
+## Where to go
+
+| You want to... | Go here |
+|---|---|
+| Report a bug | [Open an issue](https://github.com/cfpramod/open-museum-mcp/issues/new) with the artwork ID, the tool call, and what you expected. If the bug is a record the rights gate accepted that should not have passed, include the museum's raw API response. |
+| Report a security or rights-gate vulnerability | Do not open a public issue. Follow [SECURITY.md](SECURITY.md), which routes private reports through GitHub Security Advisories. License-gate bypasses are P0. |
+| Get help using the server | Read the [README](README.md). It covers install (npm, Claude Desktop `.mcpb`, VS Code, Cursor), the available tools, and the verification model. |
+| Suggest a museum to add | Use the [museum-source issue form](https://github.com/cfpramod/open-museum-mcp/issues/new?template=museum-source.yml). It asks for the API URL, the rights field, and a sample record, which is everything someone needs to pick up the adapter. |
+| Propose a feature or ask an open-ended question | Open an issue (or a GitHub Discussion if Discussions is enabled on the repo). |
+
+## Response expectations
+
+This is a side project with a single maintainer (see [MAINTAINERS.md](MAINTAINERS.md) and [GOVERNANCE.md](GOVERNANCE.md)). There is no SLA for bug reports or feature requests, but pull requests get reviewed promptly. Security reports get an acknowledgement within 7 days, per [SECURITY.md](SECURITY.md).
+
+If you can write the adapter or the fix yourself, a pull request is the fastest path. See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/assets/wordmark.svg
+++ b/assets/wordmark.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  open-museum-mcp wordmark (neutral, text-based) for registry listings.
+  Single-ink, transparent background, so it sits on light or dark surfaces.
+  Note: the wordmark uses a system monospace stack via <text>. For guaranteed
+  rendering everywhere (registries that rasterize without the font), a designer
+  should convert the text to vector paths. Flagged for Pramod.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="560" height="120" viewBox="0 0 560 120" role="img" aria-label="open-museum-mcp">
+  <title>open-museum-mcp</title>
+  <g fill="none" stroke="#1f2937" stroke-width="6" stroke-linecap="square">
+    <!-- a spare framed-artwork glyph -->
+    <rect x="24" y="28" width="64" height="64" rx="2"/>
+    <line x1="40" y1="76" x2="56" y2="52"/>
+    <line x1="56" y1="52" x2="72" y2="76"/>
+  </g>
+  <text x="116" y="72"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace"
+        font-size="34" font-weight="600" letter-spacing="-0.5"
+        fill="#1f2937">open-museum<tspan fill="#6b7280">-mcp</tspan></text>
+</svg>


### PR DESCRIPTION
## Summary

Additive project-maturity files surfaced by an OSS-hardening review. No code or behaviour changes; one small README addition, the rest are new files.

- **GOVERNANCE.md** — solo-maintainer model, decision process, and how governance broadens (promotion-to-maintainer criteria) as contributors emerge. Reuses the README's existing cadence framing.
- **SUPPORT.md** — routing: bugs → issues, security → SECURITY.md, usage → README, museum suggestions → the `museum-source.yml` form, ideas → issues/Discussions.
- **MAINTAINERS.md** — maintainer, scope, contact routes; ties to GOVERNANCE.
- **CITATION.cff** — CFF 1.2.0 (version 0.5.0, MIT, repo URL, ORCID) so GitHub renders "Cite this repository".
- **README** — short "Project status" note: archive-and-announce if maintenance ever stops; package/adapters/schema stay usable.
- **.github/FUNDING.yml** — inert placeholder routing to the maintainer. No live target until confirmed; Sponsors-must-be-enabled caveat noted in-file.
- **assets/wordmark.svg** — neutral text-based wordmark for registry listings.
- **.gitignore** — ignore local `session-states/` handover notes (separate commit).

## Notes for review

- `FUNDING.yml` ships fully commented, so no Sponsor button renders. Confirm the target (`github: cfpramod` and/or a `custom:` URL) before activating.
- All new prose is em-dash free by request.

## Test Plan

- [ ] CFF validates as CFF 1.2.0 (already parsed locally; GitHub will show the "Cite this repository" widget)
- [ ] `FUNDING.yml` renders no Sponsor button (all lines commented)
- [ ] README "Project status" section reads correctly
- [ ] No source/test files touched; `npm test` still green

Co-Authored by Pramod Prasanth <pramod@chainalign.com>