### PR TITLE
feat: clearance_record tool + Clearance Manifest spec v0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] — 2026-06-05
+
+### Added
+
+- **`clearance_record` MCP tool — portable, fail-closed Clearance Manifests.** A new first-class tool emits a [Clearance Manifest](spec/clearance/v0.1/spec.md) for any artwork id: a machine-readable JSON-LD rights-clearance artifact carrying the work's provenance, citation, the rights determination, and an auditable trail of *how* that determination was reached, answering reuse questions ("may I print this and sell it?") as binary booleans. A non-cleared work — rejected by the rights gate, an unknown museum, or an invalid id — returns a definitive **deny** manifest, not an error: a deny is a valid answer. The payload is wrapped in a Tier-0 integrity envelope whose SHA-256 is computed over the RFC 8785 (JCS) canonicalization of the payload; the payload never holds its own hash.
+- **In-repo Clearance Manifest spec v0.1 (`spec/clearance/v0.1/`).** Authored against the permanent `openclearance.org` namespace: the normative `spec.md`, JSON Schema (Draft 2020-12), JSON-LD `context.jsonld`, the non-normative determination-rule registry (`rules.md`), the `unrecognised_rule` advisory schema, committed conformance examples, and a URL-stability `VERSIONING.md`. The schema is exercised by an ajv conformance suite over freshly-emitted accept and deny manifests.
+- **`Federation.clearanceManifest(id)` on the reusable core.** The clearance logic lives in a Workers-safe `src/core/clearance/` module (zero runtime dependencies, no `node:` imports, Web Crypto only), so non-Node front doors (e.g. the web app) can emit manifests too. The single license→clearance mapping table is the sole place determinations live, fail-closed by construction.
+
 ## [0.6.0] — 2026-06-02
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,8 +10,8 @@ authors:
 repository-code: "https://github.com/cfpramod/open-museum-mcp"
 url: "https://github.com/cfpramod/open-museum-mcp"
 license: MIT
-version: 0.6.0
-date-released: "2026-06-02"
+version: 0.7.0
+date-released: "2026-06-05"
 keywords:
   - mcp
   - model-context-protocol

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "open-museum-mcp",
   "display_name": "Open Museum",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "License-verified federated search across open-access museum collections.",
   "long_description": "Federated MCP search across major open-access museum collections — currently The Met, Cleveland Museum of Art, Art Institute of Chicago, Wikimedia Commons, and Europeana, with more being added. Records pass per-museum rights verification (strict-default-deny on ambiguous license signals) and ship with citation output in `full`, `caption`, and `short` formats — paste-ready for papers, slide decks, and inline references.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-museum-mcp",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-museum-mcp",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
@@ -18,6 +18,8 @@
       },
       "devDependencies": {
         "@types/node": "^25.6.0",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
         "tsx": "^4.19.2",
         "typescript": "^6.0.3",
         "vitest": "^4.1.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-museum-mcp",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-museum-mcp",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.0",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
     "tsx": "^4.19.2",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-museum-mcp",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "MCP server for license-verified search across open-access museum collections (The Met, Cleveland, AIC, Wikimedia Commons, Europeana).",
   "type": "module",
   "main": "dist/server.js",

--- a/spec/clearance/VERSIONING.md
+++ b/spec/clearance/VERSIONING.md
@@ -1,0 +1,77 @@
+# Versioning and URL stability
+
+This document is the public promise behind the Clearance Manifest's schema and
+context URLs. It explains how versions are numbered, what is guaranteed to stay
+stable, and how the canonical "latest" pointer works.
+
+## Semantic versioning at the spec level
+
+Clearance Manifest versions are `MAJOR.MINOR.PATCH`:
+
+- **PATCH** (e.g. v0.1.0 to v0.1.1): clarifications, new examples, additive
+  OPTIONAL fields, and other backward-compatible changes that no conforming
+  consumer needs to react to.
+- **MINOR** (e.g. a future `v0.x`): additive, backward-compatible vocabulary or
+  field changes — new optional fields and expanded recommended-rule baselines
+  that older validators can safely ignore. Requires a real use case and a public
+  review window.
+- **MAJOR** (e.g. an eventual `v1.0`): breaking changes. Requires demonstrated
+  implementation experience, broad review, and a migration story.
+
+A version's schema validates documents that declare that version (`specVersion`),
+but the `@context` IRI — not `specVersion` — is the normative authority for term
+expansion.
+
+## Permanent, immutable, stable URLs
+
+Every published version is served at a permanent URL and **never changes
+content**:
+
+```
+https://openclearance.org/v0.1/...
+```
+
+Once a version is published:
+
+- Its schema `$id`s, JSON-LD context, rule-registry ids, and document shapes are
+  **frozen**. We do not edit a published version in place. Corrections and
+  additions ship as a new version.
+- Its URLs stay live indefinitely. Breaking a published URL would break every
+  document, validator, and toolchain pinned to it, so we treat it as a trust
+  violation, not a maintenance decision.
+
+This is why the `$id` host was chosen deliberately and fixed before first
+publication: the base cannot move afterward without breaking the immutability
+promise. (The misspelling `clearence.org`, registered first by accident, is kept
+only as a 301 redirect typo-trap and is never a canonical base.)
+
+## Canonical = latest, with no redirects
+
+- **The documentation defaults to the newest version.** "Read the spec" points at
+  the current line (today, v0.1).
+- **Older version pages stay published** and link forward to the current line.
+  They are not removed and are supported indefinitely.
+- **No redirects from old to new.** A request for `v0.1/...` must keep resolving
+  to v0.1, because version-pinned tooling depends on it.
+
+## Deprecation
+
+Fields and recommended-rule ids may be deprecated but are not removed within a
+major version. Deprecations are called out in the spec prose and in JSON Schema
+`description` fields, with the version in which removal is planned.
+
+## Canonicalisation stability
+
+The Tier-0 integrity hash is computed over the **RFC 8785 (JCS)**
+canonicalization of the payload. JCS is a fixed, deterministic canonicalization;
+v0.1 introduces no spec-specific array sorting or pre-processing on top of it. Any
+future change to how the signed/hashed bytes are derived would change the
+integrity contract, so it MUST be introduced with an explicit
+canonicalisation-version marker or deferred to a major bump — never by silently
+changing the derivation.
+
+## Stability commitment
+
+- v0.1 is released and frozen; it remains valid and served indefinitely.
+- Within a major version, minor and patch releases are backward-compatible.
+- Anything breaking ships only under a new major version, with migration guidance.

--- a/spec/clearance/v0.1/advisory-entry.schema.json
+++ b/spec/clearance/v0.1/advisory-entry.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openclearance.org/v0.1/advisory-entry.schema.json",
+  "title": "Clearance Manifest AdvisoryEntry v0.1",
+  "description": "One element of the advisories[] array a conforming verifier emits alongside the structural pass/fail result. AdvisoryEntry objects are verifier output, not manifest fields: the ClearanceManifest schema intentionally has no advisories property. The separation encodes the design principle that structural validity (schema rejects) is independent of determination-rule recognition (verifier emits a non-fatal advisory).",
+  "type": "object",
+  "required": ["code", "severity", "message", "path"],
+  "additionalProperties": false,
+  "properties": {
+    "code": {
+      "type": "string",
+      "enum": ["unrecognised_rule"],
+      "description": "Stable machine-readable advisory code. unrecognised_rule: a well-formed basis.rule id that is not in the current rule-registry baseline. The manifest is still structurally valid."
+    },
+    "severity": {
+      "type": "string",
+      "const": "advisory",
+      "description": "Always 'advisory'. Non-fatal by construction; a document that triggers an advisory still passes structural validation."
+    },
+    "message": { "type": "string", "minLength": 1 },
+    "path": {
+      "type": "string",
+      "description": "Dotted path to the field that triggered the advisory (e.g. 'clearance.commercialReproduction.basis.rule'). Empty string for a document-level advisory."
+    },
+    "rule": {
+      "type": "string",
+      "description": "The specific rule id that triggered the advisory (for unrecognised_rule)."
+    }
+  }
+}

--- a/spec/clearance/v0.1/clearance-manifest.schema.json
+++ b/spec/clearance/v0.1/clearance-manifest.schema.json
@@ -1,0 +1,213 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openclearance.org/v0.1/clearance-manifest.schema.json",
+  "title": "Clearance Manifest v0.1",
+  "description": "A portable, fail-closed rights-clearance artifact for one creative work. The schema validates BOTH an accepted (cleared) and a rejected (deny) manifest: a deny is a valid answer, not an error, so descriptive sub-fields under work/source are optional and the deny path carries only what is recoverable from the rejection. Structural validity is independent of determination-rule recognition: an unrecognised basis.rule is structurally valid and yields a non-fatal 'unrecognised_rule' advisory at verification time, never a schema rejection. The @context URI is the sole normative authority for term expansion; specVersion is human-readable convenience only.",
+  "type": "object",
+  "required": ["@context", "type", "specVersion", "work", "source", "rights", "clearance", "verification"],
+  "additionalProperties": false,
+  "properties": {
+    "@context": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" },
+      "contains": { "const": "https://openclearance.org/v0.1/context.jsonld" },
+      "description": "JSON-LD context. MUST include the openclearance v0.1 context IRI — the sole normative authority for expansion and validation."
+    },
+    "type": { "const": "ClearanceManifest" },
+    "specVersion": {
+      "const": "0.1",
+      "description": "Human-readable version convenience. Not normative — the @context IRI fixes the actual vocabulary."
+    },
+    "work": {
+      "type": "object",
+      "required": ["id"],
+      "additionalProperties": false,
+      "description": "The work being cleared. Only `id` is guaranteed; descriptive fields are present on the accept path and absent on the deny path (a rejected record is not fully identified).",
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "title": { "type": "string" },
+        "artist": {
+          "type": "object",
+          "required": ["name", "attributionType"],
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string" },
+            "nationality": { "type": "string" },
+            "lifespan": { "type": "string", "description": "Display-form life dates (e.g. '1853–1890'); not a structured date." },
+            "attributionType": {
+              "type": "string",
+              "enum": ["named", "anonymous", "workshop", "after", "attributed", "circle", "follower"]
+            }
+          }
+        },
+        "displayDate": { "type": "string" },
+        "yearStart": { "type": ["integer", "null"], "description": "Machine-normalized start year; negative = BCE." },
+        "yearEnd": { "type": ["integer", "null"], "description": "Machine-normalized end year; negative = BCE." },
+        "medium": { "type": "string" }
+      }
+    },
+    "source": {
+      "type": "object",
+      "required": ["museum"],
+      "additionalProperties": false,
+      "description": "Provenance source. `museum` is guaranteed (its `code` is the federation identifier); URLs and images are present on the accept path.",
+      "properties": {
+        "museum": {
+          "type": "object",
+          "required": ["code"],
+          "additionalProperties": false,
+          "properties": {
+            "code": { "type": "string", "minLength": 1 },
+            "name": { "type": "string" },
+            "url": { "type": "string", "format": "uri" }
+          }
+        },
+        "apiUrl": { "type": "string", "format": "uri" },
+        "pageUrl": { "type": "string", "format": "uri" },
+        "originalUrl": { "type": "string", "format": "uri" },
+        "imageUrls": {
+          "type": "object",
+          "required": ["full"],
+          "additionalProperties": false,
+          "properties": {
+            "full": { "type": "string" },
+            "large": { "type": "string" },
+            "thumbnail": { "type": "string" },
+            "width": { "type": "integer" },
+            "height": { "type": "integer" },
+            "byteSize": { "type": "integer" }
+          }
+        }
+      }
+    },
+    "rights": {
+      "type": "object",
+      "required": ["statement", "sourceApiValue", "imageOpenAccess", "metadataOpenAccess", "confidence"],
+      "additionalProperties": false,
+      "description": "The rights determination carried (not adjudicated) by this manifest.",
+      "properties": {
+        "statement": {
+          "type": ["string", "null"],
+          "description": "Rights-statement URI (CC / rightsstatements.org). null on a deny — no positive open-rights statement applies."
+        },
+        "sourceApiValue": {
+          "type": ["object", "null"],
+          "required": ["field", "value"],
+          "additionalProperties": false,
+          "description": "Forensic link binding the raw museum API value to its field name. null on a deny.",
+          "properties": {
+            "field": { "type": "string", "minLength": 1 },
+            "value": {}
+          }
+        },
+        "imageOpenAccess": { "type": "boolean" },
+        "metadataOpenAccess": { "type": "boolean" },
+        "confidence": { "type": "string", "enum": ["high", "medium", "low"] }
+      }
+    },
+    "clearance": {
+      "type": "object",
+      "required": ["commercialReproduction", "derivatives", "attributionRequired"],
+      "additionalProperties": false,
+      "description": "The instant, machine-actionable answer. Each facet pairs a boolean with a structured basis.",
+      "properties": {
+        "commercialReproduction": { "$ref": "#/$defs/permitFacet" },
+        "derivatives": { "$ref": "#/$defs/permitFacet" },
+        "attributionRequired": { "$ref": "#/$defs/requireFacet" }
+      }
+    },
+    "verification": {
+      "type": "object",
+      "required": ["determinedBy", "tool", "determinedAt", "ruleContext", "determinationSource"],
+      "additionalProperties": false,
+      "description": "How the rights determination was reached, as an auditable event. Actor vs tool are distinct; on a deny the actor is the engine rights-gate, not the museum.",
+      "properties": {
+        "determinedBy": {
+          "type": "object",
+          "required": ["actor", "role"],
+          "additionalProperties": false,
+          "properties": {
+            "actor": { "type": "string", "minLength": 1 },
+            "role": { "type": "string", "minLength": 1 }
+          }
+        },
+        "tool": { "type": "string", "minLength": 1 },
+        "determinedAt": { "type": "string", "format": "date-time" },
+        "ruleContext": { "type": "string", "minLength": 1 },
+        "determinationSource": {
+          "type": "object",
+          "required": ["type", "retrievedAt"],
+          "additionalProperties": false,
+          "properties": {
+            "type": { "type": "string", "enum": ["api-field", "rights-gate-default"] },
+            "field": { "type": "string" },
+            "url": { "type": "string", "format": "uri" },
+            "retrievedAt": { "type": "string", "format": "date-time" }
+          }
+        }
+      }
+    },
+    "citation": {
+      "type": "object",
+      "required": ["full", "caption", "short"],
+      "additionalProperties": false,
+      "description": "Rendered attribution strings. Omitted for an unidentified rejected record.",
+      "properties": {
+        "full": { "type": "string", "minLength": 1 },
+        "caption": { "type": "string", "minLength": 1 },
+        "short": { "type": "string", "minLength": 1 }
+      }
+    },
+    "extensions": {
+      "type": "object",
+      "description": "Forward-compatible vendor escape hatch. Producers MAY carry namespaced extension data here; consumers MUST ignore terms they do not recognise."
+    }
+  },
+  "$defs": {
+    "basis": {
+      "type": "object",
+      "required": ["rule", "inputs", "summary"],
+      "additionalProperties": false,
+      "description": "The structured reasoning behind one clearance boolean. Shape is normative; rule ids are an open set (see the rule registry).",
+      "properties": {
+        "rule": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+          "description": "Bare kebab-case determination-rule id resolving to https://openclearance.org/v0.1/rules#<rule>. NOT a closed enum — an unrecognised id is valid and yields an 'unrecognised_rule' advisory."
+        },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["field", "value"],
+            "additionalProperties": false,
+            "properties": {
+              "field": { "type": "string", "minLength": 1 },
+              "value": {}
+            }
+          }
+        },
+        "summary": { "type": "string", "minLength": 1 }
+      }
+    },
+    "permitFacet": {
+      "type": "object",
+      "required": ["permitted", "basis"],
+      "additionalProperties": false,
+      "properties": {
+        "permitted": { "type": "boolean" },
+        "basis": { "$ref": "#/$defs/basis" }
+      }
+    },
+    "requireFacet": {
+      "type": "object",
+      "required": ["required", "basis"],
+      "additionalProperties": false,
+      "properties": {
+        "required": { "type": "boolean" },
+        "basis": { "$ref": "#/$defs/basis" }
+      }
+    }
+  }
+}

