### PR TITLE
chore(release): bundle spec/clearance in the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "files": [
     "dist",
+    "spec/clearance",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
## Summary
- The `files` field shipped only `dist/`, so the normative openclearance v0.1 spec (schema, `@context`, rules, examples) was **absent from the published npm tarball**.
- Add `spec/clearance` to `files` so consumers can validate Clearance Manifests offline against the bundled schema. openclearance.org remains the canonical served copy.
- No runtime or version change — release-packaging only. Blocks the 0.7.0 publish (which should ship the spec).

## Test Plan
- [x] `npm pack --dry-run` lists all 8 `spec/clearance/**` files in the tarball
- [x] `dist/core/clearance/*` and `dist/server.js` still present
- [x] `npm test` → 256 passing on this base
- [x] `npm run build` clean

Co-Authored by Pramod Prasanth <pramod@chainalign.com>