### PR TITLE
refactor: extract reusable federation core (open-museum-mcp/core)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] — 2026-06-02
+
+### Added
+
+- **Reusable federation core, published at the `open-museum-mcp/core` subpath.** The engine (fetchers, license gate, date parser, citation, and the search/get/cite orchestration) is now a transport-agnostic `createFederation({ fetchers, cache })` factory in `src/core/`, free of `node:sqlite` and the MCP SDK so it runs on non-Node runtimes (e.g. Cloudflare Workers). The cache is injected via a small `CacheStore` interface (synchronous or async), letting the MCP server keep its `node:sqlite` cache while other front doors supply their own (KV, etc.). Rights-gate enforcement is unchanged and lives inside each fetcher's `normalize`, so no rejected record reaches the cache or a caller regardless of front door.
+
+### Changed
+
+- **`server.ts` is now a thin MCP wrapper over the core.** Behaviour is identical (same tools, same outputs, same strict-default-deny gate); the search/get/cite logic moved into `createFederation`. The previously untestable search pipeline is now unit-tested directly with a fake cache and fake fetchers.
+
 ## [0.5.0] — 2026-04-27
 
 ### Changed (breaking — runtime requirement)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,8 +10,8 @@ authors:
 repository-code: "https://github.com/cfpramod/open-museum-mcp"
 url: "https://github.com/cfpramod/open-museum-mcp"
 license: MIT