--- a/spec/clearance/v0.1/context.jsonld
+++ b/spec/clearance/v0.1/context.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "https://openclearance.org/v0.1/vocab#",
+    "oc": "https://openclearance.org/v0.1/vocab#",
+    "schema": "https://schema.org/",
+    "dcterms": "http://purl.org/dc/terms/",
+    "prov": "http://www.w3.org/ns/prov#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+    "ClearanceManifest": "oc:ClearanceManifest",
+    "type": "@type",
+    "specVersion": "oc:specVersion",
+    "extensions": "oc:extensions",
+
+    "work": "oc:work",
+    "id": "schema:identifier",
+    "title": "schema:name",
+    "artist": "schema:creator",
+    "name": "schema:name",
+    "nationality": "schema:nationality",
+    "lifespan": "oc:lifespan",
+    "attributionType": "oc:attributionType",
+    "displayDate": "schema:dateCreated",
+    "yearStart": { "@id": "oc:yearStart", "@type": "xsd:integer" },
+    "yearEnd": { "@id": "oc:yearEnd", "@type": "xsd:integer" },
+    "medium": "dcterms:medium",
+
+    "source": "oc:source",
+    "museum": "schema:provider",
+    "code": "schema:identifier",
+    "url": { "@id": "schema:url", "@type": "@id" },
+    "apiUrl": { "@id": "oc:apiUrl", "@type": "@id" },
+    "pageUrl": { "@id": "schema:url", "@type": "@id" },
+    "originalUrl": { "@id": "dcterms:source", "@type": "@id" },
+    "imageUrls": {
+      "@id": "schema:image",
+      "@context": {
+        "full": { "@id": "schema:contentUrl", "@type": "@id" },
+        "large": { "@id": "oc:largeImage", "@type": "@id" },
+        "thumbnail": { "@id": "schema:thumbnailUrl", "@type": "@id" },
+        "width": { "@id": "schema:width", "@type": "xsd:integer" },
+        "height": { "@id": "schema:height", "@type": "xsd:integer" },
+        "byteSize": { "@id": "schema:contentSize", "@type": "xsd:integer" }
+      }
+    },
+
+    "rights": "oc:rights",
+    "statement": { "@id": "schema:license", "@type": "@id" },
+    "sourceApiValue": "oc:sourceApiValue",
+    "field": "oc:field",
+    "value": "rdf:value",
+    "imageOpenAccess": { "@id": "oc:imageOpenAccess", "@type": "xsd:boolean" },
+    "metadataOpenAccess": { "@id": "oc:metadataOpenAccess", "@type": "xsd:boolean" },
+    "confidence": "oc:confidence",
+
+    "clearance": "oc:clearance",
+    "commercialReproduction": "oc:commercialReproduction",
+    "derivatives": "oc:derivatives",
+    "attributionRequired": "oc:attributionRequired",
+    "permitted": { "@id": "oc:permitted", "@type": "xsd:boolean" },
+    "required": { "@id": "oc:required", "@type": "xsd:boolean" },
+    "basis": "oc:basis",
+    "rule": "oc:rule",
+    "inputs": "oc:inputs",
+    "summary": "oc:summary",
+
+    "verification": "oc:verification",
+    "determinedBy": "prov:wasAttributedTo",
+    "actor": "prov:agent",
+    "role": "prov:hadRole",
+    "tool": "oc:tool",
+    "determinedAt": { "@id": "prov:generatedAtTime", "@type": "xsd:dateTime" },
+    "ruleContext": "oc:ruleContext",
+    "determinationSource": "prov:wasDerivedFrom",
+    "retrievedAt": { "@id": "oc:retrievedAt", "@type": "xsd:dateTime" },
+
+    "citation": {
+      "@id": "oc:citation",
+      "@context": {
+        "full": "dcterms:bibliographicCitation",
+        "caption": "oc:caption",
+        "short": "oc:short"
+      }
+    }
+  }
+}

--- a/spec/clearance/v0.1/examples/cc0-accepted.json
+++ b/spec/clearance/v0.1/examples/cc0-accepted.json
@@ -1,0 +1,107 @@
+{
+  "@context": [
+    "https://schema.org/",
+    "http://purl.org/dc/terms/",
+    "https://openclearance.org/v0.1/context.jsonld"
+  ],
+  "type": "ClearanceManifest",
+  "specVersion": "0.1",
+  "work": {
+    "id": "met:436535",
+    "title": "Wheat Field with Cypresses",
+    "artist": {
+      "name": "Vincent van Gogh",
+      "nationality": "Dutch",
+      "lifespan": "1853–1890",
+      "attributionType": "named"
+    },
+    "displayDate": "1889",
+    "yearStart": 1889,
+    "yearEnd": 1889,
+    "medium": "Oil on canvas"
+  },
+  "source": {
+    "museum": {
+      "code": "met",
+      "name": "The Metropolitan Museum of Art",
+      "url": "https://www.metmuseum.org"
+    },
+    "apiUrl": "https://collectionapi.metmuseum.org/public/collection/v1/objects/436535",
+    "pageUrl": "https://www.metmuseum.org/art/collection/search/436535",
+    "imageUrls": {
+      "full": "https://images.metmuseum.org/CRDImages/ep/original/DT1567.jpg",
+      "thumbnail": "https://images.metmuseum.org/CRDImages/ep/web-large/DT1567.jpg"
+    }
+  },
+  "rights": {
+    "statement": "https://creativecommons.org/publicdomain/zero/1.0/",
+    "sourceApiValue": {
+      "field": "isPublicDomain",
+      "value": "true"
+    },
+    "imageOpenAccess": true,
+    "metadataOpenAccess": true,
+    "confidence": "high"
+  },
+  "clearance": {
+    "commercialReproduction": {
+      "permitted": true,
+      "basis": {
+        "rule": "cc0-grants-commercial",
+        "inputs": [
+          {
+            "field": "license.type",
+            "value": "CC0"
+          }
+        ],
+        "summary": "CC0 public-domain dedication permits all uses, including commercial."
+      }
+    },
+    "derivatives": {
+      "permitted": true,
+      "basis": {
+        "rule": "cc0-grants-derivatives",
+        "inputs": [
+          {
+            "field": "license.type",
+            "value": "CC0"
+          }
+        ],
+        "summary": "CC0 public-domain dedication permits modification and derivative works."
+      }
+    },
+    "attributionRequired": {
+      "required": false,
+      "basis": {
+        "rule": "cc0-waives-attribution",
+        "inputs": [
+          {
+            "field": "license.type",
+            "value": "CC0"
+          }
+        ],
+        "summary": "CC0 public-domain dedication requires no attribution as a condition of reuse."
+      }
+    }
+  },
+  "verification": {
+    "determinedBy": {
+      "actor": "museum:met",
+      "role": "rights-source"
+    },
+    "tool": "open-museum-mcp@0.7.0 · met.isPublicDomain",
+    "determinedAt": "2026-06-04T09:15:00.000Z",
+    "ruleContext": "met.isPublicDomain='true' ⇒ CC0",
+    "determinationSource": {
+      "type": "api-field",
+      "field": "isPublicDomain",
+      "url": "https://collectionapi.metmuseum.org/public/collection/v1/objects/436535",
+      "retrievedAt": "2026-06-04T09:15:00.000Z"
+    }
+  },
+  "citation": {
+    "full": "Vincent van Gogh, Wheat Field with Cypresses. 1889. The Metropolitan Museum of Art. CC0. https://www.metmuseum.org/art/collection/search/436535.",
+    "caption": "Vincent van Gogh, Wheat Field with Cypresses, 1889. Oil on canvas. The Metropolitan Museum of Art, CC0. https://www.metmuseum.org/art/collection/search/436535",
+    "short": "Wheat Field with Cypresses (Vincent van Gogh, 1889)"
+  }
+}

--- a/spec/clearance/v0.1/examples/deny-unrecognized.json
+++ b/spec/clearance/v0.1/examples/deny-unrecognized.json
@@ -1,0 +1,78 @@
+{
+  "@context": [
+    "https://schema.org/",
+    "http://purl.org/dc/terms/",
+    "https://openclearance.org/v0.1/context.jsonld"
+  ],
+  "type": "ClearanceManifest",
+  "specVersion": "0.1",
+  "work": {
+    "id": "xyz:1"
+  },
+  "source": {
+    "museum": {
+      "code": "xyz"
+    }
+  },
+  "rights": {
+    "statement": null,
+    "sourceApiValue": null,
+    "imageOpenAccess": false,
+    "metadataOpenAccess": false,
+    "confidence": "low"
+  },
+  "clearance": {
+    "commercialReproduction": {
+      "permitted": false,
+      "basis": {
+        "rule": "default-deny",
+        "inputs": [
+          {
+            "field": "rejection.reason",
+            "value": "rights_status='Educational Use Only' (strict default reject)"
+          }
+        ],
+        "summary": "rights gate rejected 'xyz:1': rights_status='Educational Use Only' (strict default reject) ⇒ default deny"
+      }
+    },
+    "derivatives": {
+      "permitted": false,
+      "basis": {
+        "rule": "default-deny",
+        "inputs": [
+          {
+            "field": "rejection.reason",
+            "value": "rights_status='Educational Use Only' (strict default reject)"
+          }
+        ],
+        "summary": "rights gate rejected 'xyz:1': rights_status='Educational Use Only' (strict default reject) ⇒ default deny"
+      }
+    },
+    "attributionRequired": {
+      "required": false,
+      "basis": {
+        "rule": "default-deny",
+        "inputs": [
+          {
+            "field": "rejection.reason",
+            "value": "rights_status='Educational Use Only' (strict default reject)"
+          }
+        ],
+        "summary": "rights gate rejected 'xyz:1': rights_status='Educational Use Only' (strict default reject) ⇒ default deny"
+      }
+    }
+  },
+  "verification": {
+    "determinedBy": {
+      "actor": "engine:open-museum-mcp",
+      "role": "rights-gate"
+    },
+    "tool": "open-museum-mcp@0.7.0 · rights-gate",
+    "determinedAt": "2026-06-05T00:00:00.000Z",
+    "ruleContext": "strict default deny: rights_status='Educational Use Only' (strict default reject)",
+    "determinationSource": {
+      "type": "rights-gate-default",
+      "retrievedAt": "2026-06-05T00:00:00.000Z"
+    }
+  }
+}

