### PR TITLE
fix(aic): combine search filters under bool/must (closes #28)

### DIFF
--- a/src/fetchers/aic.ts
+++ b/src/fetchers/aic.ts
@@ -66,14 +66,19 @@ export const aicFetcher: Fetcher = {
   async search(query: string, limit: number, options: SearchOptions = {}): Promise<string[]> {
     const url = new URL(`${AIC_API}/artworks/search`);
     url.searchParams.set('q', query);
-    // Push the rights filter to AIC server-side via Elasticsearch term
-    // query, so the gate has fewer rejections to handle. Defense in depth:
-    // validateAicLicense still re-checks each fetched record.
-    url.searchParams.set('query[term][is_public_domain]', 'true');
+    // AIC proxies the `query[...]` params straight into Elasticsearch. Multiple
+    // filter clauses must be combined under a single bool/must array; two
+    // sibling clauses in one query object (e.g. `query[term]` + `query[exists]`)
+    // is invalid ES and AIC rejects the whole request with HTTP 400 (#28).
+    //
+    // Push the rights filter to AIC server-side via the term clause, so the gate
+    // has fewer rejections to handle. Defense in depth: validateAicLicense still
+    // re-checks each fetched record.
+    url.searchParams.set('query[bool][must][0][term][is_public_domain]', 'true');
     if (options.hasImage !== false) {
-      // exists query against image_id keeps records without IIIF imagery
+      // exists clause against image_id keeps records without IIIF imagery
       // out of the candidate list.
-      url.searchParams.set('query[exists][field]', 'image_id');
+      url.searchParams.set('query[bool][must][1][exists][field]', 'image_id');
     }
     url.searchParams.set('limit', String(limit));
     url.searchParams.set('fields', 'id');

--- a/tests/aic.test.ts
+++ b/tests/aic.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { aicFetcher } from '../src/fetchers/aic.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -162,5 +162,65 @@ describe('AIC adapter normalization', () => {
     expect(result.status).toBe('rejected');
     if (result.status !== 'rejected') return;
     expect(result.rejection.reason).toContain('strict default reject');
+  });
+});
+
+describe('AIC search query construction (#28)', () => {
+  // Capture the URL passed to fetch without making a live call. AIC proxies
+  // the `query[...]` params straight into Elasticsearch, so the exact param
+  // shape is what the bug is about: two sibling clauses in one query object
+  // (`query[term]` + `query[exists]`) is invalid ES and AIC returns HTTP 400.
+  // The clauses must be combined under a single `bool/must` array instead.
+  function stubFetchCapturingUrl(): { urls: string[] } {
+    const urls: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: string | URL) => {
+        urls.push(input.toString());
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ data: [{ id: 11 }] }),
+        } as Response;
+      }),
+    );
+    return { urls };
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('combines the rights and image filters under a single bool/must array', async () => {
+    const cap = stubFetchCapturingUrl();
+    await aicFetcher.search('Hopper Nighthawks', 3, { hasImage: true });
+    const params = new URL(cap.urls[0]).searchParams;
+
+    // The bug shape: two sibling query clauses. Neither may appear.
+    expect(params.has('query[term][is_public_domain]')).toBe(false);
+    expect(params.has('query[exists][field]')).toBe(false);
+
+    // The fix shape: a bool/must array carrying both clauses.
+    expect(params.get('query[bool][must][0][term][is_public_domain]')).toBe('true');
+    expect(params.get('query[bool][must][1][exists][field]')).toBe('image_id');
+
+    // Free-text query and field projection are unchanged.
+    expect(params.get('q')).toBe('Hopper Nighthawks');
+    expect(params.get('fields')).toBe('id');
+  });
+
+  it('omits the image-exists clause when hasImage is false', async () => {
+    const cap = stubFetchCapturingUrl();
+    await aicFetcher.search('Monet', 5, { hasImage: false });
+    const params = new URL(cap.urls[0]).searchParams;
+
+    expect(params.get('query[bool][must][0][term][is_public_domain]')).toBe('true');
+    expect(params.has('query[bool][must][1][exists][field]')).toBe(false);
+  });
+
+  it('maps numeric response ids to aic:-prefixed strings', async () => {
+    stubFetchCapturingUrl();
+    const ids = await aicFetcher.search('Monet', 3, {});
+    expect(ids).toEqual(['aic:11']);
   });
 });


### PR DESCRIPTION
## Summary

AIC `search` returned **HTTP 400** whenever both the rights filter (`query[term][is_public_domain]`) and the image filter (`query[exists][field]`) were set. AIC proxies the `query[...]` params straight into Elasticsearch, and two sibling clauses in one query object is invalid ES:

```
[term] malformed query, expected [END_OBJECT] but found [FIELD_NAME]
```

**Root cause is the clause combination, not multi-word queries** (the issue's first guess). Reproduced live:

| Query | Filters | Result |
|---|---|---|
| `Hopper Nighthawks` | term + exists | 400 |
| `Hopper` (single word) | term + exists | **400** |
| `Hopper Nighthawks` | term only | 200 |
| `Hopper Nighthawks` | exists only | 200 |

So multi-word vs single-word is irrelevant; some calls worked only because `hasImage:false` sets the `term` clause alone.

## Fix

Wrap both clauses in a single `bool/must` array, which is valid ES and which AIC accepts:

```
query[bool][must][0][term][is_public_domain]=true
query[bool][must][1][exists][field]=image_id
```

Verified live that search relevance is unchanged (identical top-5 for `q=Monet`) and the image filter still applies.

## Test Plan

- [x] New `search()` URL-construction tests (fetch stubbed, no live calls): assert the `bool/must` shape, that the old sibling clauses are gone, and the `hasImage:false` path
- [x] `npx vitest run` — 206 passing
- [x] `tscq --noEmit` clean
- [x] Live end-to-end through the real adapter: the two queries from the issue (`Hopper Nighthawks`, `Caillebotte Paris Street Rainy`) now return records instead of 400

Co-Authored by Pramod Prasanth <pramod@chainalign.com>