-version: 0.5.0
-date-released: "2026-04-27"
+version: 0.6.0
+date-released: "2026-06-02"
 keywords:
   - mcp
   - model-context-protocol

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "open-museum-mcp",
   "display_name": "Open Museum",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "License-verified federated search across open-access museum collections.",
   "long_description": "Federated MCP search across major open-access museum collections — currently The Met, Cleveland Museum of Art, Art Institute of Chicago, Wikimedia Commons, and Europeana, with more being added. Records pass per-museum rights verification (strict-default-deny on ambiguous license signals) and ship with citation output in `full`, `caption`, and `short` formats — paste-ready for papers, slide decks, and inline references.",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,16 @@
 {
   "name": "open-museum-mcp",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "MCP server for license-verified search across open-access museum collections (The Met, Cleveland, AIC, Wikimedia Commons, Europeana).",
   "type": "module",
   "main": "dist/server.js",
+  "exports": {
+    ".": "./dist/server.js",
+    "./core": {
+      "types": "./dist/core/index.d.ts",
+      "default": "./dist/core/index.js"
+    }
+  },
   "bin": {
     "open-museum-mcp": "dist/server.js"
   },

--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -1,0 +1,22 @@
+import type { Artwork } from '../types.js';
+
+/** A value that may be returned synchronously or as a promise. */
+export type Awaitable<T> = T | Promise<T>;
+
+/**
+ * The minimal cache surface the federation engine depends on. Two methods for
+ * normalized objects, two for search-result ID lists.
+ *
+ * Implementations may be synchronous or asynchronous: the MCP server's
+ * `node:sqlite` cache returns values directly, while an edge deployment
+ * (e.g. Cloudflare KV) returns promises. The federation `await`s every call,
+ * so both satisfy this interface. Keeping the surface this small is what lets
+ * the same engine run on a stdio server and on a Workers runtime that cannot
+ * load `node:sqlite`.
+ */
+export interface CacheStore {
+  getObject(id: string): Awaitable<Artwork | null>;
+  upsertObject(art: Artwork): Awaitable<void>;
+  getQuery(cacheKey: string): Awaitable<string[] | null>;
+  putQuery(cacheKey: string, ids: string[]): Awaitable<void>;
+}

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -1,0 +1,201 @@
+import { z } from 'zod';
+import { cite as citeArtwork, type CiteStyle } from '../cite.js';
+import { dedupeWikimediaUploads } from '../dedupe.js';
+import type { Fetcher } from '../fetchers/types.js';
+import type { Artwork } from '../types.js';
+import { filterByYearRange } from '../yearFilter.js';
+import type { CacheStore } from './cache.js';
+
+// Museum IDs follow `<code>:<segment>(/<segment>)*`. Each segment is
+// alphanumeric, underscore, or hyphen. The four numeric-ID museums (Met,
+// Cleveland, AIC, Wikimedia) match a single all-digit segment; Europeana's
+// hierarchical IDs (`9200338/BibliographicResource_3000093834108`) match
+// multiple slash-separated segments. The negative lookahead blocks `..`
+// path-traversal attempts cleanly.
+export const ID_REGEX = /^[a-z]+:(?!.*\.\.)[A-Za-z0-9_-]+(?:\/[A-Za-z0-9_-]+)*$/;
+
+// Cap concurrent fetches to one museum's API. The Met has no batch endpoint,
+// so a search of limit 50 fans out into up to 50 object fetches; without a
+// cap, we'd hammer the upstream and risk rate-limit errors. 8 is empirically
+// gentle and keeps wall-clock time within the same order of magnitude.
+const DEFAULT_FETCH_CONCURRENCY = 8;
+
+/**
+ * Parsed parameters for a federation search. Shared by every front door (MCP
+ * tool, HTTP endpoint) so validation lives in one place. The date bounds gate
+ * the *result set*, not the upstream search call — each museum's free-text
+ * search runs unchanged, and records whose [yearStart, yearEnd] fall outside
+ * the window are dropped after the fact. BCE is a negative integer.
+ */
+export const SearchParamsSchema = z.object({
+  query: z.string().min(1),
+  museum: z.string().optional(),
+  has_image: z.boolean().default(true),
+  limit: z.number().int().min(1).max(50).default(10),
+  year_min: z.number().int().optional(),
+  year_max: z.number().int().optional(),
+});
+export type SearchParams = z.infer<typeof SearchParamsSchema>;
+
+export interface SearchResult {
+  count: number;
+  results: Artwork[];
+}
+
+export type FetchOutcome =
+  | { ok: true; artwork: Artwork }
+  | { ok: false; reason: string };
+
+export type CiteOutcome =
+  | { ok: true; citation: string }
+  | { ok: false; reason: string };
+
+/**
+ * Thrown when a search or lookup names a museum code that is not in the
+ * registry. Hosts catch this to render their own error shape (MCP error
+ * result, HTTP 400, etc.) rather than leaking an empty result set.
+ */
+export class UnknownMuseumError extends Error {
+  constructor(public readonly museum: string) {
+    super(`unknown museum: ${museum}`);
+    this.name = 'UnknownMuseumError';
+  }
+}
+
+export interface FederationOptions {
+  fetchers: Record<string, Fetcher>;
+  cache: CacheStore;
+  /** Override the per-museum fetch concurrency cap (default 8). */
+  concurrency?: number;
+  /**
+   * Invoked when a fetched record is rejected by its rights gate. Rejections
+   * are expected — strict-default-deny is the project's spine — so this is a
+   * diagnostic hook, not an error path. The MCP server logs to stderr here.
+   */
+  onReject?: (id: string, reason: string) => void;
+}
+
+export interface Federation {
+  readonly fetchers: Record<string, Fetcher>;
+  search(params: SearchParams): Promise<SearchResult>;
+  getArtwork(id: string): Promise<FetchOutcome>;
+  cite(id: string, style: CiteStyle): Promise<CiteOutcome>;
+}
+
+async function withConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const idx = next++;
+      if (idx >= items.length) return;
+      results[idx] = await fn(items[idx]);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+// The cache key includes the overfetch count, not the user-facing `limit`.
+// That means limit:5 and limit:6 produce different keys (since 5*2=10 vs
+// 6*2=12). The trade-off: more cache rows, but each row is guaranteed to
+// hold enough IDs to satisfy a request at its overfetch tier even after
+// rights-gate rejections. Bucketing would need explicit refill logic.
+function searchCacheKey(
+  query: string,
+  museum: string | undefined,
+  hasImage: boolean,
+  overFetch: number,
+): string {
+  return JSON.stringify({ q: query, m: museum ?? '*', hi: hasImage, of: overFetch });
+}
+
+/**
+ * Build a federation over a set of museum fetchers and a cache. This is the
+ * shared engine behind every front door: the MCP server wraps it for stdio
+ * JSON-RPC; an HTTP service wraps it for the web. All rights-gate enforcement
+ * lives in `fetcher.normalize`, so a rejected record never reaches the cache
+ * or a caller — regardless of which front door asked.
+ */
+export function createFederation(opts: FederationOptions): Federation {
+  const { fetchers, cache } = opts;
+  const concurrency = opts.concurrency ?? DEFAULT_FETCH_CONCURRENCY;
+  const onReject = opts.onReject;
+
+  async function getArtwork(id: string): Promise<FetchOutcome> {
+    if (!ID_REGEX.test(id)) {
+      return { ok: false, reason: `invalid artwork id: ${id}` };
+    }
+
+    const cached = await cache.getObject(id);
+    if (cached) return { ok: true, artwork: cached };
+
+    // ID_REGEX guarantees a non-empty `[a-z]+` segment before ':'.
+    const code = id.slice(0, id.indexOf(':'));
+    const fetcher = fetchers[code];
+    if (!fetcher) return { ok: false, reason: `unknown museum code: ${code}` };
+
+    const raw = await fetcher.getRaw(id);
+    const result = fetcher.normalize(raw);
+    if (result.status === 'rejected') {
+      onReject?.(id, result.rejection.reason);
+      return { ok: false, reason: result.rejection.reason };
+    }
+
+    await cache.upsertObject(result.artwork);
+    return { ok: true, artwork: result.artwork };
+  }
+
+  async function search(params: SearchParams): Promise<SearchResult> {
+    const fetcherList = params.museum
+      ? fetchers[params.museum]
+        ? [fetchers[params.museum]]
+        : []
+      : Object.values(fetchers);
+    if (fetcherList.length === 0) {
+      throw new UnknownMuseumError(params.museum ?? '');
+    }
+
+    const overFetch = params.has_image ? params.limit * 2 : params.limit;
+    const cacheKey = searchCacheKey(params.query, params.museum, params.has_image, overFetch);
+
+    let allIds = await cache.getQuery(cacheKey);
+    if (!allIds) {
+      const idLists = await Promise.all(
+        fetcherList.map((f) =>
+          f.search(params.query, overFetch, { hasImage: params.has_image }).catch(() => [] as string[]),
+        ),
+      );
+      allIds = idLists.flat();
+      await cache.putQuery(cacheKey, allIds);
+    }
+
+    const fetched = await withConcurrency(allIds, concurrency, (id) =>
+      getArtwork(id).catch((err: unknown) => ({
+        ok: false as const,
+        reason: err instanceof Error ? err.message : 'fetch failed',
+      })),
+    );
+    const accepted: Artwork[] = fetched
+      .filter((r): r is { ok: true; artwork: Artwork } => r.ok)
+      .map((r) => r.artwork);
+    const filtered = accepted.filter((a) => !params.has_image || Boolean(a.imageUrls.full));
+    const deduped = dedupeWikimediaUploads(filtered);
+    const dated = filterByYearRange(deduped, params.year_min, params.year_max);
+    const results = dated.slice(0, params.limit);
+
+    return { count: results.length, results };
+  }
+
+  async function cite(id: string, style: CiteStyle): Promise<CiteOutcome> {
+    const out = await getArtwork(id);
+    if (!out.ok) return { ok: false, reason: out.reason };
+    return { ok: true, citation: citeArtwork(out.artwork, style) };
+  }
+
+  return { fetchers, search, getArtwork, cite };
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Public entry point for the federation engine — the shared core behind both
+ * the MCP server and any HTTP/edge front door. It carries no transport and no
+ * storage: callers inject a {@link CacheStore} and a set of {@link Fetcher}s,
+ * and get back a {@link Federation} whose every result has already passed the
+ * per-museum rights gate. Deliberately free of `node:sqlite` and the MCP SDK
+ * so it runs unchanged on a Cloudflare Workers runtime.
+ */
+export {
+  createFederation,
+  SearchParamsSchema,
+  ID_REGEX,
+  UnknownMuseumError,
+  type Federation,
+  type FederationOptions,
+  type SearchParams,
+  type SearchResult,
+  type FetchOutcome,
+  type CiteOutcome,
+} from './federation.js';
+
+export type { CacheStore, Awaitable } from './cache.js';
+
+// Pure helpers a front door commonly needs alongside the federation.
+export { cite, type CiteStyle } from '../cite.js';
+export type { Artwork, ArtworkImages, ArtworkSource, ArtworkLicense, ValidationResult } from '../types.js';
+export type { Fetcher, SearchOptions } from '../fetchers/types.js';
+
+// Built-in museum fetchers, so a host can assemble its own registry (and
+// decide which to enable based on available API keys).
+export { metFetcher } from '../fetchers/met.js';
+export { clevelandFetcher } from '../fetchers/cleveland.js';
+export { aicFetcher } from '../fetchers/aic.js';
+export { wikimediaFetcher } from '../fetchers/wikimedia.js';
+export { europeanaFetcher } from '../fetchers/europeana.js';

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,9 +11,14 @@ import dotenv from 'dotenv';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { z } from 'zod';
-import { cite, type CiteStyle } from './cite.js';
+import {
+  createFederation,
+  ID_REGEX,
+  SearchParamsSchema,
+  UnknownMuseumError,
+  type CiteStyle,
+} from './core/index.js';
 import { Cache } from './db.js';
-import { dedupeWikimediaUploads } from './dedupe.js';
 import { buildSeedQueryFromConstraints } from './discoverSeed.js';
 import { aicFetcher } from './fetchers/aic.js';
 import { clevelandFetcher } from './fetchers/cleveland.js';
@@ -21,8 +26,6 @@ import { europeanaFetcher } from './fetchers/europeana.js';
 import { metFetcher } from './fetchers/met.js';
 import { wikimediaFetcher } from './fetchers/wikimedia.js';
 import type { Fetcher } from './fetchers/types.js';
-import type { Artwork } from './types.js';
-import { filterByYearRange } from './yearFilter.js';
 
 // Load env vars before reading any keys. Cwd `.env` (developer flow) wins
 // over `~/.open-museum-mcp/.env` (production / MCP-client-launched flow);
@@ -54,50 +57,16 @@ if (process.env.EUROPEANA_API_KEY) {
 const CACHE_PATH = process.env.OMM_CACHE_PATH ?? join(homedir(), '.open-museum-mcp', 'cache.db');
 const cache = new Cache({ path: CACHE_PATH });
 
-// Museum IDs follow `<code>:<segment>(/<segment>)*`. Each segment is
-// alphanumeric, underscore, or hyphen. The four numeric-ID museums (Met,
-// Cleveland, AIC, Wikimedia) match a single all-digit segment; Europeana's
-// hierarchical IDs (`9200338/BibliographicResource_3000093834108`) match
-// multiple slash-separated segments. The negative lookahead blocks `..`
-// path-traversal attempts cleanly.
-const ID_REGEX = /^[a-z]+:(?!.*\.\.)[A-Za-z0-9_-]+(?:\/[A-Za-z0-9_-]+)*$/;
-
-// Cap concurrent fetches to one museum's API. The Met has no batch endpoint,
-// so a search of limit 50 fans out into up to 50 object fetches; without a
-// cap, we'd hammer the upstream and risk rate-limit errors. 8 is empirically
-// gentle and keeps wall-clock time within the same order of magnitude.
-const FETCH_CONCURRENCY = 8;
-
-async function withConcurrency<T, R>(
-  items: T[],
-  limit: number,
-  fn: (item: T) => Promise<R>,
-): Promise<R[]> {
-  const results = new Array<R>(items.length);
-  let next = 0;
-  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
-    while (true) {
-      const idx = next++;
-      if (idx >= items.length) return;
-      results[idx] = await fn(items[idx]);
-    }
-  });
-  await Promise.all(workers);
-  return results;
-}
-
-const SearchInput = z.object({
-  query: z.string().min(1),
-  museum: z.string().optional(),
-  has_image: z.boolean().default(true),
-  limit: z.number().int().min(1).max(50).default(10),
-  // Optional date-range constraint. Either bound may be omitted. BCE is
-  // expressed as a negative integer (e.g. year_min: -500 for 500 BCE).
-  // The bounds gate the *result set*, not the upstream search call —
-  // each museum's free-text search runs unchanged, and we drop accepted
-  // records whose [yearStart, yearEnd] falls outside the window.
-  year_min: z.number().int().optional(),
-  year_max: z.number().int().optional(),
+// The federation engine is transport-agnostic. The MCP server is one front
+// door over it (stdio JSON-RPC); the web app is another (HTTP + KV cache).
+// Rejections are logged to stderr — stdout is the MCP protocol channel — so
+// operators can diagnose "why did my search return fewer results than
+// expected?". The strict-default-deny gate lives inside each fetcher's
+// `normalize`, so no rejected record ever reaches the cache or the wire.
+const federation = createFederation({
+  fetchers: FETCHERS,
+  cache,
+  onReject: (id, reason) => console.error(`[open-museum-mcp] rejected ${id}: ${reason}`),
 });
 
 const GetInput = z.object({
@@ -116,35 +85,8 @@ const DiscoverInput = z.object({
   museum: z.string().min(1).optional(),
 });
 
-async function fetchAndCache(id: string): Promise<{ ok: true; artwork: Artwork } | { ok: false; reason: string }> {
-  if (!ID_REGEX.test(id)) {
-    return { ok: false, reason: `invalid artwork id: ${id}` };
-  }
-
-  const cached = cache.getObject(id);
-  if (cached) return { ok: true, artwork: cached };
-
-  // ID_REGEX guarantees a non-empty `[a-z]+` segment before ':'.
-  const code = id.slice(0, id.indexOf(':'));
-  const fetcher = FETCHERS[code];
-  if (!fetcher) return { ok: false, reason: `unknown museum code: ${code}` };
-
-  const raw = await fetcher.getRaw(id);
-  const result = fetcher.normalize(raw);
-  if (result.status === 'rejected') {
-    // Rejections are expected — strict-default-deny is the project's spine.
-    // Log to stderr (stdout is the MCP protocol channel) so operators can
-    // diagnose "why did my search return fewer results than expected?".
-    console.error(`[open-museum-mcp] rejected ${id}: ${result.rejection.reason}`);
-    return { ok: false, reason: result.rejection.reason };
-  }
-
-  cache.upsertObject(result.artwork);
-  return { ok: true, artwork: result.artwork };
-}
-
 const server = new Server(
-  { name: 'open-museum-mcp', version: '0.5.0' },
+  { name: 'open-museum-mcp', version: '0.6.0' },
   {
     capabilities: {
       tools: {},
@@ -259,74 +201,38 @@ function errorResult(message: string) {
   return { content: [{ type: 'text' as const, text: message }], isError: true };
 }
 
-// The cache key includes the overfetch count, not the user-facing `limit`.
-// That means limit:5 and limit:6 produce different keys (since 5*2=10 vs
-// 6*2=12). The trade-off: more cache rows, but each row is guaranteed to
-// hold enough IDs to satisfy a request at its overfetch tier even after
-// rights-gate rejections. Bucketing would need explicit refill logic.
-function searchCacheKey(query: string, museum: string | undefined, hasImage: boolean, overFetch: number): string {
-  return JSON.stringify({ q: query, m: museum ?? '*', hi: hasImage, of: overFetch });
-}
-
 async function handleSearch(args: unknown) {
-  const input = SearchInput.parse(args);
-  const fetchers = input.museum
-    ? (FETCHERS[input.museum] ? [FETCHERS[input.museum]] : [])
-    : Object.values(FETCHERS);
-  if (fetchers.length === 0) {
-    return errorResult(`unknown museum: ${input.museum}`);
+  const params = SearchParamsSchema.parse(args);
+  try {
+    const result = await federation.search(params);
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(result, null, 2),
+        },
+      ],
+    };
+  } catch (err) {
+    if (err instanceof UnknownMuseumError) {
+      return errorResult(`unknown museum: ${err.museum}`);
+    }
+    throw err;
   }
-
-  const overFetch = input.has_image ? input.limit * 2 : input.limit;
-  const cacheKey = searchCacheKey(input.query, input.museum, input.has_image, overFetch);
-
-  let allIds = cache.getQuery(cacheKey);
-  if (!allIds) {
-    const idLists = await Promise.all(
-      fetchers.map((f) =>
-        f.search(input.query, overFetch, { hasImage: input.has_image }).catch(() => [] as string[]),
-      ),
-    );
-    allIds = idLists.flat();
-    cache.putQuery(cacheKey, allIds);
-  }
-
-  const fetched = await withConcurrency(allIds, FETCH_CONCURRENCY, (id) =>
-    fetchAndCache(id).catch((err: unknown) => ({
-      ok: false as const,
-      reason: err instanceof Error ? err.message : 'fetch failed',
-    })),
-  );
-  const accepted: Artwork[] = fetched
-    .filter((r): r is { ok: true; artwork: Artwork } => r.ok)
-    .map((r) => r.artwork);
-  const filtered = accepted.filter((a) => !input.has_image || Boolean(a.imageUrls.full));
-  const deduped = dedupeWikimediaUploads(filtered);
-  const dated = filterByYearRange(deduped, input.year_min, input.year_max);
-  const results = dated.slice(0, input.limit);
-
-  return {
-    content: [
-      {
-        type: 'text' as const,
-        text: JSON.stringify({ count: results.length, results }, null, 2),
-      },
-    ],
-  };
 }
 
 async function handleGet(args: unknown) {
   const input = GetInput.parse(args);
-  const out = await fetchAndCache(input.id);
+  const out = await federation.getArtwork(input.id);
   if (!out.ok) return errorResult(out.reason);
   return { content: [{ type: 'text' as const, text: JSON.stringify(out.artwork, null, 2) }] };
 }
 
 async function handleCite(args: unknown) {
   const input = CiteInput.parse(args);
-  const out = await fetchAndCache(input.id);
+  const out = await federation.cite(input.id, input.style as CiteStyle);
   if (!out.ok) return errorResult(out.reason);
-  return { content: [{ type: 'text' as const, text: cite(out.artwork, input.style as CiteStyle) }] };
+  return { content: [{ type: 'text' as const, text: out.citation }] };
 }
 
 async function handleDiscoverRandom(args: unknown) {
@@ -417,7 +323,7 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
   if (!ID_REGEX.test(id)) {
     throw new Error(`invalid museum URI: ${uri} (id must match ${ID_REGEX})`);
   }
-  const out = await fetchAndCache(id);
+  const out = await federation.getArtwork(id);
   if (!out.ok) {
     throw new Error(`cannot resolve ${uri}: ${out.reason}`);
   }

--- a/tests/federation.test.ts
+++ b/tests/federation.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createFederation, UnknownMuseumError } from '../src/core/index.js';
+import type { CacheStore } from '../src/core/index.js';
+import type { Fetcher } from '../src/fetchers/types.js';
+import type { Artwork, ValidationResult } from '../src/types.js';
+
+function makeArtwork(id: string, over: Partial<Artwork> = {}): Artwork {
+  const code = id.slice(0, id.indexOf(':'));
+  return {
+    id,
+    museum: { code, name: code.toUpperCase(), url: `https://${code}.example` },
+    title: `Work ${id}`,
+    artist: { name: 'Anon', attributionType: 'named' },
+    displayDate: '1700',
+    yearStart: 1700,
+    yearEnd: 1700,
+    medium: 'oil',
+    region: null,
+    period: null,
+    imageUrls: { full: `https://img.example/${id}.jpg` },
+    imageOpenAccess: true,
+    metadataOpenAccess: true,
+    license: {
+      type: 'CC0',
+      rawValue: 'true',
+      verificationSource: `${code}.test`,
+      verifiedAt: '2026-01-01T00:00:00.000Z',
+      confidence: 'high',
+    },
+    source: { apiUrl: `https://${code}.example/api/${id}`, pageUrl: `https://${code}.example/${id}` },
+    ...over,
+  };
+}
+
+function memoryCache() {
+  const objects = new Map<string, Artwork>();
+  const queries = new Map<string, string[]>();
+  const store: CacheStore = {
+    getObject: (id) => objects.get(id) ?? null,
+    upsertObject: (a) => {
+      objects.set(a.id, a);
+    },
+    getQuery: (k) => queries.get(k) ?? null,
+    putQuery: (k, ids) => {
+      queries.set(k, ids);
+    },
+  };
+  return { store, objects, queries };
+}
+
+interface FakeConfig {
+  /** IDs returned by search (the overfetch candidate list). */
+  ids: string[];
+  /** IDs the rights gate accepts; everything else is rejected. */
+  accept: Set<string>;
+  /** Accepted IDs that carry no image (empty `imageUrls.full`). */
+  imageless?: Set<string>;
+  /** Per-id Artwork overrides (e.g. to set yearStart for the date filter). */
+  over?: Record<string, Partial<Artwork>>;
+}
+
+function fakeFetcher(code: string, config: FakeConfig) {
+  let searchCalls = 0;
+  const fetcher: Fetcher = {
+    code,
+    name: code.toUpperCase(),
+    async search() {
+      searchCalls++;
+      return config.ids;
+    },
+    async getRaw(id: string) {
+      return { id };
+    },
+    normalize(raw: unknown): ValidationResult {
+      const id = (raw as { id: string }).id;
+      if (!config.accept.has(id)) {
+        return { status: 'rejected', rejection: { id, museumCode: code, reason: `${code}: not open`, rawSnapshot: raw } };
+      }
+      const over = { ...(config.over?.[id] ?? {}) };
+      if (config.imageless?.has(id)) over.imageUrls = { full: '' };
+      return { status: 'accepted', artwork: makeArtwork(id, over) };
+    },
+  };
+  return { fetcher, get searchCalls() { return searchCalls; } };
+}
+
+describe('createFederation.search', () => {
+  it('overfetches, drops rights-gate rejections, and slices to limit', async () => {
+    // limit 2, has_image true -> overFetch 4. Four candidates, one rejected.
+    const t = fakeFetcher('test', {
+      ids: ['test:1', 'test:2', 'test:3', 'test:4'],
+      accept: new Set(['test:1', 'test:2', 'test:3']),
+    });
+    const { store } = memoryCache();
+    const fed = createFederation({ fetchers: { test: t.fetcher }, cache: store });
+
+    const out = await fed.search({ query: 'x', has_image: true, limit: 2 });
+    expect(out.count).toBe(2);
+    expect(out.results.map((r) => r.id)).toEqual(['test:1', 'test:2']);
+  });
+
+  it('reuses the cached id list on a second identical search (no second fetcher.search)', async () => {
+    const t = fakeFetcher('test', { ids: ['test:1', 'test:2'], accept: new Set(['test:1', 'test:2']) });
+    const { store } = memoryCache();
+    const fed = createFederation({ fetchers: { test: t.fetcher }, cache: store });
+
+    await fed.search({ query: 'x', has_image: true, limit: 1 });
+    await fed.search({ query: 'x', has_image: true, limit: 1 });
+    expect(t.searchCalls).toBe(1);
+  });
+
+  it('excludes image-less records when has_image is true', async () => {
+    const t = fakeFetcher('test', {
+      ids: ['test:1', 'test:2'],
+      accept: new Set(['test:1', 'test:2']),
+      imageless: new Set(['test:1']),
+    });
+    const { store } = memoryCache();
+    const fed = createFederation({ fetchers: { test: t.fetcher }, cache: store });
+
+    const out = await fed.search({ query: 'x', has_image: true, limit: 10 });
+    expect(out.results.map((r) => r.id)).toEqual(['test:2']);
+  });
+
+  it('applies the year-range filter to the result set', async () => {
+    const t = fakeFetcher('test', {
+      ids: ['test:1', 'test:2'],
+      accept: new Set(['test:1', 'test:2']),
+      over: {
+        'test:1': { yearStart: 1500, yearEnd: 1500 },
+        'test:2': { yearStart: 1900, yearEnd: 1900 },
+      },
+    });
+    const { store } = memoryCache();
+    const fed = createFederation({ fetchers: { test: t.fetcher }, cache: store });
+
+    const out = await fed.search({ query: 'x', has_image: true, limit: 10, year_min: 1800, year_max: 2000 });
+    expect(out.results.map((r) => r.id)).toEqual(['test:2']);
+  });
+
+  it('throws UnknownMuseumError for an unregistered museum code', async () => {
+    const t = fakeFetcher('test', { ids: [], accept: new Set() });
+    const { store } = memoryCache();
+    const fed = createFederation({ fetchers: { test: t.fetcher }, cache: store });
+
+    await expect(fed.search({ query: 'x', has_image: true, limit: 5, museum: 'nope' })).rejects.toBeInstanceOf(
+      UnknownMuseumError,
+    );
+  });
+});
+
+describe('createFederation.getArtwork', () => {
+  it('rejects a malformed id before any fetch', async () => {
+    const t = fakeFetcher('test', { ids: [], accept: new Set() });
+    const { store } = memoryCache();
+    const fed = createFederation({ fetchers: { test: t.fetcher }, cache: store });
+
+    const out = await fed.getArtwork('not a valid id');
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.reason).toContain('invalid artwork id');
+  });
+
+  it('does not cache rejected records and invokes onReject', async () => {
+    const t = fakeFetcher('test', { ids: ['test:9'], accept: new Set() });
+    const { store, objects } = memoryCache();
+    const onReject = vi.fn();
+    const fed = createFederation({ fetchers: { test: t.fetcher }, cache: store, onReject });
+
+    const out = await fed.getArtwork('test:9');
+    expect(out.ok).toBe(false);
+    expect(objects.has('test:9')).toBe(false);
+    expect(onReject).toHaveBeenCalledWith('test:9', expect.stringContaining('not open'));
+  });
+
+  it('caches an accepted record and serves the cache on the next call', async () => {
+    const t = fakeFetcher('test', { ids: ['test:1'], accept: new Set(['test:1']) });
+    const { store, objects } = memoryCache();
+    const fed = createFederation({ fetchers: { test: t.fetcher }, cache: store });
+
+    const first = await fed.getArtwork('test:1');
+    expect(first.ok).toBe(true);
+    expect(objects.has('test:1')).toBe(true);
+
+    const getRawSpy = vi.spyOn(t.fetcher, 'getRaw');
+    const second = await fed.getArtwork('test:1');
+    expect(second.ok).toBe(true);
+    expect(getRawSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('createFederation.cite', () => {
+  it('renders a citation for an accepted record and propagates rejection reasons', async () => {
+    const t = fakeFetcher('test', { ids: ['test:1'], accept: new Set(['test:1']) });
+    const { store } = memoryCache();
+    const fed = createFederation({ fetchers: { test: t.fetcher }, cache: store });
+
+    const ok = await fed.cite('test:1', 'short');
+    expect(ok.ok).toBe(true);
+    if (ok.ok) expect(ok.citation.length).toBeGreaterThan(0);
+
+    const bad = await fed.cite('test:404', 'short');
+    expect(bad.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of the open-museum.art web app: extract the engine so it can run outside the MCP server (e.g. on Cloudflare Workers) without duplicating the rights gate.

- Lifts the search / get / cite orchestration out of `server.ts` into a transport-agnostic **`createFederation({ fetchers, cache })`** factory in `src/core/`.
- The cache is injected via a small **`CacheStore`** interface (sync *or* async), so the MCP server keeps its `node:sqlite` cache while a web front door can supply a Cloudflare KV cache.
- The core imports **neither `node:sqlite` nor the MCP SDK**, so it loads on non-Node runtimes. Verified by loading the built `dist/core/index.js` directly.
- New **`open-museum-mcp/core`** subpath export (with emitted types).
- `server.ts` is now a thin MCP wrapper. Behaviour is unchanged — same tools, same outputs, same strict-default-deny gate (still enforced inside each fetcher's `normalize`, so no rejected record reaches the cache or the wire).

## Why

The web app needs to reuse the exact license gate the MCP server uses, on an edge runtime that can't load `node:sqlite`. Extracting a clean core (open) lets both the MCP server and the (separate, private) web app sit on one engine — no copy-paste of the rights logic, which is the project's trust anchor.

## Test Plan

- [x] `vitest run` — **215 pass** (206 preserved + 9 new federation unit tests with a fake cache + fake fetchers, covering overfetch, rights-gate rejection, image filter, year filter, query-cache reuse, unknown-museum error, and the cache write/read path)
- [x] `tsc --noEmit` clean
- [x] `npm run build` clean; `dist/core/` emits `.js` + `.d.ts`
- [x] Built `dist/core/index.js` loads with no eager `node:sqlite`/SDK import
- [x] Version bumped to 0.6.0 across package.json, manifest.json, CITATION.cff, CHANGELOG (per CONTRIBUTING Releasing checklist)

Co-Authored by Pramod Prasanth <pramod@chainalign.com>