--- a/spec/clearance/v0.1/rules.md
+++ b/spec/clearance/v0.1/rules.md
@@ -1,0 +1,103 @@
+# Clearance Manifest v0.1 rule registry (non-normative baseline)
+
+This is the v0.1 baseline of recognised **determination rules** for the `basis.rule` field
+defined in [`spec.md`](spec.md). It is **non-normative** and **deliberately conservative**: it
+lists the rules a v0.1-baseline clearance corpus is expected to recognise (the CC0 and Public
+Domain truth tables, plus the fail-closed default), not the full set a producer may emit.
+
+Every rule id is a bare kebab-case token that resolves as a fragment under this document's
+permanent URL:
+
+```
+https://openclearance.org/v0.1/rules#<rule-id>
+```
+
+For example, `cc0-grants-commercial` resolves to
+`https://openclearance.org/v0.1/rules#cc0-grants-commercial`.
+
+## What is normative and what is not
+
+The spec normatively defines only the **shape** of `basis`:
+
+```jsonc
+"basis": {
+  "rule":    "cc0-grants-commercial",          // string, required — a stable rule id
+  "inputs":  [{ "field": "license.type", "value": "CC0" }],  // array, required — the evidence
+  "summary": "CC0 public-domain dedication permits all uses, including commercial."  // required
+}
+```
+
+`rule`, `inputs`, and `summary` are all **required** — honesty-by-architecture. A determination
+that cannot name its rule, cite its inputs, and state its reasoning is not a valid determination.
+
+This registry — the *meaning* of each rule id and its truth-table outcome — is **not** part of the
+schema. The set of rule ids is **open, not a closed enum**:
+
+- A `basis.rule` whose id is listed below is a recognised v0.1-baseline determination.
+- A `basis.rule` whose id is **not** listed below is still a **structurally valid** Clearance
+  Manifest. A conforming verifier emits a non-fatal `unrecognised_rule` advisory (mirroring the
+  PIF `unrecognised_token` contract; see the advisory contract in [`spec.md`](spec.md)); it
+  **MUST NOT** reject the document for an unrecognised rule id.
+- This separation encodes the design principle that structural validity (schema rejects) is
+  independent of determination-rule recognition (verifier emits a non-fatal advisory).
+
+## How to read this list
+
+- **The registry grows by PR.** A new permissive-license truth table is a new set of rule ids
+  plus a test; it needs no schema change. Propose additions per the governance process.
+- **Rule ids are stable and immutable within a version.** Once published at
+  `https://openclearance.org/v0.1/rules`, a rule id's meaning is frozen. A corrected or expanded
+  truth table ships as a new spec version, never by editing a published rule in place. (See
+  [`../../../VERSIONING.md`](../../../VERSIONING.md) once authored.)
+- **Fail-closed is the contract.** Any license signal that is missing, ambiguous, or not on this
+  permissive list resolves to `default-deny`: every clearance boolean `false`, `confidence: low`,
+  and the failing value carried verbatim in `inputs`.
+
+---
+
+## CC0 — Creative Commons Zero (`https://creativecommons.org/publicdomain/zero/1.0/`)
+
+The rights holder has waived all copyright and related rights worldwide. All downstream uses are
+permitted; no attribution is legally required.
+
+| Rule id | Asserts | Keys on (`inputs`) | Outcome |
+|---|---|---|---|
+| `cc0-grants-commercial` | `clearance.commercialReproduction.permitted` | `license.type = CC0` | `true` |
+| `cc0-grants-derivatives` | `clearance.derivatives.permitted` | `license.type = CC0` | `true` |
+| `cc0-waives-attribution` | `clearance.attributionRequired.required` | `license.type = CC0` | `false` |
+
+## Public Domain — No Copyright (`http://rightsstatements.org/vocab/NoC-US/1.0/`)
+
+The work is in the public domain in its source jurisdiction (no subsisting copyright). All
+downstream uses are permitted; no attribution is legally required.
+
+| Rule id | Asserts | Keys on (`inputs`) | Outcome |
+|---|---|---|---|
+| `pd-grants-commercial` | `clearance.commercialReproduction.permitted` | `license.type = PD` | `true` |
+| `pd-grants-derivatives` | `clearance.derivatives.permitted` | `license.type = PD` | `true` |
+| `pd-waives-attribution` | `clearance.attributionRequired.required` | `license.type = PD` | `false` |
+
+## Fail-closed default
+
+Applied to **every** clearance dimension whenever the license signal is missing, ambiguous, or
+not one of the permissive rows above (e.g. `CC-BY`, `CC-BY-SA`, `OTHER`, `UNKNOWN`, or a value the
+engine could not resolve at all).
+
+| Rule id | Asserts | Keys on (`inputs`) | Outcome |
+|---|---|---|---|
+| `default-deny` | all of `commercialReproduction.permitted`, `derivatives.permitted`, `attributionRequired.required` | the unrecognised or absent license value, carried verbatim | `false` |
+
+Under `default-deny`, `attributionRequired.required` is `false` not because attribution is waived
+but because there is no cleared use to attribute — the deny is total. `confidence` is always `low`
+and the `summary` names the exact value that failed to clear.
+
+---
+
+## Why CC-BY / CC-BY-SA are not (yet) baseline rules
+
+v0.1 of the reference engine only emits `CC0` and `PD` with `confidence: high`. Attribution- and
+share-alike-bearing licenses (`CC-BY`, `CC-BY-SA`) require additional clearance facets
+(`attributionRequired: true` with a specific credit string, a `shareAlikeRequired` facet) that the
+v0.1 truth tables do not yet model. Until those facets and their rules are defined, such licenses
+resolve to `default-deny` — fail-closed, never a partial guess. Adding them is a future registry
+PR, not a schema change.

--- a/spec/clearance/v0.1/rules.md
+++ b/spec/clearance/v0.1/rules.md
@@ -48,7 +48,7 @@ schema. The set of rule ids is **open, not a closed enum**:
 - **Rule ids are stable and immutable within a version.** Once published at
   `https://openclearance.org/v0.1/rules`, a rule id's meaning is frozen. A corrected or expanded
   truth table ships as a new spec version, never by editing a published rule in place. (See
-  [`../../../VERSIONING.md`](../../../VERSIONING.md) once authored.)
+  [`../VERSIONING.md`](../VERSIONING.md).)
 - **Fail-closed is the contract.** Any license signal that is missing, ambiguous, or not on this
   permissive list resolves to `default-deny`: every clearance boolean `false`, `confidence: low`,
   and the failing value carried verbatim in `inputs`.

--- a/spec/clearance/v0.1/rules.md
+++ b/spec/clearance/v0.1/rules.md
@@ -66,10 +66,13 @@ permitted; no attribution is legally required.
 | `cc0-grants-derivatives` | `clearance.derivatives.permitted` | `license.type = CC0` | `true` |
 | `cc0-waives-attribution` | `clearance.attributionRequired.required` | `license.type = CC0` | `false` |
 
-## Public Domain — No Copyright (`http://rightsstatements.org/vocab/NoC-US/1.0/`)
+## Public Domain — Public Domain Mark (`https://creativecommons.org/publicdomain/mark/1.0/`)
 
-The work is in the public domain in its source jurisdiction (no subsisting copyright). All
-downstream uses are permitted; no attribution is legally required.
+The work carries no known worldwide copyright (Creative Commons Public Domain Mark). The engine
+emits `license.type = PD` only for the worldwide Public Domain Mark (Europeana `rights`) and the
+Wikimedia PD/PDM templates — never a jurisdiction-scoped `rightsstatements.org` value such as
+NoC-US, which claims a narrower (US) scope the gate does not assert. All downstream uses are
+permitted; no attribution is legally required.
 
 | Rule id | Asserts | Keys on (`inputs`) | Outcome |
 |---|---|---|---|

--- a/spec/clearance/v0.1/spec.md
+++ b/spec/clearance/v0.1/spec.md
@@ -6,8 +6,8 @@
 - **This document is normative.** Companion artifacts: the JSON-LD context
   ([`context.jsonld`](context.jsonld)), the JSON Schema
   ([`clearance-manifest.schema.json`](clearance-manifest.schema.json)), the rule
-  registry ([`rules.md`](rules.md)), the conformance suite
-  ([`conformance/`](conformance/)), and the URL-stability promise
+  registry ([`rules.md`](rules.md)), the conformance example manifests
+  ([`examples/`](examples/)), and the URL-stability promise
   ([`../VERSIONING.md`](../VERSIONING.md)).
 
 The key words MUST, MUST NOT, REQUIRED, SHOULD, SHOULD NOT, and MAY are to be
@@ -26,9 +26,11 @@ booleans. A manifest is emitted for cleared **and** non-cleared works alike: a
 ## Design principles
 
 1. **Compose, don't reinvent.** The format binds existing standards through its
-   JSON-LD `@context`: Creative Commons and rightsstatements.org URIs (rights
-   status), schema.org and Dublin Core (descriptive and provenance metadata), and
-   W3C PROV (the determination event). Its only original contribution is the thin
+   JSON-LD `@context`: Creative Commons rights URIs (rights status — v0.1 emits
+   the CC0 and Public Domain Mark URIs; the model also accommodates
+   rightsstatements.org URIs for vocabularies a future version may admit),
+   schema.org and Dublin Core (descriptive and provenance metadata), and W3C PROV
+   (the determination event). Its only original contribution is the thin
    **clearance layer** bridging descriptive metadata and reuse viability, defined
    under the `oc:` vocabulary.
 2. **Transport over adjudication.** This spec defines the *shape and transport*
@@ -200,8 +202,11 @@ critical defect; a false deny is tolerable.
 
 A document conforms to Clearance Manifest v0.1 if it validates against
 [`clearance-manifest.schema.json`](clearance-manifest.schema.json) and expands
-cleanly under [`context.jsonld`](context.jsonld). A *verifier* conforms if it
-agrees with the conformance suite ([`conformance/`](conformance/)) on every case,
-including emitting the declared advisories for structurally-valid documents with
+cleanly under [`context.jsonld`](context.jsonld). The conformance example
+manifests in [`examples/`](examples/) (one accepted, one deny) are the reference
+fixtures; the schema is exercised against freshly-emitted accept and deny
+manifests by the ajv harness in `tests/clearance/conformance.test.ts`. A
+*verifier* conforms if it agrees with that suite on every case, including
+emitting the declared advisories for structurally-valid documents with
 unrecognised rule ids. URL stability and the versioning promise are described in
 [`../VERSIONING.md`](../VERSIONING.md).

--- a/spec/clearance/v0.1/spec.md
+++ b/spec/clearance/v0.1/spec.md
@@ -1,0 +1,207 @@
+# Clearance Manifest v0.1
+
+- **Status:** Draft, published and frozen as v0.1.
+- **Namespace authority:** `https://openclearance.org/v0.1/`
+- **Artifact type:** `ClearanceManifest`
+- **This document is normative.** Companion artifacts: the JSON-LD context
+  ([`context.jsonld`](context.jsonld)), the JSON Schema
+  ([`clearance-manifest.schema.json`](clearance-manifest.schema.json)), the rule
+  registry ([`rules.md`](rules.md)), the conformance suite
+  ([`conformance/`](conformance/)), and the URL-stability promise
+  ([`../VERSIONING.md`](../VERSIONING.md)).
+
+The key words MUST, MUST NOT, REQUIRED, SHOULD, SHOULD NOT, and MAY are to be
+interpreted as described in RFC 2119.
+
+## Abstract
+
+A **Clearance Manifest** is a portable, cryptographically verifiable,
+machine-readable JSON-LD document asserting whether one specific creative work is
+rights-cleared for reuse. It carries the work's provenance, citation, and an
+auditable trail of *how* the rights determination was reached, and answers
+downstream questions ("may I print this and sell it?") as binary, actionable
+booleans. A manifest is emitted for cleared **and** non-cleared works alike: a
+**deny is a valid answer**, not an error.
+
+## Design principles
+
+1. **Compose, don't reinvent.** The format binds existing standards through its
+   JSON-LD `@context`: Creative Commons and rightsstatements.org URIs (rights
+   status), schema.org and Dublin Core (descriptive and provenance metadata), and
+   W3C PROV (the determination event). Its only original contribution is the thin
+   **clearance layer** bridging descriptive metadata and reuse viability, defined
+   under the `oc:` vocabulary.
+2. **Transport over adjudication.** This spec defines the *shape and transport*
+   of a rights assertion so it flows between systems. It does **not** adjudicate
+   jurisdiction-specific copyright law. An external authority (a museum, an
+   engine) *makes* the determination; the manifest *carries* it, immutably and
+   auditably.
+3. **Payload purity.** The data model never contains its own hash, its signature,
+   or any commercial data. Integrity and attestation live in the transport
+   envelope; commerce lives in a separate sibling assertion.
+4. **One-directional dependency.** The neutral core never references any
+   commercial layer; a commercial layer references the core by immutable hash.
+
+## Conceptual model
+
+A manifest has two parts that never mix:
+
+- **The payload** — pure JSON-LD describing the work, its source, the rights
+  determination, the clearance booleans, the determination event, and (when the
+  work is identified) its citations.
+- **The envelope** — a thin wrapper holding integrity (and, in higher tiers,
+  authenticity) over the payload. The envelope references the payload; the
+  payload never references the envelope.
+
+## The payload
+
+The payload is normatively shaped by [`clearance-manifest.schema.json`](clearance-manifest.schema.json)
+and semantically expanded by [`context.jsonld`](context.jsonld). Top-level
+required members: `@context`, `type`, `specVersion`, `work`, `source`, `rights`,
+`clearance`, `verification`. `citation` is present when the work is identified.
+`extensions` is an OPTIONAL vendor escape hatch.
+
+Field names mirror the producing engine's descriptive vocabulary (e.g. `artist`,
+`displayDate`, `imageUrls`); JSON-LD semantics are supplied by aliasing those
+terms to schema.org / Dublin Core / PROV IRIs in the context. Consumers that read
+JSON field names need no IRI awareness; strict JSON-LD processors get fully
+resolved terms.
+
+### `@context` is the sole normative authority; `specVersion` is convenience
+
+The `@context` array MUST include `https://openclearance.org/v0.1/context.jsonld`.
+That IRI is the **sole normative authority** for term expansion and validation.
+`specVersion` (`"0.1"`) is a human-readable convenience for log-grepping and
+quick inspection; a consumer MUST NOT rely on it for vocabulary resolution.
+
+### `clearance` — the instant answer
+
+`clearance` exposes binary, machine-actionable facets — `commercialReproduction`
+and `derivatives` (`permitted`), and `attributionRequired` (`required`) — each
+paired with a structured `basis`. `attributionRequired` is explicit so reuse
+engines never parse strings to decide a credit line. The pattern extends (e.g. a
+future `shareAlikeRequired`) without breaking older consumers.
+
+### `basis` — structured, auditable reasoning
+
+Each clearance facet carries a `basis`:
+
+```jsonc
+"basis": {
+  "rule":    "cc0-grants-commercial",
+  "inputs":  [{ "field": "license.type", "value": "CC0" }],
+  "summary": "CC0 public-domain dedication permits all uses, including commercial."
+}
+```
+
+`rule`, `inputs`, and `summary` are all REQUIRED — honesty-by-architecture. The
+**shape** of `basis` is normative; the set of `rule` ids is **open, not a closed
+enum**. A `rule` id is a bare kebab-case token resolving as a fragment under
+[`rules.md`](rules.md) (`https://openclearance.org/v0.1/rules#<rule>`). The
+registry lists the recognised v0.1 baseline (the CC0/PD truth tables and
+`default-deny`); it is non-normative and grows by PR.
+
+#### The advisory contract
+
+A `basis.rule` whose id is **not** in the current registry baseline is still a
+**structurally valid** manifest. A conforming verifier MUST emit a non-fatal
+`unrecognised_rule` advisory and MUST NOT reject the document for it. Structural
+validity (schema) is independent of determination-rule recognition (advisory).
+See [`advisory-entry.schema.json`](advisory-entry.schema.json).
+
+### `verification` — the determination as an auditable event
+
+`verification` records *how the rights determination was reached*, distinct from
+how the clearance booleans were derived (that is `basis`). `determinedBy.actor`
+names who made the call and `role` their relationship to it; on a cleared record
+the actor is the rights source (`museum:<code>`), and on a **deny** the actor is
+the engine rights-gate (`engine:<tool>`) — the museum never asserted the deny,
+the gate did. `determinationSource` points at the evidence relied upon.
+
+## The envelope
+
+The hash and (in higher tiers) the signature wrap the payload; they are never
+fields inside it.
+
+- **Tier 0 (raw):** a minimal wrapper holding `{ tier: 0, payload, integrity: {
+  alg: "sha-256", jcs: true, hash } }`, where `hash` is computed over the
+  **RFC 8785 (JCS)** canonicalization of the payload. Integrity, not
+  authenticity. This is what a keyless distributor (e.g. the reference MCP
+  server) emits by default.
+- **Tier 1/2 (C2PA):** the payload is carried as a C2PA assertion and the
+  manifest's claim is signed. The payload schema is unchanged across tiers. These
+  tiers are **defined here but not implemented in the reference engine** — no
+  signing code ships in v0.1.
+
+### JCS warning (normative)
+
+Implementers MUST **canonicalize first, then hash the canonical bytes.** Never
+hash the raw serialized JSON string: `JSON.stringify` (or any non-canonical
+encoder) can vary key order, whitespace, number formatting, and string escaping,
+producing a different and non-interoperable hash. Canonicalization is RFC 8785:
+keys sorted by UTF-16 code unit, minimal string escaping, no insignificant
+whitespace, ECMAScript number serialization. A common interop bug is
+over-escaping non-ASCII characters; codepoints ≥ U+0080 MUST be emitted as raw
+UTF-8.
+
+## Trust model and verifier behaviour
+
+Three tiers form an adoption funnel that never sacrifices integrity:
+
+| Tier | Signer | Meaning |
+|---|---|---|
+| 0 | none (hash only) | self-asserted; integrity, no authenticity |
+| 1 | an attestor on behalf of the named actor | delegated trust; removes the PKI barrier for actors without keys |
+| 2 | the actor itself, via `did:web` / X.509 | direct, domain-bound trust; payload schema unchanged from Tier 1 |
+
+**Actor vs Signer are deliberately separate:** the *actor* makes the
+determination; the *signer/attestor* cryptographically vouches. This lets an
+actor without PKI participate (an attestor signs; the actor is named; the
+`determinationSource` records the evidence the attestor relied on).
+
+Verification produces a standardized **`VerificationState`** — the single
+variable a downstream engine checks:
+
+- `REJECTED` — hash mismatch or broken certificate chain.
+- `UNVERIFIED_SIGNAL` — Tier 0, valid hash, no attestation.
+- `ATTESTED_DELEGATE` — Tier 1, valid signature.
+- `ATTESTED_DIRECT` — Tier 2, valid domain-bound signature.
+
+A Tier-0 consumer MUST recompute the JCS hash and independently resolve `source`
+URLs, and MUST NOT attribute authenticity to a Tier-0 manifest.
+
+### Commercial gate (normative, consumer-side)
+
+A commerce/print execution that relies on a Clearance Manifest MUST require
+`VerificationState ∈ {ATTESTED_DELEGATE, ATTESTED_DIRECT}`. A Tier-0
+(`UNVERIFIED_SIGNAL`) manifest carries integrity but not authenticity and MUST
+NOT, on its own, gate a commercial transaction. This rule is defined at the spec
+level for consumers; the reference engine emits Tier 0 and does not itself run a
+commercial gate.
+
+## Commerce binding (out of core)
+
+Commercial data is **never nested** inside a Clearance Manifest. It travels as a
+separate assertion under a vendor namespace that **references the manifest by its
+content hash**. When the two travel together they are *sibling* assertions, each
+independently hashed; the neutral manifest stays byte-identical to what the
+engine emitted and independently verifiable. The direction is invariant:
+**commerce → references → clearance**, never the reverse.
+
+## Fail-closed contract
+
+Any rights signal that is missing, ambiguous, or not affirmatively permissive
+MUST resolve to a deny: every clearance boolean `false`, `confidence: "low"`,
+`statement: null`, and a `basis` (rule `default-deny`) carrying the exact failing
+value in `inputs`. A bug that lets a non-cleared record present as cleared is a
+critical defect; a false deny is tolerable.
+
+## Conformance
+
+A document conforms to Clearance Manifest v0.1 if it validates against
+[`clearance-manifest.schema.json`](clearance-manifest.schema.json) and expands
+cleanly under [`context.jsonld`](context.jsonld). A *verifier* conforms if it
+agrees with the conformance suite ([`conformance/`](conformance/)) on every case,
+including emitting the declared advisories for structurally-valid documents with
+unrecognised rule ids. URL stability and the versioning promise are described in
+[`../VERSIONING.md`](../VERSIONING.md).

--- a/src/clearanceTool.ts
+++ b/src/clearanceTool.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+import type { Federation } from './core/index.js';
+
+/**
+ * Input schema for the `clearance_record` MCP tool.
+ *
+ * Deliberately does NOT regex-validate the id against ID_REGEX, unlike
+ * `get_artwork` and `cite`. The clearance tool's contract is that a non-cleared
+ * work — including a malformed id — returns a definitive DENY manifest, not an
+ * error. `federation.clearanceManifest` emits that deny for an invalid id, so
+ * gating the id here would wrongly convert a contractual deny into a ZodError.
+ */
+export const ClearanceInput = z.object({
+  id: z.string(),
+});
+
+/**
+ * Handle a `clearance_record` call. Returns a normal (non-error) tool result
+ * for every id: a cleared work yields a permitted manifest, a non-cleared or
+ * malformed id yields a deny manifest. Both are valid answers.
+ */
+export async function handleClearanceRecord(federation: Federation, args: unknown) {
+  const input = ClearanceInput.parse(args);
+  const env = await federation.clearanceManifest(input.id);
+  return { content: [{ type: 'text' as const, text: JSON.stringify(env, null, 2) }] };
+}

--- a/src/core/clearance/envelope.ts
+++ b/src/core/clearance/envelope.ts
@@ -1,0 +1,32 @@
+import { canonicalizeToBytes } from './jcs.js';
+
+/**
+ * Tier-0 envelope: integrity, not authenticity. It wraps a pure Clearance
+ * Manifest payload with a hash computed over the payload's RFC 8785 (JCS)
+ * canonical bytes. The hash lives HERE, never inside the payload — payload
+ * purity is a design invariant (the payload never carries its own hash, its
+ * signature, or any commercial data).
+ *
+ * This is what the distributed OSS MCP emits by default; it ships no key.
+ * Tiers 1/2 (C2PA signing) wrap the same payload with a signature — the payload
+ * shape is unchanged across tiers.
+ */
+export interface Tier0Envelope<T = unknown> {
+  tier: 0;
+  payload: T;
+  integrity: { alg: 'sha-256'; jcs: true; hash: string };
+}
+
+/**
+ * Wrap a payload in a Tier-0 envelope. Canonicalizes FIRST (RFC 8785), then
+ * hashes the canonical bytes with Web Crypto (`crypto.subtle`, Workers-safe).
+ * Throws if the payload is not canonicalizable JSON.
+ */
+export async function wrapTier0<T>(payload: T): Promise<Tier0Envelope<T>> {
+  const bytes = canonicalizeToBytes(payload);
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  const hash = Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  return { tier: 0, payload, integrity: { alg: 'sha-256', jcs: true, hash } };
+}

--- a/src/core/clearance/jcs.ts
+++ b/src/core/clearance/jcs.ts
@@ -1,0 +1,71 @@
+// RFC 8785 JSON Canonicalization Scheme (JCS).
+//
+// Produces the canonical UTF-8 serialization of a JSON value: object keys sorted
+// by UTF-16 code unit, ECMAScript number serialization, minimal string escaping,
+// no insignificant whitespace. This is the byte sequence a Clearance Manifest's
+// Tier-0 envelope hashes over.
+//
+// Lifted verbatim (ported to TypeScript) from the PIF sibling standard's vetted
+// dependency-free verifier (pif-spec/verifier/jcs.mjs). Runs unchanged in Node,
+// the browser, and Cloudflare Workers — no dependencies, no `node:` imports.
+//
+// IMPORTANT (the contract the spec must warn implementers about): canonicalize
+// FIRST, then hash the canonical bytes. Never hash the raw serialized string —
+// JSON.stringify on the same object can produce different bytes (key order,
+// whitespace) and therefore a different, non-interoperable hash.
+
+/**
+ * Canonicalize a JSON-compatible value to its RFC 8785 string form.
+ * Throws on values JSON cannot represent (functions, symbols, undefined,
+ * non-finite numbers) — a Clearance Manifest payload must be canonicalizable.
+ */
+export function canonicalize(value: unknown): string {
+  if (value === null) return 'null';
+
+  const t = typeof value;
+
+  if (t === 'boolean') return value ? 'true' : 'false';
+
+  if (t === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error('JCS: non-finite numbers are not permitted in JSON');
+    }
+    // JSON.stringify uses ECMAScript Number-to-string, which is what JCS mandates.
+    return JSON.stringify(value);
+  }
+
+  if (t === 'string') {
+    // ECMAScript JSON string escaping (control chars as \u00XX, correct surrogate
+    // handling) is exactly the escaping RFC 8785 specifies.
+    //
+    // PORTABILITY NOTE for non-JS implementers (RFC 8785 §3.2.2.2): escape ONLY the
+    // two mandatory characters (" -> \", \ -> \\) and the C0 control range U+0000..U+001F,
+    // using the short forms \b \t \n \f \r where they exist and \u00XX (lowercase hex)
+    // otherwise. Do NOT escape the forward solidus "/", and do NOT escape any non-ASCII
+    // character; codepoints >= U+0080 are emitted as raw UTF-8. Over-escaping (e.g.
+    // \uXXXX for every non-ASCII char, as some language JSON encoders do by default) is
+    // the most common interop bug and will produce a different byte string, hence a
+    // different hash. V8's JSON.stringify already implements exactly this.
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return '[' + value.map(canonicalize).join(',') + ']';
+  }
+
+  if (t === 'object') {
+    // Object.keys() then default Array sort: lexicographic by UTF-16 code unit,
+    // which is the ordering RFC 8785 requires.
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj).sort();
+    const members = keys.map((k) => JSON.stringify(k) + ':' + canonicalize(obj[k]));
+    return '{' + members.join(',') + '}';
+  }
+
+  throw new Error(`JCS: unsupported value of type ${t}`);
+}
+
+/** Canonicalize and encode to UTF-8 bytes (ArrayBuffer-backed, for Web Crypto). */
+export function canonicalizeToBytes(value: unknown): Uint8Array<ArrayBuffer> {
+  return new TextEncoder().encode(canonicalize(value));
+}

--- a/src/core/clearance/licenseMap.ts
+++ b/src/core/clearance/licenseMap.ts
@@ -37,10 +37,16 @@ const PERMISSIVE: Partial<
     rulePrefix: 'cc0',
     summaryNoun: 'CC0 public-domain dedication',
   },
+  // The gate only emits type=PD for the worldwide Creative Commons Public
+  // Domain Mark (Europeana `rights` = .../publicdomain/mark/1.0/) and the
+  // Wikimedia PD/PDM templates — never a jurisdiction-scoped rightsstatements.org
+  // value. The Public Domain Mark URI is therefore the accurate, gate-aligned
+  // statement; the old US-scoped NoC-US URI claimed a narrower (and incorrect)
+  // scope the gate never asserts.
   PD: {
-    statement: 'http://rightsstatements.org/vocab/NoC-US/1.0/',
+    statement: 'https://creativecommons.org/publicdomain/mark/1.0/',
     rulePrefix: 'pd',
-    summaryNoun: 'public-domain status',
+    summaryNoun: 'Public Domain Mark status',
   },
 };
 

--- a/src/core/clearance/licenseMap.ts
+++ b/src/core/clearance/licenseMap.ts
@@ -1,0 +1,94 @@
+import type { LicenseType, RightsConfidence } from '../../types.js';
+
+/**
+ * The structured `basis` for a single clearance determination. Shape is normative
+ * (schema-enforced): `rule`, `inputs`, and `summary` are all required —
+ * honesty-by-architecture. A determination that cannot name its rule, cite its
+ * inputs, and state its reasoning is not a valid determination.
+ *
+ * `rule` is a stable id that resolves as a fragment under the rule registry:
+ * `https://openclearance.org/v0.1/rules#<rule>`. The set of ids is OPEN, not a
+ * closed enum — an unrecognised id yields a non-fatal `unrecognised_rule`
+ * advisory at verification time, never a schema rejection. See
+ * `spec/clearance/v0.1/rules.md`.
+ */
+export interface ClearanceBasis {
+  rule: string;
+  inputs: { field: string; value: unknown }[];
+  summary: string;
+}
+
+export interface ClearanceDecision {
+  statement: string | null;
+  commercialReproduction: { permitted: boolean; basis: ClearanceBasis };
+  derivatives: { permitted: boolean; basis: ClearanceBasis };
+  attributionRequired: { required: boolean; basis: ClearanceBasis };
+  confidence: RightsConfidence;
+}
+
+// The ONLY place clearance determinations live. Fail-closed: a license type not
+// listed here resolves to all-false / default-deny. Adding a recognised
+// permissive license later is a single entry here + a rule-registry row + a test.
+const PERMISSIVE: Partial<
+  Record<LicenseType, { statement: string; rulePrefix: string; summaryNoun: string }>
+> = {
+  CC0: {
+    statement: 'https://creativecommons.org/publicdomain/zero/1.0/',
+    rulePrefix: 'cc0',
+    summaryNoun: 'CC0 public-domain dedication',
+  },
+  PD: {
+    statement: 'http://rightsstatements.org/vocab/NoC-US/1.0/',
+    rulePrefix: 'pd',
+    summaryNoun: 'public-domain status',
+  },
+};
+
+export function clearanceForLicense(type: LicenseType): ClearanceDecision {
+  const ok = PERMISSIVE[type];
+  const inputs = [{ field: 'license.type', value: type }];
+
+  if (ok) {
+    return {
+      statement: ok.statement,
+      commercialReproduction: {
+        permitted: true,
+        basis: {
+          rule: `${ok.rulePrefix}-grants-commercial`,
+          inputs,
+          summary: `${ok.summaryNoun} permits all uses, including commercial.`,
+        },
+      },
+      derivatives: {
+        permitted: true,
+        basis: {
+          rule: `${ok.rulePrefix}-grants-derivatives`,
+          inputs,
+          summary: `${ok.summaryNoun} permits modification and derivative works.`,
+        },
+      },
+      attributionRequired: {
+        required: false,
+        basis: {
+          rule: `${ok.rulePrefix}-waives-attribution`,
+          inputs,
+          summary: `${ok.summaryNoun} requires no attribution as a condition of reuse.`,
+        },
+      },
+      confidence: 'high',
+    };
+  }
+
+  const denyBasis: ClearanceBasis = {
+    rule: 'default-deny',
+    inputs,
+    summary: `unrecognized or non-permissive license type '${type}' ⇒ default deny`,
+  };
+  return {
+    statement: null,
+    commercialReproduction: { permitted: false, basis: denyBasis },
+    derivatives: { permitted: false, basis: denyBasis },
+    attributionRequired: { required: false, basis: denyBasis },
+    confidence: 'low',
+  };
+}

--- a/src/core/clearance/manifest.ts
+++ b/src/core/clearance/manifest.ts
@@ -1,0 +1,219 @@
+import { cite } from '../../cite.js';
+import type {
+  Artist,
+  Artwork,
+  ArtworkImages,
+  RejectedArtwork,
+  RightsConfidence,
+  ValidationResult,
+} from '../../types.js';
+import { clearanceForLicense, type ClearanceBasis } from './licenseMap.js';
+
+/**
+ * The pure Clearance Manifest payload (JSON-LD). It never contains its own hash,
+ * its signature, or any commercial data — integrity lives in the Tier-0 envelope
+ * (see envelope.ts), commerce in a sibling vendor assertion that references this
+ * payload by content hash. The payload is byte-identical to what the engine
+ * emits and independently verifiable.
+ *
+ * Field names mirror the engine's canonical Artwork vocabulary wherever they map
+ * (`artist`, `displayDate`, `imageUrls`, `imageOpenAccess`, `metadataOpenAccess`,
+ * `museum`) so the open-museum.art data-model reconciliation is a thin mapping,
+ * not a translation. JSON-LD semantics are supplied by aliasing these terms to
+ * schema.org / Dublin Core IRIs in context.jsonld — the `@context` is the sole
+ * normative authority; `specVersion` is human-readable convenience only.
+ */
+export interface ClearanceManifestPayload {
+  '@context': string[];
+  type: 'ClearanceManifest';
+  specVersion: string;
+  work: ClearanceWork;
+  source: ClearanceSource;
+  rights: ClearanceRights;
+  clearance: ClearanceBlock;
+  verification: ClearanceVerification;
+  /** Omitted for rejected records, which carry no identified Artwork to cite. */
+  citation?: ClearanceCitation;
+}
+
+export interface ClearanceWork {
+  id: string;
+  title?: string;
+  artist?: Artist;
+  displayDate?: string;
+  yearStart?: number | null;
+  yearEnd?: number | null;
+  medium?: string;
+}
+
+export interface ClearanceMuseum {
+  code: string;
+  name?: string;
+  url?: string;
+}
+
+export interface ClearanceSource {
+  museum: ClearanceMuseum;
+  apiUrl?: string;
+  pageUrl?: string;
+  originalUrl?: string;
+  imageUrls?: ArtworkImages;
+}
+
+export interface ClearanceRights {
+  statement: string | null;
+  sourceApiValue: { field: string; value: unknown } | null;
+  imageOpenAccess: boolean;
+  metadataOpenAccess: boolean;
+  confidence: RightsConfidence;
+}
+
+export interface ClearanceBlock {
+  commercialReproduction: { permitted: boolean; basis: ClearanceBasis };
+  derivatives: { permitted: boolean; basis: ClearanceBasis };
+  attributionRequired: { required: boolean; basis: ClearanceBasis };
+}
+
+export interface ClearanceVerification {
+  determinedBy: { actor: string; role: string };
+  tool: string;
+  determinedAt: string;
+  ruleContext: string;
+  determinationSource: { type: string; field?: string; url?: string; retrievedAt: string };
+}
+
+export interface ClearanceCitation {
+  full: string;
+  caption: string;
+  short: string;
+}
+
+export interface BuildOptions {
+  /** Engine version string for the `verification.tool` provenance field. */
+  engineVersion: string;
+  /**
+   * Generation timestamp, used only where no determination timestamp exists in
+   * the data (the deny path has no `license.verifiedAt`). Injected so manifests
+   * are deterministic and reproducible as conformance fixtures.
+   */
+  now: string;
+}
+
+const CONTEXT: string[] = [
+  'https://schema.org/',
+  'http://purl.org/dc/terms/',
+  'https://openclearance.org/v0.1/context.jsonld',
+];
+const TYPE = 'ClearanceManifest' as const;
+const SPEC_VERSION = '0.1';
+const TOOL_NAME = 'open-museum-mcp';
+
+/** Split `<museum>.<field path>` on the first dot. `met.isPublicDomain` → field `isPublicDomain`. */
+function apiFieldOf(verificationSource: string): string {
+  const i = verificationSource.indexOf('.');
+  return i < 0 ? verificationSource : verificationSource.slice(i + 1);
+}
+
+export function buildClearancePayload(
+  result: ValidationResult,
+  opts: BuildOptions,
+): ClearanceManifestPayload {
+  return result.status === 'accepted'
+    ? buildAccepted(result.artwork, opts)
+    : buildRejected(result.rejection, opts);
+}
+
+function buildAccepted(art: Artwork, opts: BuildOptions): ClearanceManifestPayload {
+  const decision = clearanceForLicense(art.license.type);
+  const field = apiFieldOf(art.license.verificationSource);
+
+  return {
+    '@context': CONTEXT,
+    type: TYPE,
+    specVersion: SPEC_VERSION,
+    work: {
+      id: art.id,
+      title: art.title,
+      artist: art.artist,
+      displayDate: art.displayDate,
+      yearStart: art.yearStart,
+      yearEnd: art.yearEnd,
+      medium: art.medium,
+    },
+    source: {
+      museum: { code: art.museum.code, name: art.museum.name, url: art.museum.url },
+      apiUrl: art.source.apiUrl,
+      pageUrl: art.source.pageUrl,
+      ...(art.source.originalUrl ? { originalUrl: art.source.originalUrl } : {}),
+      imageUrls: art.imageUrls,
+    },
+    rights: {
+      statement: decision.statement,
+      sourceApiValue: { field, value: art.license.rawValue },
+      imageOpenAccess: art.imageOpenAccess,
+      metadataOpenAccess: art.metadataOpenAccess,
+      confidence: decision.confidence,
+    },
+    clearance: {
+      commercialReproduction: decision.commercialReproduction,
+      derivatives: decision.derivatives,
+      attributionRequired: decision.attributionRequired,
+    },
+    verification: {
+      determinedBy: { actor: `museum:${art.museum.code}`, role: 'rights-source' },
+      tool: `${TOOL_NAME}@${opts.engineVersion} · ${art.license.verificationSource}`,
+      determinedAt: art.license.verifiedAt,
+      ruleContext: `${art.license.verificationSource}='${art.license.rawValue}' ⇒ ${art.license.type}`,
+      determinationSource: {
+        type: 'api-field',
+        field,
+        url: art.source.apiUrl,
+        retrievedAt: art.license.verifiedAt,
+      },
+    },
+    citation: {
+      full: cite(art, 'full'),
+      caption: cite(art, 'caption'),
+      short: cite(art, 'short'),
+    },
+  };
+}
+
+function buildRejected(rej: RejectedArtwork, opts: BuildOptions): ClearanceManifestPayload {
+  // The deny determination (all-false booleans, default-deny rule, low
+  // confidence) comes from the single source of truth; the rejection supplies
+  // the case-specific evidence (the gate's verbatim reason) into each basis.
+  const decision = clearanceForLicense('UNKNOWN');
+  const basis: ClearanceBasis = {
+    rule: 'default-deny',
+    inputs: [{ field: 'rejection.reason', value: rej.reason }],
+    summary: `rights gate rejected '${rej.id}': ${rej.reason} ⇒ default deny`,
+  };
+
+  return {
+    '@context': CONTEXT,
+    type: TYPE,
+    specVersion: SPEC_VERSION,
+    work: { id: rej.id },
+    source: { museum: { code: rej.museumCode } },
+    rights: {
+      statement: decision.statement,
+      sourceApiValue: null,
+      imageOpenAccess: false,
+      metadataOpenAccess: false,
+      confidence: decision.confidence,
+    },
+    clearance: {
+      commercialReproduction: { permitted: false, basis },
+      derivatives: { permitted: false, basis },
+      attributionRequired: { required: false, basis },
+    },
+    verification: {
+      determinedBy: { actor: 'engine:open-museum-mcp', role: 'rights-gate' },
+      tool: `${TOOL_NAME}@${opts.engineVersion} · rights-gate`,
+      determinedAt: opts.now,
+      ruleContext: `strict default deny: ${rej.reason}`,
+      determinationSource: { type: 'rights-gate-default', retrievedAt: opts.now },
+    },
+  };
+}

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -5,6 +5,8 @@ import type { Fetcher } from '../fetchers/types.js';
 import type { Artwork } from '../types.js';
 import { filterByYearRange } from '../yearFilter.js';
 import type { CacheStore } from './cache.js';
+import { wrapTier0, type Tier0Envelope } from './clearance/envelope.js';
+import { buildClearancePayload, type ClearanceManifestPayload } from './clearance/manifest.js';
 
 // Museum IDs follow `<code>:<segment>(/<segment>)*`. Each segment is
 // alphanumeric, underscore, or hyphen. The four numeric-ID museums (Met,
@@ -73,6 +75,19 @@ export interface FederationOptions {
    * diagnostic hook, not an error path. The MCP server logs to stderr here.
    */
   onReject?: (id: string, reason: string) => void;
+  /**
+   * Engine version string stamped into a Clearance Manifest's
+   * `verification.tool` provenance field. The host (MCP server) supplies its
+   * real package version; defaults to a placeholder so the core stays usable
+   * without one.
+   */
+  engineVersion?: string;
+  /**
+   * Clock for the generation timestamp used where no determination timestamp
+   * exists in the data (the clearance deny path has no `license.verifiedAt`).
+   * Injectable so emitted manifests are deterministic in tests and fixtures.
+   */
+  clock?: () => string;
 }
 
 export interface Federation {
@@ -80,6 +95,14 @@ export interface Federation {
   search(params: SearchParams): Promise<SearchResult>;
   getArtwork(id: string): Promise<FetchOutcome>;
   cite(id: string, style: CiteStyle): Promise<CiteOutcome>;
+  /**
+   * Emit a portable, fail-closed Clearance Manifest (rights-clearance +
+   * provenance + citation) for an artwork id, wrapped in a Tier-0 integrity
+   * envelope. A non-cleared work — rejected by the rights gate, an unknown
+   * museum, or an invalid id — returns a definitive *deny* manifest, never an
+   * error: a deny is a valid answer.
+   */
+  clearanceManifest(id: string): Promise<Tier0Envelope<ClearanceManifestPayload>>;
 }
 
 async function withConcurrency<T, R>(
@@ -125,6 +148,8 @@ export function createFederation(opts: FederationOptions): Federation {
   const { fetchers, cache } = opts;
   const concurrency = opts.concurrency ?? DEFAULT_FETCH_CONCURRENCY;
   const onReject = opts.onReject;
+  const engineVersion = opts.engineVersion ?? '0.0.0';
+  const clock = opts.clock ?? (() => new Date().toISOString());
 
   async function getArtwork(id: string): Promise<FetchOutcome> {
     if (!ID_REGEX.test(id)) {
@@ -197,5 +222,32 @@ export function createFederation(opts: FederationOptions): Federation {
     return { ok: true, citation: citeArtwork(out.artwork, style) };
   }
 
-  return { fetchers, search, getArtwork, cite };
+  async function clearanceManifest(
+    id: string,
+  ): Promise<Tier0Envelope<ClearanceManifestPayload>> {
+    const buildOpts = { engineVersion, now: clock() };
+    const code = id.includes(':') ? id.slice(0, id.indexOf(':')) : '';
+
+    const deny = (reason: string) =>
+      wrapTier0(
+        buildClearancePayload(
+          { status: 'rejected', rejection: { id, museumCode: code, reason, rawSnapshot: null } },
+          buildOpts,
+        ),
+      );
+
+    if (!ID_REGEX.test(id)) return deny(`invalid artwork id: ${id}`);
+
+    const fetcher = fetchers[code];
+    if (!fetcher) return deny(`unknown museum code: ${code}`);
+
+    // Determinations are cheap and version-bound, so the manifest path does not
+    // touch the object cache — it always reflects the current rights gate.
+    const raw = await fetcher.getRaw(id);
+    const result = fetcher.normalize(raw);
+    if (result.status === 'rejected') onReject?.(id, result.rejection.reason);
+    return wrapTier0(buildClearancePayload(result, buildOpts));
+  }
+
+  return { fetchers, search, getArtwork, cite, clearanceManifest };
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -21,6 +21,23 @@ export {
 
 export type { CacheStore, Awaitable } from './cache.js';
 
+// Clearance Manifest — the portable, fail-closed rights-clearance artifact and
+// its Tier-0 integrity envelope, emitted by Federation.clearanceManifest.
+export { wrapTier0, type Tier0Envelope } from './clearance/envelope.js';
+export {
+  buildClearancePayload,
+  type ClearanceManifestPayload,
+  type ClearanceWork,
+  type ClearanceSource,
+  type ClearanceMuseum,
+  type ClearanceRights,
+  type ClearanceBlock,
+  type ClearanceVerification,
+  type ClearanceCitation,
+  type BuildOptions,
+} from './clearance/manifest.js';
+export { clearanceForLicense, type ClearanceDecision, type ClearanceBasis } from './clearance/licenseMap.js';
+
 // Pure helpers a front door commonly needs alongside the federation.
 export { cite, type CiteStyle } from '../cite.js';
 export type { Artwork, ArtworkImages, ArtworkSource, ArtworkLicense, ValidationResult } from '../types.js';

--- a/src/server.ts
+++ b/src/server.ts
@@ -59,7 +59,7 @@ const cache = new Cache({ path: CACHE_PATH });
 
 // Single source for the server version. Stamped into the MCP handshake and into
 // each Clearance Manifest's `verification.tool` provenance field.
-const VERSION = '0.6.0';
+const VERSION = '0.7.0';
 
 // The federation engine is transport-agnostic. The MCP server is one front
 // door over it (stdio JSON-RPC); the web app is another (HTTP + KV cache).

--- a/src/server.ts
+++ b/src/server.ts
@@ -57,6 +57,10 @@ if (process.env.EUROPEANA_API_KEY) {
 const CACHE_PATH = process.env.OMM_CACHE_PATH ?? join(homedir(), '.open-museum-mcp', 'cache.db');
 const cache = new Cache({ path: CACHE_PATH });
 
+// Single source for the server version. Stamped into the MCP handshake and into
+// each Clearance Manifest's `verification.tool` provenance field.
+const VERSION = '0.6.0';
+
 // The federation engine is transport-agnostic. The MCP server is one front
 // door over it (stdio JSON-RPC); the web app is another (HTTP + KV cache).
 // Rejections are logged to stderr — stdout is the MCP protocol channel — so
@@ -66,6 +70,7 @@ const cache = new Cache({ path: CACHE_PATH });
 const federation = createFederation({
   fetchers: FETCHERS,
   cache,
+  engineVersion: VERSION,
   onReject: (id, reason) => console.error(`[open-museum-mcp] rejected ${id}: ${reason}`),
 });
 
@@ -78,6 +83,10 @@ const CiteInput = z.object({
   style: z.enum(['short', 'full', 'caption']).default('full'),
 });
 
+const ClearanceInput = z.object({
+  id: z.string().regex(ID_REGEX),
+});
+
 const DiscoverInput = z.object({
   region: z.string().min(1).optional(),
   period: z.string().min(1).optional(),
@@ -86,7 +95,7 @@ const DiscoverInput = z.object({
 });
 
 const server = new Server(
-  { name: 'open-museum-mcp', version: '0.6.0' },
+  { name: 'open-museum-mcp', version: VERSION },
   {
     capabilities: {
       tools: {},
@@ -194,6 +203,18 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         properties: {},
       },
     },
+    {
+      name: 'clearance_record',
+      description:
+        'Emit a portable, fail-closed Clearance Manifest (rights-clearance + provenance + citation) for an artwork id, wrapped in a Tier-0 integrity envelope (RFC 8785 JCS sha-256). A non-cleared work — rejected by the rights gate, an unknown museum, or an invalid id — returns a definitive DENY manifest, not an error: a deny is a valid answer. Conforms to the in-repo Clearance Manifest spec at spec/clearance/v0.1 (openclearance.org/v0.1).',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'Normalized artwork ID, format museumcode:id (e.g. met:436535).' },
+        },
+        required: ['id'],
+      },
+    },
   ],
 }));
 
@@ -278,6 +299,14 @@ async function handleDiscoverRandom(args: unknown) {
   return { content: [{ type: 'text' as const, text: JSON.stringify(artwork, null, 2) }] };
 }
 
+async function handleClearance(args: unknown) {
+  const input = ClearanceInput.parse(args);
+  // clearanceManifest never throws for a non-cleared work — a deny is a valid
+  // manifest, returned as a normal (non-error) tool result.
+  const env = await federation.clearanceManifest(input.id);
+  return { content: [{ type: 'text' as const, text: JSON.stringify(env, null, 2) }] };
+}
+
 function handleListTraditions() {
   const traditions = cache.listTraditions();
   const isEmpty = traditions.regions.length === 0 && traditions.periods.length === 0;
@@ -297,6 +326,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     if (name === 'cite') return await handleCite(args);
     if (name === 'discover_random') return await handleDiscoverRandom(args);
     if (name === 'list_traditions') return handleListTraditions();
+    if (name === 'clearance_record') return await handleClearance(args);
     return errorResult(`unknown tool: ${name}`);
   } catch (err) {
     if (err instanceof z.ZodError) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import {
   UnknownMuseumError,
   type CiteStyle,
 } from './core/index.js';
+import { handleClearanceRecord } from './clearanceTool.js';
 import { Cache } from './db.js';
 import { buildSeedQueryFromConstraints } from './discoverSeed.js';
 import { aicFetcher } from './fetchers/aic.js';
@@ -81,10 +82,6 @@ const GetInput = z.object({
 const CiteInput = z.object({
   id: z.string().regex(ID_REGEX),
   style: z.enum(['short', 'full', 'caption']).default('full'),
-});
-
-const ClearanceInput = z.object({
-  id: z.string().regex(ID_REGEX),
 });
 
 const DiscoverInput = z.object({
@@ -299,14 +296,6 @@ async function handleDiscoverRandom(args: unknown) {
   return { content: [{ type: 'text' as const, text: JSON.stringify(artwork, null, 2) }] };
 }
 
-async function handleClearance(args: unknown) {
-  const input = ClearanceInput.parse(args);
-  // clearanceManifest never throws for a non-cleared work — a deny is a valid
-  // manifest, returned as a normal (non-error) tool result.
-  const env = await federation.clearanceManifest(input.id);
-  return { content: [{ type: 'text' as const, text: JSON.stringify(env, null, 2) }] };
-}
-
 function handleListTraditions() {
   const traditions = cache.listTraditions();
   const isEmpty = traditions.regions.length === 0 && traditions.periods.length === 0;
@@ -326,7 +315,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     if (name === 'cite') return await handleCite(args);
     if (name === 'discover_random') return await handleDiscoverRandom(args);
     if (name === 'list_traditions') return handleListTraditions();
-    if (name === 'clearance_record') return await handleClearance(args);
+    if (name === 'clearance_record') return await handleClearanceRecord(federation, args);
     return errorResult(`unknown tool: ${name}`);
   } catch (err) {
     if (err instanceof z.ZodError) {

--- a/tests/clearance/clearance-tool-input.test.ts
+++ b/tests/clearance/clearance-tool-input.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { createFederation } from '../../src/core/index.js';
+import type { CacheStore } from '../../src/core/index.js';
+import { ClearanceInput, handleClearanceRecord } from '../../src/clearanceTool.js';
+
+function memoryCache(): CacheStore {
+  const objects = new Map();
+  const queries = new Map();
+  return {
+    getObject: (id) => objects.get(id) ?? null,
+    upsertObject: (a) => {
+      objects.set(a.id, a);
+    },
+    getQuery: (k) => queries.get(k) ?? null,
+    putQuery: (k, ids) => {
+      queries.set(k, ids);
+    },
+  };
+}
+
+describe('clearance_record tool input contract', () => {
+  it('accepts an arbitrary string id — no ID_REGEX gate at the tool boundary', () => {
+    // The tool contract is "a non-cleared work returns a DENY manifest, not an
+    // error". A regex gate here (as get_artwork/cite use) would convert a
+    // malformed id into a ZodError instead of letting the engine emit the deny.
+    expect(ClearanceInput.safeParse({ id: 'not a valid id' }).success).toBe(true);
+    expect(ClearanceInput.safeParse({ id: 'met:436535' }).success).toBe(true);
+  });
+
+  it('still requires an id', () => {
+    expect(ClearanceInput.safeParse({}).success).toBe(false);
+    expect(ClearanceInput.safeParse({ id: 123 }).success).toBe(false);
+  });
+
+  it('a malformed id yields a deny manifest as a normal (non-error) tool result', async () => {
+    const fed = createFederation({ fetchers: {}, cache: memoryCache() });
+    const res = await handleClearanceRecord(fed, { id: 'not a valid id' });
+
+    expect(res.isError).toBeUndefined();
+    const env = JSON.parse(res.content[0].text);
+    expect(env.tier).toBe(0);
+    expect(env.payload.clearance.commercialReproduction.permitted).toBe(false);
+    expect(env.payload.clearance.commercialReproduction.basis.summary).toContain(
+      'invalid artwork id',
+    );
+  });
+});

--- a/tests/clearance/conformance.test.ts
+++ b/tests/clearance/conformance.test.ts
@@ -1,0 +1,134 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+import { describe, expect, it } from 'vitest';
+import { buildClearancePayload } from '../../src/core/clearance/manifest.js';
+import type { Artwork, ValidationResult } from '../../src/types.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const specDir = join(here, '../../spec/clearance/v0.1');
+const readJson = (rel: string) => JSON.parse(readFileSync(join(specDir, rel), 'utf8'));
+
+const ajv = new Ajv2020({ allErrors: true, strict: false });
+addFormats(ajv);
+const validate = ajv.compile(readJson('clearance-manifest.schema.json'));
+
+const OPTS = { engineVersion: '0.7.0', now: '2026-06-05T00:00:00.000Z' };
+
+function cc0Met(): Artwork {
+  return {
+    id: 'met:436535',
+    museum: {
+      code: 'met',
+      name: 'The Metropolitan Museum of Art',
+      url: 'https://www.metmuseum.org',
+    },
+    title: 'Wheat Field with Cypresses',
+    artist: {
+      name: 'Vincent van Gogh',
+      nationality: 'Dutch',
+      lifespan: '1853–1890',
+      attributionType: 'named',
+    },
+    displayDate: '1889',
+    yearStart: 1889,
+    yearEnd: 1889,
+    medium: 'Oil on canvas',
+    region: 'Europe',
+    period: null,
+    imageUrls: {
+      full: 'https://images.metmuseum.org/CRDImages/ep/original/436535.jpg',
+      thumbnail: 'https://images.metmuseum.org/CRDImages/ep/web-large/436535.jpg',
+    },
+    imageOpenAccess: true,
+    metadataOpenAccess: true,
+    license: {
+      type: 'CC0',
+      rawValue: 'true',
+      verificationSource: 'met.isPublicDomain',
+      verifiedAt: '2026-01-02T03:04:05.000Z',
+      confidence: 'high',
+    },
+    source: {
+      apiUrl: 'https://collectionapi.metmuseum.org/public/collection/v1/objects/436535',
+      pageUrl: 'https://www.metmuseum.org/art/collection/search/436535',
+    },
+  };
+}
+
+const accepted: ValidationResult = { status: 'accepted', artwork: cc0Met() };
+const denied: ValidationResult = {
+  status: 'rejected',
+  rejection: {
+    id: 'xyz:1',
+    museumCode: 'xyz',
+    reason: "rights_status='Educational Use Only' (strict default reject)",
+    rawSnapshot: null,
+  },
+};
+
+describe('Clearance Manifest conformance (ajv Draft 2020-12)', () => {
+  it('a freshly-built accepted CC0 payload validates', () => {
+    const ok = validate(buildClearancePayload(accepted, OPTS));
+    expect(validate.errors ?? []).toEqual([]);
+    expect(ok).toBe(true);
+  });
+
+  it('a freshly-built deny payload validates (a deny is a valid manifest)', () => {
+    const ok = validate(buildClearancePayload(denied, OPTS));
+    expect(validate.errors ?? []).toEqual([]);
+    expect(ok).toBe(true);
+  });
+
+  it('an unrecognised basis.rule stays structurally valid (advisory, not a reject)', () => {
+    const p = buildClearancePayload(accepted, OPTS);
+    p.clearance.commercialReproduction.basis.rule = 'some-unknown-future-rule';
+    expect(validate(p)).toBe(true);
+  });
+
+  it('rejects a payload missing a required block', () => {
+    const p = buildClearancePayload(accepted, OPTS) as Record<string, unknown>;
+    delete p.clearance;
+    expect(validate(p)).toBe(false);
+  });
+
+  it('rejects a bad confidence enum', () => {
+    const p = buildClearancePayload(accepted, OPTS);
+    (p.rights as { confidence: string }).confidence = 'pretty-sure';
+    expect(validate(p)).toBe(false);
+  });
+
+  it('rejects a malformed basis.rule (not bare kebab-case)', () => {
+    const p = buildClearancePayload(accepted, OPTS);
+    p.clearance.derivatives.basis.rule = 'Not Kebab Case';
+    expect(validate(p)).toBe(false);
+  });
+
+  it('rejects an @context missing the openclearance authority IRI', () => {
+    const p = buildClearancePayload(accepted, OPTS);
+    p['@context'] = ['https://schema.org/'];
+    expect(validate(p)).toBe(false);
+  });
+
+  it('the committed example manifests validate', () => {
+    for (const f of ['examples/cc0-accepted.json', 'examples/deny-unrecognized.json']) {
+      const ok = validate(readJson(f));
+      expect({ file: f, errors: validate.errors ?? [] }).toEqual({ file: f, errors: [] });
+      expect(ok).toBe(true);
+    }
+  });
+
+  it('the advisory-entry schema accepts an unrecognised_rule advisory', () => {
+    const validateAdv = ajv.compile(readJson('advisory-entry.schema.json'));
+    const adv = {
+      code: 'unrecognised_rule',
+      severity: 'advisory',
+      message: "rule 'some-unknown-future-rule' is not in the v0.1 baseline",
+      path: 'clearance.commercialReproduction.basis.rule',
+      rule: 'some-unknown-future-rule',
+    };
+    expect(validateAdv(adv)).toBe(true);
+  });
+});

--- a/tests/clearance/envelope.test.ts
+++ b/tests/clearance/envelope.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { wrapTier0 } from '../../src/core/clearance/envelope.js';
+
+describe('wrapTier0', () => {
+  it('wraps a payload with a JCS sha-256 hash that lives outside the payload', async () => {
+    const payload = { type: 'ClearanceManifest', b: 2, a: 1 };
+    const env = await wrapTier0(payload);
+
+    expect(env.tier).toBe(0);
+    expect(env.payload).toEqual(payload);
+    expect(env.integrity.alg).toBe('sha-256');
+    expect(env.integrity.jcs).toBe(true);
+    expect(env.integrity.hash).toMatch(/^[0-9a-f]{64}$/);
+    // the payload must never carry its own hash
+    expect(env.integrity).not.toHaveProperty('tier');
+    expect(JSON.stringify(env.payload)).not.toContain(env.integrity.hash);
+  });
+
+  it('is deterministic regardless of authored key order (canonicalize before hashing)', async () => {
+    const a = await wrapTier0({ type: 'ClearanceManifest', b: 2, a: 1 });
+    const b = await wrapTier0({ a: 1, b: 2, type: 'ClearanceManifest' });
+    expect(b.integrity.hash).toBe(a.integrity.hash);
+  });
+
+  it('hashes the RFC 8785 canonical bytes, not the raw serialization (known-answer vector)', async () => {
+    // sha-256 of the canonical form {"a":1,"b":2,"type":"ClearanceManifest"},
+    // computed independently of this implementation.
+    const env = await wrapTier0({ type: 'ClearanceManifest', b: 2, a: 1 });
+    expect(env.integrity.hash).toBe(
+      'fb3a2706bb349989bc6b588758232b9fc325afd511b18c6d59c42ebb33862f5f',
+    );
+  });
+
+  it('rejects payloads that are not canonicalizable JSON', async () => {
+    await expect(wrapTier0(() => 'not json')).rejects.toThrow();
+  });
+});

--- a/tests/clearance/federation-clearance.test.ts
+++ b/tests/clearance/federation-clearance.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { createFederation } from '../../src/core/index.js';
+import type { CacheStore } from '../../src/core/index.js';
+import type { Fetcher } from '../../src/fetchers/types.js';
+import type { Artwork, ValidationResult } from '../../src/types.js';
+
+function memoryCache(): CacheStore {
+  const objects = new Map<string, Artwork>();
+  const queries = new Map<string, string[]>();
+  return {
+    getObject: (id) => objects.get(id) ?? null,
+    upsertObject: (a) => {
+      objects.set(a.id, a);
+    },
+    getQuery: (k) => queries.get(k) ?? null,
+    putQuery: (k, ids) => {
+      queries.set(k, ids);
+    },
+  };
+}
+
+function cc0Artwork(id: string): Artwork {
+  const code = id.slice(0, id.indexOf(':'));
+  return {
+    id,
+    museum: { code, name: code.toUpperCase(), url: `https://${code}.example` },
+    title: `Work ${id}`,
+    artist: { name: 'Anon', attributionType: 'named' },
+    displayDate: '1700',
+    yearStart: 1700,
+    yearEnd: 1700,
+    medium: 'oil',
+    region: null,
+    period: null,
+    imageUrls: { full: `https://img.example/${id}.jpg` },
+    imageOpenAccess: true,
+    metadataOpenAccess: true,
+    license: {
+      type: 'CC0',
+      rawValue: 'true',
+      verificationSource: `${code}.isPublicDomain`,
+      verifiedAt: '2026-01-01T00:00:00.000Z',
+      confidence: 'high',
+    },
+    source: { apiUrl: `https://${code}.example/api/${id}`, pageUrl: `https://${code}.example/${id}` },
+  };
+}
+
+const accepting: Fetcher = {
+  code: 'test',
+  name: 'TEST',
+  async search() {
+    return [];
+  },
+  async getRaw(id) {
+    return { id };
+  },
+  normalize(raw): ValidationResult {
+    return { status: 'accepted', artwork: cc0Artwork((raw as { id: string }).id) };
+  },
+};
+
+const rejecting: Fetcher = {
+  code: 'test',
+  name: 'TEST',
+  async search() {
+    return [];
+  },
+  async getRaw(id) {
+    return { id };
+  },
+  normalize(raw): ValidationResult {
+    const id = (raw as { id: string }).id;
+    return {
+      status: 'rejected',
+      rejection: { id, museumCode: 'test', reason: 'test: not open', rawSnapshot: raw },
+    };
+  },
+};
+
+describe('federation.clearanceManifest', () => {
+  it('emits a Tier-0 envelope; an accepted id is permitted', async () => {
+    const fed = createFederation({ fetchers: { test: accepting }, cache: memoryCache() });
+    const env = await fed.clearanceManifest('test:1');
+    expect(env.tier).toBe(0);
+    expect(env.payload.type).toBe('ClearanceManifest');
+    expect(env.payload.clearance.commercialReproduction.permitted).toBe(true);
+    expect(env.integrity.hash).toMatch(/^[0-9a-f]{64}$/);
+    // the hash lives in the envelope, never inside the payload
+    expect(JSON.stringify(env.payload)).not.toContain(env.integrity.hash);
+  });
+
+  it('a rejected id yields a deny manifest, not an error', async () => {
+    const fed = createFederation({ fetchers: { test: rejecting }, cache: memoryCache() });
+    const env = await fed.clearanceManifest('test:9');
+    expect(env.payload.clearance.commercialReproduction.permitted).toBe(false);
+    expect(env.payload.clearance.commercialReproduction.basis.rule).toBe('default-deny');
+    expect(env.payload.verification.determinedBy.actor).toBe('engine:open-museum-mcp');
+  });
+
+  it('an invalid id yields a deny manifest carrying the reason, not a throw', async () => {
+    const fed = createFederation({ fetchers: { test: accepting }, cache: memoryCache() });
+    const env = await fed.clearanceManifest('not a valid id');
+    expect(env.payload.clearance.commercialReproduction.permitted).toBe(false);
+    expect(env.payload.clearance.commercialReproduction.basis.summary).toContain('invalid artwork id');
+  });
+
+  it('an unknown museum code yields a deny manifest', async () => {
+    const fed = createFederation({ fetchers: { test: accepting }, cache: memoryCache() });
+    const env = await fed.clearanceManifest('zzz:1');
+    expect(env.payload.clearance.commercialReproduction.permitted).toBe(false);
+    expect(env.payload.clearance.commercialReproduction.basis.summary).toContain('unknown museum code');
+  });
+
+  it('threads the host engine version into the manifest tool provenance', async () => {
+    const fed = createFederation({
+      fetchers: { test: accepting },
+      cache: memoryCache(),
+      engineVersion: '9.9.9',
+    });
+    const env = await fed.clearanceManifest('test:1');
+    expect(env.payload.verification.tool).toContain('@9.9.9');
+  });
+});

--- a/tests/clearance/licenseMap.test.ts
+++ b/tests/clearance/licenseMap.test.ts
@@ -26,13 +26,16 @@ describe('clearanceForLicense', () => {
     }
   });
 
-  it('PD ⇒ commercial + derivatives permitted, no attribution, NoC-US statement + pd-* rules', () => {
+  it('PD ⇒ commercial + derivatives permitted, no attribution, Public Domain Mark statement + pd-* rules', () => {
     const c = clearanceForLicense('PD');
     expect(c.commercialReproduction.permitted).toBe(true);
     expect(c.derivatives.permitted).toBe(true);
     expect(c.attributionRequired.required).toBe(false);
     expect(c.confidence).toBe('high');
-    expect(c.statement).toBe('http://rightsstatements.org/vocab/NoC-US/1.0/');
+    // Worldwide Public Domain Mark — the gate only emits PD for the CC Public
+    // Domain Mark (Europeana) and Wikimedia PD/PDM templates, never the
+    // US-scoped NoC-US statement.
+    expect(c.statement).toBe('https://creativecommons.org/publicdomain/mark/1.0/');
     expect(c.commercialReproduction.basis.rule).toBe('pd-grants-commercial');
     expect(c.derivatives.basis.rule).toBe('pd-grants-derivatives');
     expect(c.attributionRequired.basis.rule).toBe('pd-waives-attribution');

--- a/tests/clearance/licenseMap.test.ts
+++ b/tests/clearance/licenseMap.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { clearanceForLicense } from '../../src/core/clearance/licenseMap.js';
+
+describe('clearanceForLicense', () => {
+  it('CC0 ⇒ all permitted, no attribution, high confidence, CC0 statement', () => {
+    const c = clearanceForLicense('CC0');
+    expect(c.commercialReproduction.permitted).toBe(true);
+    expect(c.derivatives.permitted).toBe(true);
+    expect(c.attributionRequired.required).toBe(false);
+    expect(c.confidence).toBe('high');
+    expect(c.statement).toBe('https://creativecommons.org/publicdomain/zero/1.0/');
+  });
+
+  it('CC0 basis carries registered per-facet rule ids, license.type input, and a summary', () => {
+    const c = clearanceForLicense('CC0');
+    expect(c.commercialReproduction.basis.rule).toBe('cc0-grants-commercial');
+    expect(c.derivatives.basis.rule).toBe('cc0-grants-derivatives');
+    expect(c.attributionRequired.basis.rule).toBe('cc0-waives-attribution');
+    for (const b of [
+      c.commercialReproduction.basis,
+      c.derivatives.basis,
+      c.attributionRequired.basis,
+    ]) {
+      expect(b.inputs).toEqual([{ field: 'license.type', value: 'CC0' }]);
+      expect(b.summary.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('PD ⇒ commercial + derivatives permitted, no attribution, NoC-US statement + pd-* rules', () => {
+    const c = clearanceForLicense('PD');
+    expect(c.commercialReproduction.permitted).toBe(true);
+    expect(c.derivatives.permitted).toBe(true);
+    expect(c.attributionRequired.required).toBe(false);
+    expect(c.confidence).toBe('high');
+    expect(c.statement).toBe('http://rightsstatements.org/vocab/NoC-US/1.0/');
+    expect(c.commercialReproduction.basis.rule).toBe('pd-grants-commercial');
+    expect(c.derivatives.basis.rule).toBe('pd-grants-derivatives');
+    expect(c.attributionRequired.basis.rule).toBe('pd-waives-attribution');
+    expect(c.commercialReproduction.basis.inputs).toEqual([{ field: 'license.type', value: 'PD' }]);
+  });
+
+  it('fail-closed: every non-permissive type ⇒ all false, default-deny, low confidence, null statement', () => {
+    for (const t of ['CC-BY', 'CC-BY-SA', 'OTHER', 'UNKNOWN'] as const) {
+      const c = clearanceForLicense(t);
+      expect(c.commercialReproduction.permitted).toBe(false);
+      expect(c.derivatives.permitted).toBe(false);
+      expect(c.attributionRequired.required).toBe(false);
+      expect(c.confidence).toBe('low');
+      expect(c.statement).toBeNull();
+      expect(c.commercialReproduction.basis.rule).toBe('default-deny');
+      expect(c.derivatives.basis.rule).toBe('default-deny');
+      expect(c.attributionRequired.basis.rule).toBe('default-deny');
+      // the failing value is carried verbatim in the basis inputs (forensic trail)
+      expect(c.commercialReproduction.basis.inputs).toEqual([{ field: 'license.type', value: t }]);
+      expect(c.commercialReproduction.basis.summary).toContain('default deny');
+    }
+  });
+});

--- a/tests/clearance/manifest.test.ts
+++ b/tests/clearance/manifest.test.ts
@@ -1,6 +1,13 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { buildClearancePayload } from '../../src/core/clearance/manifest.js';
+import { europeanaFetcher } from '../../src/fetchers/europeana.js';
 import type { Artwork } from '../../src/types.js';
+
+const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), '../fixtures');
+const fixture = (name: string) => JSON.parse(readFileSync(join(fixturesDir, name), 'utf8'));
 
 const NOW = '2026-06-05T12:00:00.000Z';
 const OPTS = { engineVersion: '0.7.0', now: NOW };
@@ -159,5 +166,26 @@ describe('buildClearancePayload — rejected / deny', () => {
 
   it('omits citation for an unidentified rejected record', () => {
     expect(p.citation).toBeUndefined();
+  });
+});
+
+describe('buildClearancePayload — PD statement matches gate-accepted vocabulary', () => {
+  // A real Public Domain record run through the actual rights gate. The emitted
+  // rights.statement must be a URI the gate genuinely accepts for PD — the gate
+  // only ever yields type=PD for the worldwide Public Domain Mark (Europeana)
+  // and Wikimedia PD/PDM templates, never the US-scoped NoC-US statement.
+  const result = europeanaFetcher.normalize(fixture('europeana-accepted-pdm.json'));
+
+  it('emits the worldwide Public Domain Mark, aligned with the gate rawValue', () => {
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.license.type).toBe('PD');
+
+    const p = buildClearancePayload(result, OPTS);
+    expect(p.rights.statement).toBe('https://creativecommons.org/publicdomain/mark/1.0/');
+    // The clearance statement is not a hardcoded divergence from the gate: for
+    // this record the gate's own accepted rawValue is the same PDM URI.
+    expect(p.rights.statement).toBe(result.artwork.license.rawValue);
+    expect(p.rights.statement).not.toContain('rightsstatements.org');
   });
 });

--- a/tests/clearance/manifest.test.ts
+++ b/tests/clearance/manifest.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import { buildClearancePayload } from '../../src/core/clearance/manifest.js';
+import type { Artwork } from '../../src/types.js';
+
+const NOW = '2026-06-05T12:00:00.000Z';
+const OPTS = { engineVersion: '0.7.0', now: NOW };
+
+function cc0Met(over: Partial<Artwork> = {}): Artwork {
+  return {
+    id: 'met:436535',
+    museum: { code: 'met', name: 'The Metropolitan Museum of Art', url: 'https://www.metmuseum.org' },
+    title: 'Wheat Field with Cypresses',
+    artist: {
+      name: 'Vincent van Gogh',
+      nationality: 'Dutch',
+      lifespan: '1853–1890',
+      attributionType: 'named',
+    },
+    displayDate: '1889',
+    yearStart: 1889,
+    yearEnd: 1889,
+    medium: 'Oil on canvas',
+    region: 'Europe',
+    period: null,
+    imageUrls: {
+      full: 'https://images.metmuseum.org/CRDImages/ep/original/436535.jpg',
+      thumbnail: 'https://images.metmuseum.org/CRDImages/ep/web-large/436535.jpg',
+    },
+    imageOpenAccess: true,
+    metadataOpenAccess: true,
+    license: {
+      type: 'CC0',
+      rawValue: 'true',
+      verificationSource: 'met.isPublicDomain',
+      verifiedAt: '2026-01-02T03:04:05.000Z',
+      confidence: 'high',
+    },
+    source: {
+      apiUrl: 'https://collectionapi.metmuseum.org/public/collection/v1/objects/436535',
+      pageUrl: 'https://www.metmuseum.org/art/collection/search/436535',
+    },
+    ...over,
+  };
+}
+
+describe('buildClearancePayload — accepted CC0', () => {
+  const p = buildClearancePayload({ status: 'accepted', artwork: cc0Met() }, OPTS);
+
+  it('carries the JSON-LD envelope constants (schema.org with trailing slash)', () => {
+    expect(p.type).toBe('ClearanceManifest');
+    expect(p.specVersion).toBe('0.1');
+    expect(p['@context']).toContain('https://schema.org/');
+    expect(p['@context']).toContain('http://purl.org/dc/terms/');
+    expect(p['@context']).toContain('https://openclearance.org/v0.1/context.jsonld');
+  });
+
+  it('mirrors engine Artwork vocabulary in work + source', () => {
+    expect(p.work.id).toBe('met:436535');
+    expect(p.work.title).toBe('Wheat Field with Cypresses');
+    expect(p.work.artist?.name).toBe('Vincent van Gogh');
+    expect(p.work.displayDate).toBe('1889');
+    expect(p.work.yearStart).toBe(1889);
+    expect(p.work.medium).toBe('Oil on canvas');
+    expect(p.source.museum).toEqual({
+      code: 'met',
+      name: 'The Metropolitan Museum of Art',
+      url: 'https://www.metmuseum.org',
+    });
+    expect(p.source.apiUrl).toContain('collectionapi.metmuseum.org');
+    expect(p.source.imageUrls?.full).toContain('images.metmuseum.org');
+  });
+
+  it('permits all uses with high confidence and the CC0 statement', () => {
+    expect(p.clearance.commercialReproduction.permitted).toBe(true);
+    expect(p.clearance.derivatives.permitted).toBe(true);
+    expect(p.clearance.attributionRequired.required).toBe(false);
+    expect(p.clearance.commercialReproduction.basis.rule).toBe('cc0-grants-commercial');
+    expect(p.rights.statement).toBe('https://creativecommons.org/publicdomain/zero/1.0/');
+    expect(p.rights.confidence).toBe('high');
+  });
+
+  it('binds the raw API value to its field name (forensic link)', () => {
+    expect(p.rights.sourceApiValue).toEqual({ field: 'isPublicDomain', value: 'true' });
+    expect(p.rights.imageOpenAccess).toBe(true);
+    expect(p.rights.metadataOpenAccess).toBe(true);
+  });
+
+  it('records the determination as an auditable event sourced to the museum', () => {
+    expect(p.verification.determinedBy).toEqual({ actor: 'museum:met', role: 'rights-source' });
+    expect(p.verification.tool).toBe('open-museum-mcp@0.7.0 · met.isPublicDomain');
+    // determinedAt is the engine verification time, deterministic (not build time)
+    expect(p.verification.determinedAt).toBe('2026-01-02T03:04:05.000Z');
+    expect(p.verification.determinationSource).toMatchObject({
+      type: 'api-field',
+      field: 'isPublicDomain',
+      retrievedAt: '2026-01-02T03:04:05.000Z',
+    });
+    expect(p.verification.ruleContext).toContain('CC0');
+  });
+
+  it('emits all three citation styles', () => {
+    expect(p.citation?.full.length).toBeGreaterThan(0);
+    expect(p.citation?.caption.length).toBeGreaterThan(0);
+    expect(p.citation?.short.length).toBeGreaterThan(0);
+  });
+
+  it('never embeds its own hash (payload purity)', () => {
+    expect(p).not.toHaveProperty('integrity');
+    expect(p).not.toHaveProperty('hash');
+  });
+});
+
+describe('buildClearancePayload — rejected / deny', () => {
+  const p = buildClearancePayload(
+    {
+      status: 'rejected',
+      rejection: {
+        id: 'xyz:1',
+        museumCode: 'xyz',
+        reason: "rights_status='Educational Only' (strict default reject)",
+        rawSnapshot: { rights_status: 'Educational Only' },
+      },
+    },
+    OPTS,
+  );
+
+  it('is a definitive deny, not an error — all clearance false, low confidence, null statement', () => {
+    expect(p.type).toBe('ClearanceManifest');
+    expect(p.clearance.commercialReproduction.permitted).toBe(false);
+    expect(p.clearance.derivatives.permitted).toBe(false);
+    expect(p.clearance.attributionRequired.required).toBe(false);
+    expect(p.rights.statement).toBeNull();
+    expect(p.rights.confidence).toBe('low');
+    expect(p.rights.sourceApiValue).toBeNull();
+    expect(p.rights.imageOpenAccess).toBe(false);
+    expect(p.rights.metadataOpenAccess).toBe(false);
+  });
+
+  it('carries the gate reason verbatim in the basis (default-deny rule)', () => {
+    const b = p.clearance.commercialReproduction.basis;
+    expect(b.rule).toBe('default-deny');
+    expect(b.summary).toContain('default deny');
+    expect(b.summary).toContain('Educational Only');
+    expect(b.inputs).toContainEqual({
+      field: 'rejection.reason',
+      value: "rights_status='Educational Only' (strict default reject)",
+    });
+  });
+
+  it('attributes the deny to the engine rights-gate, not the museum', () => {
+    expect(p.verification.determinedBy).toEqual({
+      actor: 'engine:open-museum-mcp',
+      role: 'rights-gate',
+    });
+    expect(p.verification.determinedAt).toBe(NOW);
+    expect(p.work.id).toBe('xyz:1');
+    expect(p.source.museum.code).toBe('xyz');
+  });
+
+  it('omits citation for an unidentified rejected record', () => {
+    expect(p.citation).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Adds a `clearance_record` MCP tool that emits a portable, fail-closed **Clearance Manifest** for any artwork id, plus the in-repo v0.1 spec it conforms to. Shipped as **0.7.0**.

## What a Clearance Manifest is

A machine-readable JSON-LD rights-clearance artifact for one work: its provenance, citation, the rights determination, and an auditable trail of *how* that determination was reached — answering reuse questions ("may I print this and sell it?") as binary booleans. A non-cleared work returns a definitive **deny** manifest, not an error: a deny is a valid answer.

## Architecture

- **Fail-closed, single source of truth.** One `license → clearance` table (`src/core/clearance/licenseMap.ts`) is the only place determinations live; anything not affirmatively permissive resolves to all-false / `confidence: low` / `default-deny`, with the failing value carried verbatim in `basis.inputs`.
- **Payload purity + Tier-0 envelope.** The payload never holds its own hash. `wrapTier0` computes SHA-256 over the **RFC 8785 (JCS)** canonicalization of the payload (canonicalize *first*, then hash). The JCS canonicalizer is lifted from the vetted PIF sibling standard — zero deps.
- **Workers-safe core.** `src/core/clearance/` has **zero runtime dependencies and no `node:` imports** (Web Crypto only). `Federation.clearanceManifest(id)` exposes it.
- **`basis` is structured** (`{ rule, inputs, summary }`, all required). Rule ids are an **open set** resolving to a non-normative registry; an unrecognised id yields a non-fatal `unrecognised_rule` advisory, never a schema rejection.

## Spec (`spec/clearance/v0.1/`)

Authored against the permanent `openclearance.org/v0.1/` namespace: normative `spec.md`, JSON Schema (Draft 2020-12), JSON-LD `context.jsonld`, the rule registry, the advisory schema, conformance example manifests in `examples/`, and a URL-stability `VERSIONING.md`. The `@context` IRI is the sole normative authority; `specVersion` is convenience only.

## Review-round fixes (this branch, as separate commits)

- **PD rights accuracy:** PD now maps to the worldwide Public Domain Mark (`creativecommons.org/publicdomain/mark/1.0/`), not the US-scoped NoC-US statement the gate never emits. Added an integration test asserting the emitted `rights.statement` equals the gate's own accepted rawValue for a real PDM record. Propagated to `rules.md` / `spec.md`.
- **Spec/filesystem agreement:** the Conformance section linked to a non-existent `conformance/` dir; now points at `examples/` + the ajv harness path.
- **Tool contract consistency:** `clearance_record` no longer regex-gates the id (which would raise a ZodError); a malformed id now flows to the engine and returns a deny manifest, per the tool's stated contract. Input schema + handler extracted to a testable `src/clearanceTool.ts`.

## Scope

v0.1 implements **Tier 0 completely**. Tiers 1/2 (C2PA signing) are spec-documented as defined-but-not-implemented — no signing code, no stubs.

## Verification

- `tscq --noEmit` → exit 0
- `npm test` → **252 passed** (215 baseline + clearance suite incl. the review-round tests)
- `npm run build` → core exports `createFederation`; `dist/core/clearance` has no `node:` imports
- **Live smoke** against the Met API: `met:436535` / `met:11207` emit permitted CC0 manifests whose Tier-0 JCS hash recomputes; `met:1` (real non-public-domain), an unknown museum, and an invalid id each emit a valid `default-deny` manifest.

Independent of #62 (Met search relevance) — one concern per PR. **Holding for review; not merging unilaterally.**

Co-Authored by Pramod Prasanth <pramod@chainalign.com>