### PR TITLE
feat: colour facet (v0.8b) — extraction, colour search, colour-family facet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] — 2026-06-06
+
+> Published together with the unreleased 0.8.0 medium work — this single npm publish carries **both** the medium facet (0.8.0) and the colour facet (0.9.0).
+
+### Added
+
+- **Colour facet (v0.8b) — dominant-colour extraction, colour search, colour family facet.** Node-side colour enrichment runs after the rights gate on each accepted record: it fetches the **thumbnail**, extracts a dominant colour + top-5 palette via the optional `sharp` dependency, and stores `dominantColor` (hex), `palette` (`[{hex, weight}]`), and `colorFamily` (one of 11 perceptual bins) on the cached `Artwork` (additive fields; reserved `Tradition`/`obscurityScore` untouched). CIELAB is derived from the hex on demand.
+- **`search_artworks` colour filters.** `color` (hex) re-ranks results by **CIEDE2000** perceptual nearness (nearest first; colourless records excluded from a colour-ranked search); `color_family` filters to a coarse bin. Both are post-fetch over the bounded window, like the medium/year filters.
+- **`facets()` colour-family bucket.** Adds `colorFamily` counts alongside medium/date/artist, over the same bounded sample window.
+- **Colour read API exported from the core** (`ciede2000`, `hexToLab`, `nearestColorFamily`, `quantizeColors`, `COLOR_FAMILIES`, types) — Workers-safe, so the web app can render swatches and run colour search over precomputed colour.
+
+### Architecture / constraints
+
+- **`sharp` is an OPTIONAL, lazily-loaded dependency.** Colour extraction lives in Node-only `src/color/extract.ts`, never imported by the engine core, and is **injected** into the federation as a capability. If `sharp` is absent — the `.mcpb` bundle (built native-free; its staging manifest excludes optional deps), a Cloudflare Workers runtime, or any sharp-less install — extraction **fails open**: colour fields stay unset and the record is still valid. The Workers-safe core contains zero `sharp`/`node:` imports and only ever *reads* precomputed colour.
+
+### Follow-up (not in this release)
+
+- **Reaching the web app's KV cache.** The Node MCP server's `node:sqlite` cache is not the web app's Cloudflare KV, so extracting colour in the MCP server does not by itself populate the web app. v0.8b ships the **engine capability** (extraction + storage + colour search + colour facet + Workers-safe read path). A Node-side enrichment path or scheduled job that writes precomputed colour into the web app's KV is a separate follow-up.
+
 ## [0.8.0] — 2026-06-06
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ authors:
 repository-code: "https://github.com/cfpramod/open-museum-mcp"
 url: "https://github.com/cfpramod/open-museum-mcp"
 license: MIT
-version: 0.8.0
+version: 0.9.0
 date-released: "2026-06-06"
 keywords:
   - mcp

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "open-museum-mcp",
   "display_name": "Open Museum",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "License-verified federated search across open-access museum collections.",
   "long_description": "Federated MCP search across major open-access museum collections — currently The Met, Cleveland Museum of Art, Art Institute of Chicago, Wikimedia Commons, and Europeana, with more being added. Records pass per-museum rights verification (strict-default-deny on ambiguous license signals) and ship with citation output in `full`, `caption`, and `short` formats — paste-ready for papers, slide decks, and inline references.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-museum-mcp",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-museum-mcp",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
@@ -26,6 +26,9 @@
       },
       "engines": {
         "node": ">=22.5"
+      },
+      "optionalDependencies": {
+        "sharp": "^0.34.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -44,7 +47,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -514,6 +516,472 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -1258,7 +1726,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -2402,6 +2870,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
@@ -2452,6 +2933,51 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -2643,7 +3169,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD",
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-museum-mcp",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "MCP server for license-verified search across open-access museum collections (The Met, Cleveland, AIC, Wikimedia Commons, Europeana).",
   "type": "module",
   "main": "dist/server.js",
@@ -67,5 +67,8 @@
     "tsx": "^4.19.2",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"
+  },
+  "optionalDependencies": {
+    "sharp": "^0.34.0"
   }
 }

--- a/src/color/colorMath.ts
+++ b/src/color/colorMath.ts
@@ -53,6 +53,12 @@ export interface ColorData {
 
 // --- hex <-> rgb ---
 
+/**
+ * Parse a 6-digit hex colour (with or without leading `#`) to RGB. Callers MUST
+ * pre-validate the input — a malformed string yields NaN channels rather than
+ * throwing. The server boundary already Zod-guards the `color` param against
+ * `^#?[0-9a-fA-F]{6}$`.
+ */
 export function hexToRgb(hex: string): Rgb {
   const h = hex.replace(/^#/, '');
   return {
@@ -180,39 +186,54 @@ export function ciede2000(lab1: Lab, lab2: Lab): number {
 interface FamilyRef {
   name: ColorFamily;
   hex: string;
+  /** Achromatic bins (no hue) — black/neutral/white. Gated behind a chroma floor. */
+  achromatic?: boolean;
 }
 
-// Reference anchors for the eleven bins. A colour is assigned to the family
-// whose anchor is nearest in CIEDE2000 — because CIEDE2000 weights chroma
-// strongly, low-chroma colours fall naturally to black/neutral/white by
-// lightness rather than to a saturated hue.
+// Reference anchors for the eleven bins. Binning is two-stage so that lightness
+// never overrides hue: a colour with chroma at or above CHROMA_THRESHOLD is
+// matched against the HUE anchors only (so a dark red stays red, a pale pink
+// stays pink, instead of collapsing onto black/white), while a near-grey colour
+// below the floor is matched against the achromatic anchors (black/neutral/white)
+// by lightness. Within the chosen set the nearest anchor by CIEDE2000 wins.
 const FAMILY_REFS: FamilyRef[] = [
   { name: 'red', hex: '#ff0000' },
   { name: 'orange', hex: '#ff8000' },
   { name: 'yellow', hex: '#ffff00' },
-  { name: 'green', hex: '#00a000' },
+  { name: 'green', hex: '#00cc00' },
   { name: 'blue', hex: '#0000ff' },
   { name: 'purple', hex: '#800080' },
   { name: 'pink', hex: '#ff80c0' },
   { name: 'brown', hex: '#804000' },
-  { name: 'neutral', hex: '#808080' },
-  { name: 'black', hex: '#000000' },
-  { name: 'white', hex: '#ffffff' },
+  { name: 'neutral', hex: '#808080', achromatic: true },
+  { name: 'black', hex: '#000000', achromatic: true },
+  { name: 'white', hex: '#ffffff', achromatic: true },
 ];
 
+// CIELAB chroma (C* = hypot(a, b)) at/above which a colour is treated as having
+// a hue. Below it the colour is near-grey and binned achromatic. Tuned so pale
+// tints (e.g. #ffd0d0, C≈18) keep their hue while muted greys (C≲10) stay neutral.
+const CHROMA_THRESHOLD = 12;
+
+// A colour in the orange hue sector below this lightness is brown (= dark,
+// muted orange). Above it, it stays orange.
+const BROWN_MAX_L = 45;
+
 /** The eleven colour-family bins with their reference anchor hexes. */
-export const COLOR_FAMILIES: ReadonlyArray<{ name: ColorFamily; hex: string }> = FAMILY_REFS;
+export const COLOR_FAMILIES: ReadonlyArray<{ name: ColorFamily; hex: string }> = FAMILY_REFS.map(
+  ({ name, hex }) => ({ name, hex }),
+);
 
-const FAMILY_LABS: Array<{ name: ColorFamily; lab: Lab }> = FAMILY_REFS.map((f) => ({
-  name: f.name,
-  lab: hexToLab(f.hex),
-}));
+// Achromatic anchors (black/neutral/white) for the near-grey branch — matched by
+// CIEDE2000, which for chromaless colours reduces to a lightness comparison.
+const ACHROMATIC_LABS: Array<{ name: ColorFamily; lab: Lab }> = FAMILY_REFS.filter(
+  (f) => f.achromatic,
+).map((f) => ({ name: f.name, lab: hexToLab(f.hex) }));
 
-/** Bin a CIELAB colour to its nearest colour family by CIEDE2000. */
-export function nearestColorFamily(lab: Lab): ColorFamily {
-  let best: ColorFamily = 'neutral';
+function nearestIn(lab: Lab, candidates: Array<{ name: ColorFamily; lab: Lab }>): ColorFamily {
+  let best = candidates[0].name;
   let bestDist = Infinity;
-  for (const ref of FAMILY_LABS) {
+  for (const ref of candidates) {
     const d = ciede2000(lab, ref.lab);
     if (d < bestDist) {
       bestDist = d;
@@ -220,6 +241,37 @@ export function nearestColorFamily(lab: Lab): ColorFamily {
     }
   }
   return best;
+}
+
+// Map a CIELAB hue angle (degrees) to a spectral family. Boundaries are the
+// midpoints between adjacent anchor hue angles (red 40°, orange 60°, yellow 103°,
+// green 136°, blue 306°, purple 328°, pink 349°); the wide green→blue span
+// absorbs the rarely-seen cyan/teal region. Hue angle is lightness-invariant, so
+// a dark or pale colour keeps its hue family instead of collapsing to black/white.
+function hueSector(h: number): ColorFamily {
+  if (h >= 14.5 && h < 50) return 'red';
+  if (h >= 50 && h < 81.5) return 'orange';
+  if (h >= 81.5 && h < 119.5) return 'yellow';
+  if (h >= 119.5 && h < 221) return 'green';
+  if (h >= 221 && h < 317) return 'blue';
+  if (h >= 317 && h < 338.5) return 'purple';
+  return 'pink'; // [338.5, 360) ∪ [0, 14.5)
+}
+
+/**
+ * Bin a CIELAB colour to a colour family. Near-grey colours
+ * (C* < CHROMA_THRESHOLD) go to black/neutral/white by lightness. Chromatic
+ * colours are binned by hue angle (lightness-invariant, so dark reds stay red
+ * and pale pinks stay pink), with a dark orange reclassified as brown.
+ */
+export function nearestColorFamily(lab: Lab): ColorFamily {
+  const chroma = Math.hypot(lab.a, lab.b);
+  if (chroma < CHROMA_THRESHOLD) return nearestIn(lab, ACHROMATIC_LABS);
+
+  let hue = (Math.atan2(lab.b, lab.a) * 180) / Math.PI;
+  if (hue < 0) hue += 360;
+  const family = hueSector(hue);
+  return family === 'orange' && lab.l < BROWN_MAX_L ? 'brown' : family;
 }
 
 // --- quantization ---

--- a/src/color/colorMath.ts
+++ b/src/color/colorMath.ts
@@ -1,0 +1,266 @@
+/**
+ * Pure colour math — Workers-safe (no `node:` imports, no `sharp`, no I/O).
+ *
+ * This is the READ-side of the colour feature: hex/RGB/CIELAB conversion,
+ * CIEDE2000 perceptual distance, the controlled colour-family bins, and a small
+ * pixel quantizer. Colour *extraction* (decoding image bytes) lives in the
+ * Node-only `extract.ts` and is never imported by the engine core, so the core
+ * stays runnable on Cloudflare Workers, which only ever read precomputed colour.
+ */
+
+export interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+export interface Lab {
+  l: number;
+  a: number;
+  b: number;
+}
+
+export interface PaletteEntry {
+  hex: string;
+  /** Fraction of sampled pixels in this colour's cluster, 0..1. */
+  weight: number;
+}
+
+export const COLOR_FAMILY_NAMES = [
+  'red',
+  'orange',
+  'yellow',
+  'green',
+  'blue',
+  'purple',
+  'pink',
+  'brown',
+  'neutral',
+  'black',
+  'white',
+] as const;
+
+export type ColorFamily = (typeof COLOR_FAMILY_NAMES)[number];
+
+/** Precomputed colour for one artwork. Stored on the cached record. */
+export interface ColorData {
+  dominantColor: string;
+  palette: PaletteEntry[];
+  colorFamily: ColorFamily;
+  /** CIELAB of the dominant colour, for distance queries (derivable from hex). */
+  lab: Lab;
+}
+
+// --- hex <-> rgb ---
+
+export function hexToRgb(hex: string): Rgb {
+  const h = hex.replace(/^#/, '');
+  return {
+    r: parseInt(h.slice(0, 2), 16),
+    g: parseInt(h.slice(2, 4), 16),
+    b: parseInt(h.slice(4, 6), 16),
+  };
+}
+
+export function rgbToHex({ r, g, b }: Rgb): string {
+  const c = (n: number) => Math.max(0, Math.min(255, Math.round(n))).toString(16).padStart(2, '0');
+  return `#${c(r)}${c(g)}${c(b)}`;
+}
+
+// --- rgb -> CIELAB (sRGB, D65) ---
+
+function srgbToLinear(channel: number): number {
+  const c = channel / 255;
+  return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+export function rgbToLab({ r, g, b }: Rgb): Lab {
+  const R = srgbToLinear(r);
+  const G = srgbToLinear(g);
+  const B = srgbToLinear(b);
+  // sRGB -> XYZ (D65), scaled to the 0..100 reference-white range.
+  const x = (R * 0.4124 + G * 0.3576 + B * 0.1805) * 100;
+  const y = (R * 0.2126 + G * 0.7152 + B * 0.0722) * 100;
+  const z = (R * 0.0193 + G * 0.1192 + B * 0.9505) * 100;
+  // D65 reference white.
+  const Xn = 95.047;
+  const Yn = 100.0;
+  const Zn = 108.883;
+  const e = 216 / 24389;
+  const k = 24389 / 27;
+  const f = (t: number) => (t > e ? Math.cbrt(t) : (k * t + 16) / 116);
+  const fx = f(x / Xn);
+  const fy = f(y / Yn);
+  const fz = f(z / Zn);
+  return { l: 116 * fy - 16, a: 500 * (fx - fy), b: 200 * (fy - fz) };
+}
+
+export function hexToLab(hex: string): Lab {
+  return rgbToLab(hexToRgb(hex));
+}
+
+// --- CIEDE2000 perceptual distance ---
+
+const DEG = Math.PI / 180;
+
+function hueDeg(b: number, ap: number): number {
+  if (b === 0 && ap === 0) return 0;
+  const h = Math.atan2(b, ap) / DEG;
+  return h < 0 ? h + 360 : h;
+}
+
+/** CIEDE2000 colour difference (Sharma, Wu & Dalal 2005). kL=kC=kH=1. */
+export function ciede2000(lab1: Lab, lab2: Lab): number {
+  const { l: L1, a: a1, b: b1 } = lab1;
+  const { l: L2, a: a2, b: b2 } = lab2;
+
+  const C1 = Math.hypot(a1, b1);
+  const C2 = Math.hypot(a2, b2);
+  const Cbar = (C1 + C2) / 2;
+  const Cbar7 = Math.pow(Cbar, 7);
+  const G = 0.5 * (1 - Math.sqrt(Cbar7 / (Cbar7 + Math.pow(25, 7))));
+
+  const a1p = (1 + G) * a1;
+  const a2p = (1 + G) * a2;
+  const C1p = Math.hypot(a1p, b1);
+  const C2p = Math.hypot(a2p, b2);
+  const h1p = hueDeg(b1, a1p);
+  const h2p = hueDeg(b2, a2p);
+
+  const dLp = L2 - L1;
+  const dCp = C2p - C1p;
+
+  let dhp = 0;
+  if (C1p * C2p !== 0) {
+    let diff = h2p - h1p;
+    if (diff > 180) diff -= 360;
+    else if (diff < -180) diff += 360;
+    dhp = diff;
+  }
+  const dHp = 2 * Math.sqrt(C1p * C2p) * Math.sin((dhp / 2) * DEG);
+
+  const Lbarp = (L1 + L2) / 2;
+  const Cbarp = (C1p + C2p) / 2;
+
+  let hbarp = h1p + h2p;
+  if (C1p * C2p !== 0) {
+    if (Math.abs(h1p - h2p) > 180) {
+      if (h1p + h2p < 360) hbarp = (h1p + h2p + 360) / 2;
+      else hbarp = (h1p + h2p - 360) / 2;
+    } else {
+      hbarp = (h1p + h2p) / 2;
+    }
+  }
+
+  const T =
+    1 -
+    0.17 * Math.cos((hbarp - 30) * DEG) +
+    0.24 * Math.cos(2 * hbarp * DEG) +
+    0.32 * Math.cos((3 * hbarp + 6) * DEG) -
+    0.2 * Math.cos((4 * hbarp - 63) * DEG);
+
+  const dtheta = 30 * Math.exp(-Math.pow((hbarp - 275) / 25, 2));
+  const Cbarp7 = Math.pow(Cbarp, 7);
+  const Rc = 2 * Math.sqrt(Cbarp7 / (Cbarp7 + Math.pow(25, 7)));
+  const Sl = 1 + (0.015 * Math.pow(Lbarp - 50, 2)) / Math.sqrt(20 + Math.pow(Lbarp - 50, 2));
+  const Sc = 1 + 0.045 * Cbarp;
+  const Sh = 1 + 0.015 * Cbarp * T;
+  const Rt = -Math.sin(2 * dtheta * DEG) * Rc;
+
+  return Math.sqrt(
+    Math.pow(dLp / Sl, 2) +
+      Math.pow(dCp / Sc, 2) +
+      Math.pow(dHp / Sh, 2) +
+      Rt * (dCp / Sc) * (dHp / Sh),
+  );
+}
+
+// --- colour-family bins ---
+
+interface FamilyRef {
+  name: ColorFamily;
+  hex: string;
+}
+
+// Reference anchors for the eleven bins. A colour is assigned to the family
+// whose anchor is nearest in CIEDE2000 — because CIEDE2000 weights chroma
+// strongly, low-chroma colours fall naturally to black/neutral/white by
+// lightness rather than to a saturated hue.
+const FAMILY_REFS: FamilyRef[] = [
+  { name: 'red', hex: '#ff0000' },
+  { name: 'orange', hex: '#ff8000' },
+  { name: 'yellow', hex: '#ffff00' },
+  { name: 'green', hex: '#00a000' },
+  { name: 'blue', hex: '#0000ff' },
+  { name: 'purple', hex: '#800080' },
+  { name: 'pink', hex: '#ff80c0' },
+  { name: 'brown', hex: '#804000' },
+  { name: 'neutral', hex: '#808080' },
+  { name: 'black', hex: '#000000' },
+  { name: 'white', hex: '#ffffff' },
+];
+
+/** The eleven colour-family bins with their reference anchor hexes. */
+export const COLOR_FAMILIES: ReadonlyArray<{ name: ColorFamily; hex: string }> = FAMILY_REFS;
+
+const FAMILY_LABS: Array<{ name: ColorFamily; lab: Lab }> = FAMILY_REFS.map((f) => ({
+  name: f.name,
+  lab: hexToLab(f.hex),
+}));
+
+/** Bin a CIELAB colour to its nearest colour family by CIEDE2000. */
+export function nearestColorFamily(lab: Lab): ColorFamily {
+  let best: ColorFamily = 'neutral';
+  let bestDist = Infinity;
+  for (const ref of FAMILY_LABS) {
+    const d = ciede2000(lab, ref.lab);
+    if (d < bestDist) {
+      bestDist = d;
+      best = ref.name;
+    }
+  }
+  return best;
+}
+
+// --- quantization ---
+
+// Quantize each channel to 16 levels (>>4) so near-identical pixels cluster.
+function bucketKey({ r, g, b }: Rgb): number {
+  return ((r >> 4) << 8) | ((g >> 4) << 4) | (b >> 4);
+}
+
+/**
+ * Cluster sampled pixels into a dominant colour + top-5 palette, then derive the
+ * CIELAB and colour family of the dominant. Returns null for an empty sample set
+ * so the caller can fail open (colour fields stay null, record still valid).
+ */
+export function quantizeColors(samples: Rgb[]): ColorData | null {
+  if (samples.length === 0) return null;
+
+  const buckets = new Map<number, { count: number; r: number; g: number; b: number }>();
+  for (const px of samples) {
+    const key = bucketKey(px);
+    let e = buckets.get(key);
+    if (!e) {
+      e = { count: 0, r: 0, g: 0, b: 0 };
+      buckets.set(key, e);
+    }
+    e.count++;
+    e.r += px.r;
+    e.g += px.g;
+    e.b += px.b;
+  }
+
+  const total = samples.length;
+  const palette: PaletteEntry[] = [...buckets.values()]
+    .sort((x, y) => y.count - x.count)
+    .slice(0, 5)
+    .map((e) => ({
+      hex: rgbToHex({ r: e.r / e.count, g: e.g / e.count, b: e.b / e.count }),
+      weight: e.count / total,
+    }));
+
+  const dominantColor = palette[0].hex;
+  const lab = hexToLab(dominantColor);
+  return { dominantColor, palette, colorFamily: nearestColorFamily(lab), lab };
+}

--- a/src/color/extract.ts
+++ b/src/color/extract.ts
@@ -1,0 +1,104 @@
+/**
+ * Node-side colour extraction. NOT Workers-safe and NOT imported by the engine
+ * core — only the Node MCP server (or a future enrichment job) wires it in.
+ *
+ * `sharp` is an OPTIONAL, lazily-loaded native dependency. If it is absent — the
+ * `.mcpb` bundle (which is built native-free), a Workers runtime, or CI without
+ * it — extraction is simply skipped and returns null. Colour is an enrichment,
+ * so it fails OPEN: a record with no colour is still valid (unlike the rights
+ * gate, which fails closed). Image-fetch and decode failures fail open too.
+ */
+
+import type { Artwork } from '../types.js';
+import { quantizeColors, type ColorData, type Rgb } from './colorMath.js';
+
+/** Minimal structural type for the slice of sharp's API we use. */
+export type SharpLike = (input: Uint8Array) => {
+  resize: (w: number, h: number, opts?: unknown) => ReturnType<SharpLike>;
+  raw: () => ReturnType<SharpLike>;
+  toBuffer: (opts: { resolveWithObject: true }) => Promise<{
+    data: Uint8Array;
+    info: { width: number; height: number; channels: number };
+  }>;
+};
+
+export interface ColorExtractorOptions {
+  /**
+   * Lazily load sharp; resolves null when unavailable (fail-open). Injectable so
+   * tests never depend on the native module being installed.
+   */
+  loadSharp?: () => Promise<SharpLike | null>;
+  /** Fetch image bytes; resolves null on failure. Injectable for tests. */
+  fetchImage?: (url: string) => Promise<Uint8Array | null>;
+  /** Square downsample target for the thumbnail. Default 32 (dominant colour is scale-invariant enough). */
+  sampleSize?: number;
+}
+
+export type ColorExtractor = (artwork: Artwork) => Promise<ColorData | null>;
+
+const DEFAULT_SAMPLE = 32;
+
+async function defaultLoadSharp(): Promise<SharpLike | null> {
+  try {
+    // Variable specifier on purpose: sharp is an OPTIONAL native dependency, so
+    // typecheck and the `.mcpb`/Workers builds must not statically resolve it. A
+    // literal `import('sharp')` would make tsc require the module to be present.
+    const specifier = 'sharp';
+    const mod = (await import(specifier)) as { default?: SharpLike } & Partial<SharpLike>;
+    const fn = (mod.default ?? mod) as unknown;
+    return typeof fn === 'function' ? (fn as SharpLike) : null;
+  } catch {
+    return null; // sharp not installed -> fail open
+  }
+}
+
+async function defaultFetchImage(url: string): Promise<Uint8Array | null> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    return new Uint8Array(await res.arrayBuffer());
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build a colour extractor capability to inject into the federation. The
+ * federation calls it (Node only) after the rights gate passes; when it returns
+ * null, colour fields stay unset.
+ */
+export function createColorExtractor(opts: ColorExtractorOptions = {}): ColorExtractor {
+  const loadSharp = opts.loadSharp ?? defaultLoadSharp;
+  const fetchImage = opts.fetchImage ?? defaultFetchImage;
+  const size = opts.sampleSize ?? DEFAULT_SAMPLE;
+
+  return async function extractColor(art: Artwork): Promise<ColorData | null> {
+    const url = art.imageUrls.thumbnail || art.imageUrls.full;
+    if (!url) return null;
+
+    const sharp = await loadSharp();
+    if (!sharp) return null;
+
+    const bytes = await fetchImage(url);
+    if (!bytes || bytes.length === 0) return null;
+
+    try {
+      const { data, info } = await sharp(bytes)
+        .resize(size, size, { fit: 'inside' })
+        .raw()
+        .toBuffer({ resolveWithObject: true });
+      const channels = info.channels;
+      if (channels < 3) return null;
+
+      const samples: Rgb[] = [];
+      for (let i = 0; i + channels - 1 < data.length; i += channels) {
+        // Drop fully transparent pixels so a transparent border doesn't skew the palette.
+        if (channels === 4 && data[i + 3] === 0) continue;
+        samples.push({ r: data[i], g: data[i + 1], b: data[i + 2] });
+      }
+      return quantizeColors(samples);
+    } catch {
+      return null; // decode failure -> fail open
+    }
+  };
+}

--- a/src/color/extract.ts
+++ b/src/color/extract.ts
@@ -38,6 +38,11 @@ export type ColorExtractor = (artwork: Artwork) => Promise<ColorData | null>;
 
 const DEFAULT_SAMPLE = 32;
 
+// Defence-in-depth byte cap on the enrichment fetch. Thumbnails are tiny; a
+// multi-MB response means a wrong/oversized URL, so we fail open past the cap
+// rather than buffer it. Checked against Content-Length and the actual bytes.
+const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
+
 async function defaultLoadSharp(): Promise<SharpLike | null> {
   try {
     // Variable specifier on purpose: sharp is an OPTIONAL native dependency, so
@@ -56,7 +61,11 @@ async function defaultFetchImage(url: string): Promise<Uint8Array | null> {
   try {
     const res = await fetch(url);
     if (!res.ok) return null;
-    return new Uint8Array(await res.arrayBuffer());
+    const declared = Number(res.headers.get('content-length'));
+    if (Number.isFinite(declared) && declared > MAX_IMAGE_BYTES) return null;
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    if (bytes.length > MAX_IMAGE_BYTES) return null;
+    return bytes;
   } catch {
     return null;
   }

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -294,7 +294,14 @@ export function createFederation(opts: FederationOptions): Federation {
     }
 
     const cached = await cache.getObject(id);
-    if (cached) return { ok: true, artwork: cached };
+    if (cached) {
+      // Backfill colour onto a record cached before it had any — a pre-v0.8b row
+      // still within the 90-day TTL, or one written by a sharp-less/Workers
+      // process. Without this, such rows would stay colourless until natural
+      // expiry and silently under-return from colour search/facets.
+      if (await enrichColor(cached)) await cache.upsertObject(cached);
+      return { ok: true, artwork: cached };
+    }
 
     // ID_REGEX guarantees a non-empty `[a-z]+` segment before ':'.
     const code = id.slice(0, id.indexOf(':'));
@@ -308,24 +315,28 @@ export function createFederation(opts: FederationOptions): Federation {
       return { ok: false, reason: result.rejection.reason };
     }
 
-    // Node-only colour enrichment, after the rights gate, before caching. Fails
-    // open: a null result or a thrown error leaves colour unset (the record is
-    // still valid). Absent in Workers / the .mcpb bundle, which inject nothing.
-    if (extractColor) {
-      try {
-        const color = await extractColor(result.artwork);
-        if (color) {
-          result.artwork.dominantColor = color.dominantColor;
-          result.artwork.palette = color.palette;
-          result.artwork.colorFamily = color.colorFamily;
-        }
-      } catch {
-        // enrichment failure is non-fatal
-      }
-    }
-
+    await enrichColor(result.artwork);
     await cache.upsertObject(result.artwork);
     return { ok: true, artwork: result.artwork };
+  }
+
+  // Node-only colour enrichment. Runs the injected extractor on a record that has
+  // no colour yet, mutating it in place. Returns true if colour was added (so the
+  // caller can persist it). Fails open: a null result or a thrown error leaves
+  // colour unset and the record valid. A no-op in Workers / the .mcpb bundle,
+  // which inject no extractor, and for records that already carry colour.
+  async function enrichColor(artwork: Artwork): Promise<boolean> {
+    if (!extractColor || artwork.dominantColor !== undefined) return false;
+    try {
+      const color = await extractColor(artwork);
+      if (!color) return false;
+      artwork.dominantColor = color.dominantColor;
+      artwork.palette = color.palette;
+      artwork.colorFamily = color.colorFamily;
+      return true;
+    } catch {
+      return false; // enrichment failure is non-fatal
+    }
   }
 
   // Gather the accepted, image/dedup/year-filtered candidate set for a query.

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -3,6 +3,12 @@ import { cite as citeArtwork, type CiteStyle } from '../cite.js';
 import { dedupeWikimediaUploads } from '../dedupe.js';
 import type { Fetcher } from '../fetchers/types.js';
 import { MEDIUM_CATEGORIES } from '../medium.js';
+import {
+  COLOR_FAMILY_NAMES,
+  ciede2000,
+  hexToLab,
+  type ColorData,
+} from '../color/colorMath.js';
 import type { Artwork } from '../types.js';
 import { filterByYearRange } from '../yearFilter.js';
 import type { CacheStore } from './cache.js';
@@ -53,6 +59,13 @@ export const SearchParamsSchema = z.object({
   year_min: z.number().int().optional(),
   year_max: z.number().int().optional(),
   medium: z.enum(MEDIUM_CATEGORIES).optional(),
+  /** Hex (`#rrggbb` or `rrggbb`). Ranks results by CIEDE2000 nearest to this colour. */
+  color: z
+    .string()
+    .regex(/^#?[0-9a-fA-F]{6}$/)
+    .optional(),
+  /** Coarse colour-family filter (one of the controlled bins). */
+  color_family: z.enum(COLOR_FAMILY_NAMES).optional(),
 });
 export type SearchParams = z.infer<typeof SearchParamsSchema>;
 
@@ -82,6 +95,8 @@ export interface FacetResult {
   dateBucket: FacetCount[];
   /** Top-N named artists, by count (descending). Anonymous works are excluded. */
   artist: FacetCount[];
+  /** Colour families present, by count (descending). Records without colour are skipped. */
+  colorFamily: FacetCount[];
 }
 
 // Cap on the artist facet — a swatch/chip list, not the full long tail.
@@ -131,6 +146,16 @@ export interface FederationOptions {
    * Injectable so emitted manifests are deterministic in tests and fixtures.
    */
   clock?: () => string;
+  /**
+   * Node-only colour-extraction capability. When provided, the federation runs
+   * it on each accepted record (after the rights gate, before caching) and
+   * stores the result's colour on the artwork. INJECTED, not built-in, so the
+   * core never imports `sharp`: Workers and the `.mcpb` bundle pass nothing and
+   * read precomputed colour only. It fails OPEN — a null result or a thrown
+   * error leaves colour unset and the record valid (colour is an enrichment,
+   * not a gate). The MCP server wires in `createColorExtractor()`.
+   */
+  extractColor?: (artwork: Artwork) => Promise<ColorData | null>;
 }
 
 export interface Federation {
@@ -224,6 +249,15 @@ function countDateBuckets(arts: Artwork[]): FacetCount[] {
     .map(([start, count]) => ({ value: centuryLabel(start), count }));
 }
 
+function countColorFamily(arts: Artwork[]): FacetCount[] {
+  const counts = new Map<string, number>();
+  for (const a of arts) {
+    if (!a.colorFamily) continue; // colourless records (Workers / sharp-less) skipped
+    counts.set(a.colorFamily, (counts.get(a.colorFamily) ?? 0) + 1);
+  }
+  return [...counts.entries()].map(([value, count]) => ({ value, count })).sort(sortByCountThenName);
+}
+
 function countArtists(arts: Artwork[]): FacetCount[] {
   const counts = new Map<string, number>();
   for (const a of arts) {
@@ -252,6 +286,7 @@ export function createFederation(opts: FederationOptions): Federation {
   const onReject = opts.onReject;
   const engineVersion = opts.engineVersion ?? '0.0.0';
   const clock = opts.clock ?? (() => new Date().toISOString());
+  const extractColor = opts.extractColor;
 
   async function getArtwork(id: string): Promise<FetchOutcome> {
     if (!ID_REGEX.test(id)) {
@@ -271,6 +306,22 @@ export function createFederation(opts: FederationOptions): Federation {
     if (result.status === 'rejected') {
       onReject?.(id, result.rejection.reason);
       return { ok: false, reason: result.rejection.reason };
+    }
+
+    // Node-only colour enrichment, after the rights gate, before caching. Fails
+    // open: a null result or a thrown error leaves colour unset (the record is
+    // still valid). Absent in Workers / the .mcpb bundle, which inject nothing.
+    if (extractColor) {
+      try {
+        const color = await extractColor(result.artwork);
+        if (color) {
+          result.artwork.dominantColor = color.dominantColor;
+          result.artwork.palette = color.palette;
+          result.artwork.colorFamily = color.colorFamily;
+        }
+      } catch {
+        // enrichment failure is non-fatal
+      }
     }
 
     await cache.upsertObject(result.artwork);
@@ -329,7 +380,27 @@ export function createFederation(opts: FederationOptions): Federation {
     const byMedium = params.medium
       ? dated.filter((a) => (a.mediumCategory ?? 'other') === params.medium)
       : dated;
-    const results = byMedium.slice(0, params.limit);
+
+    // color_family is a post-fetch filter (like medium); a record without colour
+    // (Workers / sharp-less enrichment) simply doesn't match.
+    const byFamily = params.color_family
+      ? byMedium.filter((a) => a.colorFamily === params.color_family)
+      : byMedium;
+
+    // `color` re-orders the survivors by CIEDE2000 nearness to the query colour.
+    // Colourless records can't be ranked by colour, so they're dropped from a
+    // colour-ranked search.
+    let ordered = byFamily;
+    if (params.color) {
+      const queryLab = hexToLab(params.color);
+      ordered = byFamily
+        .filter((a): a is Artwork & { dominantColor: string } => Boolean(a.dominantColor))
+        .map((a) => ({ a, d: ciede2000(queryLab, hexToLab(a.dominantColor)) }))
+        .sort((x, y) => x.d - y.d)
+        .map((x) => x.a);
+    }
+
+    const results = ordered.slice(0, params.limit);
 
     return { count: results.length, results };
   }
@@ -342,6 +413,7 @@ export function createFederation(opts: FederationOptions): Federation {
       medium: countMedium(candidates),
       dateBucket: countDateBuckets(candidates),
       artist: countArtists(candidates),
+      colorFamily: countColorFamily(candidates),
     };
   }
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -49,6 +49,27 @@ export type { Fetcher, SearchOptions } from '../fetchers/types.js';
 // need the value set; the normalizer is exposed for any host-side reclassifying.
 export { MEDIUM_CATEGORIES, normalizeMedium, type MediumCategory } from '../medium.js';
 
+// Colour — the Workers-safe READ side only (math + types). Extraction lives in
+// the Node-only color/extract.ts and is deliberately NOT exported here, so the
+// core stays free of `sharp`. The web app uses these to render swatches and to
+// run colour search/ranking over precomputed colour.
+export {
+  COLOR_FAMILIES,
+  COLOR_FAMILY_NAMES,
+  ciede2000,
+  hexToLab,
+  hexToRgb,
+  rgbToHex,
+  rgbToLab,
+  nearestColorFamily,
+  quantizeColors,
+  type ColorFamily,
+  type ColorData,
+  type PaletteEntry,
+  type Rgb,
+  type Lab,
+} from '../color/colorMath.js';
+
 // Built-in museum fetchers, so a host can assemble its own registry (and
 // decide which to enable based on available API keys).
 export { metFetcher } from '../fetchers/met.js';

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,6 +20,8 @@ import {
   type CiteStyle,
 } from './core/index.js';
 import { handleClearanceRecord } from './clearanceTool.js';
+import { createColorExtractor } from './color/extract.js';
+import { COLOR_FAMILY_NAMES } from './core/index.js';
 import { Cache } from './db.js';
 import { buildSeedQueryFromConstraints } from './discoverSeed.js';
 import { aicFetcher } from './fetchers/aic.js';
@@ -61,7 +63,7 @@ const cache = new Cache({ path: CACHE_PATH });
 
 // Single source for the server version. Stamped into the MCP handshake and into
 // each Clearance Manifest's `verification.tool` provenance field.
-const VERSION = '0.8.0';
+const VERSION = '0.9.0';
 
 // The federation engine is transport-agnostic. The MCP server is one front
 // door over it (stdio JSON-RPC); the web app is another (HTTP + KV cache).
@@ -74,6 +76,10 @@ const federation = createFederation({
   cache,
   engineVersion: VERSION,
   onReject: (id, reason) => console.error(`[open-museum-mcp] rejected ${id}: ${reason}`),
+  // Node-side colour enrichment. createColorExtractor lazily loads the optional
+  // `sharp` dependency; if it's absent (e.g. a sharp-less install) extraction
+  // fails open and colour fields stay unset. Workers never inject this.
+  extractColor: createColorExtractor(),
 });
 
 const GetInput = z.object({
@@ -138,6 +144,17 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
             enum: [...MEDIUM_CATEGORIES],
             description:
               'Optional medium-category filter. One of the controlled values (painting, drawing, print, photograph, sculpture, textile, ceramic, metalwork, furniture, manuscript, other). Like the year filter, it is applied after rights verification over a bounded candidate window — so a medium that is rare for the query may return fewer than `limit` results. Use the facets tool to see which values are present for a query.',
+          },
+          color: {
+            type: 'string',
+            description:
+              'Optional hex colour (#rrggbb). Re-ranks results by perceptual (CIEDE2000) nearness to this colour, nearest first. Colour is precomputed Node-side from the thumbnail; records without colour (not yet enriched) are excluded from a colour-ranked search.',
+          },
+          color_family: {
+            type: 'string',
+            enum: [...COLOR_FAMILY_NAMES],
+            description:
+              'Optional coarse colour-family filter (red, orange, yellow, green, blue, purple, pink, brown, neutral, black, white). Post-fetch over the bounded window, so a rare family may return fewer than `limit`. Use the facets tool to see which families are present.',
           },
         },
         required: ['query'],
@@ -210,7 +227,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     {
       name: 'facets',
       description:
-        'Return available facet values and counts for a query: medium categories, century date-buckets, and the top artists. Counts are computed over a BOUNDED candidate window of up to ~150 rights-verified records per museum (not the entire corpus), so they reflect the head of the result set, not exhaustive totals. Only values actually present in that window are returned (no empty buckets). Use the returned medium values with search_artworks({ ..., medium }) to drill down.',
+        'Return available facet values and counts for a query: medium categories, century date-buckets, top artists, and colour families. Counts are computed over a BOUNDED candidate window of up to ~150 rights-verified records per museum (not the entire corpus), so they reflect the head of the result set, not exhaustive totals. Only values actually present in that window are returned (no empty buckets). Use the returned medium/colorFamily values with search_artworks({ ..., medium, color_family }) to drill down.',
       inputSchema: {
         type: 'object',
         properties: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
+import type { ColorFamily, PaletteEntry } from './color/colorMath.js';
 import type { MediumCategory } from './medium.js';
 
-export type { MediumCategory };
+export type { ColorFamily, MediumCategory, PaletteEntry };
 
 export type LicenseType = 'CC0' | 'PD' | 'CC-BY' | 'CC-BY-SA' | 'OTHER' | 'UNKNOWN';
 
@@ -86,6 +87,16 @@ export interface Artwork {
   source: ArtworkSource;
   description?: string;
   rawTags?: string[];
+  /**
+   * Dominant colour as a `#rrggbb` hex. Set by Node-side colour enrichment when
+   * available; absent on Workers / the `.mcpb` bundle / any sharp-less run
+   * (enrichment fails open). Additive v0.8b field.
+   */
+  dominantColor?: string;
+  /** Top ~5 palette colours with weights (0..1), most-dominant first. Additive v0.8b. */
+  palette?: PaletteEntry[];
+  /** Coarse colour-family bin (one of ~11) for faceting. Additive v0.8b. */
+  colorFamily?: ColorFamily;
   /** Reserved for v1.0 artist-obscurity scoring across the federated corpus. Not yet populated by any fetcher. */
   obscurityScore?: number;
 }

--- a/tests/color/colorMath.test.ts
+++ b/tests/color/colorMath.test.ts
@@ -82,6 +82,26 @@ describe('colour families', () => {
     expect(nearestColorFamily(hexToLab('#000000'))).toBe('black');
     expect(nearestColorFamily(hexToLab('#808080'))).toBe('neutral');
   });
+
+  it('bins SATURATED bright greens to green (not yellow)', () => {
+    expect(nearestColorFamily(hexToLab('#00ff00'))).toBe('green');
+    expect(nearestColorFamily(hexToLab('#40ff40'))).toBe('green');
+  });
+
+  it('keeps chromatic colours in their hue family regardless of lightness', () => {
+    // dark chromatic must NOT collapse to black
+    expect(nearestColorFamily(hexToLab('#400000'))).toBe('red'); // dark red
+    expect(nearestColorFamily(hexToLab('#002040'))).toBe('blue'); // navy
+    expect(['green', 'yellow']).toContain(nearestColorFamily(hexToLab('#556b2f'))); // dark olive
+    // pale chromatic must NOT collapse to white
+    expect(['pink', 'red']).toContain(nearestColorFamily(hexToLab('#ffd0d0'))); // pale pink
+  });
+
+  it('still assigns near-achromatic colours to black / neutral / white by lightness', () => {
+    expect(nearestColorFamily(hexToLab('#101010'))).toBe('black');
+    expect(nearestColorFamily(hexToLab('#7a7a7a'))).toBe('neutral');
+    expect(nearestColorFamily(hexToLab('#fafafa'))).toBe('white');
+  });
 });
 
 describe('quantizeColors', () => {

--- a/tests/color/colorMath.test.ts
+++ b/tests/color/colorMath.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import {
+  COLOR_FAMILIES,
+  ciede2000,
+  hexToLab,
+  hexToRgb,
+  nearestColorFamily,
+  quantizeColors,
+  rgbToHex,
+} from '../../src/color/colorMath.js';
+
+describe('hex <-> rgb', () => {
+  it('parses 6-digit hex (with and without #)', () => {
+    expect(hexToRgb('#3a5f7d')).toEqual({ r: 0x3a, g: 0x5f, b: 0x7d });
+    expect(hexToRgb('ff0000')).toEqual({ r: 255, g: 0, b: 0 });
+  });
+
+  it('round-trips rgb -> hex (lowercase, #-prefixed)', () => {
+    expect(rgbToHex({ r: 58, g: 95, b: 125 })).toBe('#3a5f7d');
+    expect(rgbToHex({ r: 255, g: 0, b: 0 })).toBe('#ff0000');
+  });
+});
+
+describe('hexToLab', () => {
+  it('maps sRGB anchors to known CIELAB values (D65)', () => {
+    const white = hexToLab('#ffffff');
+    expect(white.l).toBeCloseTo(100, 1);
+    expect(white.a).toBeCloseTo(0, 1);
+    expect(white.b).toBeCloseTo(0, 1);
+
+    const black = hexToLab('#000000');
+    expect(black.l).toBeCloseTo(0, 1);
+
+    const red = hexToLab('#ff0000');
+    expect(red.l).toBeCloseTo(53.24, 1);
+    expect(red.a).toBeCloseTo(80.09, 1);
+    expect(red.b).toBeCloseTo(67.2, 1);
+  });
+});
+
+describe('ciede2000 (Sharma et al. reference vectors)', () => {
+  const within = (got: number, want: number) => expect(got).toBeCloseTo(want, 3);
+
+  it('matches published dE00 for canonical pairs', () => {
+    within(ciede2000({ l: 50, a: 2.6772, b: -79.7751 }, { l: 50, a: 0, b: -82.7485 }), 2.0425);
+    within(ciede2000({ l: 50, a: -1.3802, b: -84.2814 }, { l: 50, a: 0, b: -82.7485 }), 1.0);
+    within(ciede2000({ l: 50, a: 2.49, b: -0.001 }, { l: 50, a: -2.49, b: 0.0009 }), 7.1792);
+    within(
+      ciede2000({ l: 60.2574, a: -34.0099, b: 36.2677 }, { l: 60.4626, a: -34.1751, b: 39.4387 }),
+      1.2644,
+    );
+  });
+
+  it('is zero for identical colours', () => {
+    expect(ciede2000({ l: 50, a: 10, b: -20 }, { l: 50, a: 10, b: -20 })).toBe(0);
+  });
+});
+
+describe('colour families', () => {
+  it('exposes exactly the eleven locked bins', () => {
+    expect(COLOR_FAMILIES.map((f) => f.name)).toEqual([
+      'red',
+      'orange',
+      'yellow',
+      'green',
+      'blue',
+      'purple',
+      'pink',
+      'brown',
+      'neutral',
+      'black',
+      'white',
+    ]);
+  });
+
+  it('bins clear anchor colours to the expected family', () => {
+    expect(nearestColorFamily(hexToLab('#ff0000'))).toBe('red');
+    expect(nearestColorFamily(hexToLab('#00bf00'))).toBe('green');
+    expect(nearestColorFamily(hexToLab('#0000ff'))).toBe('blue');
+    expect(nearestColorFamily(hexToLab('#ffff00'))).toBe('yellow');
+    expect(nearestColorFamily(hexToLab('#ffffff'))).toBe('white');
+    expect(nearestColorFamily(hexToLab('#000000'))).toBe('black');
+    expect(nearestColorFamily(hexToLab('#808080'))).toBe('neutral');
+  });
+});
+
+describe('quantizeColors', () => {
+  it('returns a dominant colour, palette, family, and lab for a solid field', () => {
+    const samples = Array.from({ length: 100 }, () => ({ r: 255, g: 0, b: 0 }));
+    const c = quantizeColors(samples);
+    expect(c).not.toBeNull();
+    if (!c) return;
+    expect(c.dominantColor).toBe('#ff0000');
+    expect(c.colorFamily).toBe('red');
+    expect(c.palette.length).toBeGreaterThanOrEqual(1);
+    expect(c.palette[0].hex).toBe('#ff0000');
+    expect(c.palette[0].weight).toBeCloseTo(1, 2);
+    expect(c.lab.l).toBeCloseTo(53.24, 1);
+  });
+
+  it('picks the most frequent colour as dominant in a mixed field', () => {
+    const samples = [
+      ...Array.from({ length: 70 }, () => ({ r: 0, g: 0, b: 255 })), // blue, majority
+      ...Array.from({ length: 30 }, () => ({ r: 255, g: 255, b: 0 })), // yellow
+    ];
+    const c = quantizeColors(samples);
+    expect(c?.colorFamily).toBe('blue');
+    expect(c?.palette[0].weight).toBeGreaterThan(c!.palette[1]!.weight);
+  });
+
+  it('returns null for an empty sample set (fail-open upstream)', () => {
+    expect(quantizeColors([])).toBeNull();
+  });
+});

--- a/tests/color/extract.test.ts
+++ b/tests/color/extract.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createColorExtractor, type SharpLike } from '../../src/color/extract.js';
+import type { Artwork } from '../../src/types.js';
+
+function artwork(over: Partial<Artwork['imageUrls']> = {}): Artwork {
+  return {
+    id: 'test:1',
+    museum: { code: 'test', name: 'TEST', url: 'https://t.example' },
+    title: 'x',
+    artist: { name: 'A', attributionType: 'named' },
+    displayDate: '1900',
+    yearStart: 1900,
+    yearEnd: 1900,
+    medium: 'oil',
+    mediumCategory: 'painting',
+    region: null,
+    period: null,
+    imageUrls: { full: 'https://cdn.example/full.jpg', thumbnail: 'https://cdn.example/thumb.jpg', ...over },
+    imageOpenAccess: true,
+    metadataOpenAccess: true,
+    license: { type: 'CC0', rawValue: 'true', verificationSource: 'test', verifiedAt: '2026-01-01T00:00:00.000Z', confidence: 'high' },
+    source: { apiUrl: 'https://t.example/api', pageUrl: 'https://t.example/1' },
+  };
+}
+
+// A fake sharp that ignores resize and yields a fixed raw RGB(A) buffer.
+function fakeSharp(data: Uint8Array, channels: number): SharpLike {
+  return (() => {
+    const chain = {
+      resize: () => chain,
+      raw: () => chain,
+      toBuffer: async () => ({ data, info: { width: 2, height: 2, channels } }),
+    };
+    return chain;
+  }) as unknown as SharpLike;
+}
+
+describe('createColorExtractor — fail-open', () => {
+  it('returns null when sharp is unavailable (the .mcpb / Workers / no-sharp case)', async () => {
+    const extract = createColorExtractor({
+      loadSharp: async () => null,
+      fetchImage: async () => new Uint8Array([1, 2, 3]),
+    });
+    expect(await extract(artwork())).toBeNull();
+  });
+
+  it('returns null when the record has no image url', async () => {
+    const extract = createColorExtractor({
+      loadSharp: async () => fakeSharp(new Uint8Array([255, 0, 0]), 3),
+      fetchImage: async () => new Uint8Array([1]),
+    });
+    expect(await extract(artwork({ full: '', thumbnail: '' }))).toBeNull();
+  });
+
+  it('returns null when the image fetch fails', async () => {
+    const extract = createColorExtractor({
+      loadSharp: async () => fakeSharp(new Uint8Array([255, 0, 0]), 3),
+      fetchImage: async () => null,
+    });
+    expect(await extract(artwork())).toBeNull();
+  });
+
+  it('returns null (does not throw) when decoding throws', async () => {
+    const throwingSharp = (() => ({
+      resize: () => {
+        throw new Error('decode boom');
+      },
+    })) as unknown as SharpLike;
+    const extract = createColorExtractor({
+      loadSharp: async () => throwingSharp,
+      fetchImage: async () => new Uint8Array([1, 2, 3]),
+    });
+    expect(await extract(artwork())).toBeNull();
+  });
+});
+
+describe('createColorExtractor — extraction', () => {
+  it('extracts colour from the decoded pixels (solid red)', async () => {
+    // four red pixels, 3 channels
+    const data = new Uint8Array([255, 0, 0, 255, 0, 0, 255, 0, 0, 255, 0, 0]);
+    const extract = createColorExtractor({
+      loadSharp: async () => fakeSharp(data, 3),
+      fetchImage: async () => new Uint8Array([1, 2, 3]),
+    });
+    const c = await extract(artwork());
+    expect(c?.dominantColor).toBe('#ff0000');
+    expect(c?.colorFamily).toBe('red');
+  });
+
+  it('prefers the thumbnail URL over the full image (bandwidth)', async () => {
+    const fetchImage = vi.fn(async () => new Uint8Array([255, 0, 0, 255, 0, 0]));
+    const extract = createColorExtractor({
+      loadSharp: async () => fakeSharp(new Uint8Array([255, 0, 0, 255, 0, 0]), 3),
+      fetchImage,
+    });
+    await extract(artwork());
+    expect(fetchImage).toHaveBeenCalledWith('https://cdn.example/thumb.jpg');
+  });
+
+  it('skips fully transparent pixels when an alpha channel is present', async () => {
+    // one opaque blue pixel + one transparent pixel (alpha 0)
+    const data = new Uint8Array([0, 0, 255, 255, 0, 0, 0, 0]);
+    const extract = createColorExtractor({
+      loadSharp: async () => fakeSharp(data, 4),
+      fetchImage: async () => new Uint8Array([1]),
+    });
+    const c = await extract(artwork());
+    expect(c?.dominantColor).toBe('#0000ff');
+    expect(c?.colorFamily).toBe('blue');
+  });
+});

--- a/tests/color/extract.test.ts
+++ b/tests/color/extract.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createColorExtractor, type SharpLike } from '../../src/color/extract.js';
 import type { Artwork } from '../../src/types.js';
 
@@ -69,6 +69,25 @@ describe('createColorExtractor — fail-open', () => {
     const extract = createColorExtractor({
       loadSharp: async () => throwingSharp,
       fetchImage: async () => new Uint8Array([1, 2, 3]),
+    });
+    expect(await extract(artwork())).toBeNull();
+  });
+});
+
+describe('createColorExtractor — default fetch byte cap', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('fails open when the image exceeds the byte cap (oversized Content-Length)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: { 'content-length': String(50 * 1024 * 1024) },
+      })),
+    );
+    // default fetchImage (not injected) so the cap is exercised
+    const extract = createColorExtractor({
+      loadSharp: async () => fakeSharp(new Uint8Array([255, 0, 0]), 3),
     });
     expect(await extract(artwork())).toBeNull();
   });

--- a/tests/color/workers-safe.test.ts
+++ b/tests/color/workers-safe.test.ts
@@ -1,0 +1,60 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const srcRoot = join(here, '../../src');
+
+function tsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) out.push(...tsFiles(p));
+    else if (entry.endsWith('.ts')) out.push(p);
+  }
+  return out;
+}
+
+// The engine core (and the colour read-side math) must stay runnable on
+// Cloudflare Workers: no native `sharp`, no `node:` builtins. Colour extraction
+// is Node-only and lives in src/color/extract.ts, which the core never imports.
+const WORKERS_SAFE_GLOBS = [join(srcRoot, 'core'), join(srcRoot, 'color', 'colorMath.ts')];
+
+function collect(target: string): string[] {
+  return statSync(target).isDirectory() ? tsFiles(target) : [target];
+}
+
+describe('Workers-safe core has no sharp or node: imports', () => {
+  const files = WORKERS_SAFE_GLOBS.flatMap(collect);
+
+  it('covers the expected modules', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  // Strip line and block comments so doc mentions of "node:sqlite" /
+  // "color/extract" don't trip the import checks — only real imports matter.
+  const stripComments = (src: string) =>
+    src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+
+  // Collect the specifier of every static/dynamic import / require.
+  const importSpecifiers = (src: string): string[] => {
+    const specs: string[] = [];
+    const re = /(?:from|import|require)\s*\(?\s*['"]([^'"]+)['"]/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(src)) !== null) specs.push(m[1]);
+    return specs;
+  };
+
+  for (const file of WORKERS_SAFE_GLOBS.flatMap(collect)) {
+    const rel = file.slice(srcRoot.length + 1);
+    it(`${rel} imports neither sharp nor node: nor the Node-only extractor`, () => {
+      const specs = importSpecifiers(stripComments(readFileSync(file, 'utf8')));
+      for (const spec of specs) {
+        expect(spec).not.toBe('sharp');
+        expect(spec.startsWith('node:')).toBe(false);
+        expect(spec).not.toMatch(/color\/extract/);
+      }
+    });
+  }
+});

--- a/tests/federation.test.ts
+++ b/tests/federation.test.ts
@@ -417,3 +417,125 @@ describe('createFederation.search medium filter — bounded under-delivery', () 
     expect(out.results.every((r) => r.mediumCategory === 'print')).toBe(true);
   });
 });
+
+describe('createFederation colour enrichment (Node capability, fail-open)', () => {
+  it('applies an injected extractColor to accepted records before caching', async () => {
+    const t = fakeFetcher('test', { ids: ['test:1'], accept: new Set(['test:1']) });
+    const { store, objects } = memoryCache();
+    const fed = createFederation({
+      fetchers: { test: t.fetcher },
+      cache: store,
+      extractColor: async () => ({
+        dominantColor: '#3a5f7d',
+        palette: [{ hex: '#3a5f7d', weight: 1 }],
+        colorFamily: 'blue',
+        lab: { l: 40, a: -5, b: -20 },
+      }),
+    });
+
+    const out = await fed.getArtwork('test:1');
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.artwork.dominantColor).toBe('#3a5f7d');
+    expect(out.artwork.colorFamily).toBe('blue');
+    expect(out.artwork.palette).toEqual([{ hex: '#3a5f7d', weight: 1 }]);
+    // colour is persisted on the cached record
+    expect(objects.get('test:1')?.colorFamily).toBe('blue');
+  });
+
+  it('leaves colour unset when no extractor is injected (Workers / sharp-less read path)', async () => {
+    const t = fakeFetcher('test', { ids: ['test:1'], accept: new Set(['test:1']) });
+    const { store } = memoryCache();
+    const fed = createFederation({ fetchers: { test: t.fetcher }, cache: store });
+
+    const out = await fed.getArtwork('test:1');
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.artwork.dominantColor).toBeUndefined();
+    expect(out.artwork.colorFamily).toBeUndefined();
+  });
+
+  it('fails open: an extractor that returns null or throws does not fail the record', async () => {
+    const t = fakeFetcher('test', { ids: ['test:1', 'test:2'], accept: new Set(['test:1', 'test:2']) });
+    const { store } = memoryCache();
+    const fed = createFederation({
+      fetchers: { test: t.fetcher },
+      cache: store,
+      extractColor: async (a) => {
+        if (a.id === 'test:2') throw new Error('extract boom');
+        return null;
+      },
+    });
+
+    const a1 = await fed.getArtwork('test:1');
+    const a2 = await fed.getArtwork('test:2');
+    expect(a1.ok).toBe(true);
+    expect(a2.ok).toBe(true);
+    if (a1.ok) expect(a1.artwork.colorFamily).toBeUndefined();
+    if (a2.ok) expect(a2.artwork.colorFamily).toBeUndefined();
+  });
+});
+
+describe('createFederation.search colour', () => {
+  function colourFetcher() {
+    const over: Record<string, Partial<Artwork>> = {
+      'test:1': { dominantColor: '#ff0000', colorFamily: 'red' },
+      'test:2': { dominantColor: '#0000ff', colorFamily: 'blue' },
+      'test:3': { dominantColor: '#00a000', colorFamily: 'green' },
+      'test:4': {}, // no colour (enrichment failed / Workers)
+    };
+    return fakeFetcher('test', {
+      ids: ['test:1', 'test:2', 'test:3', 'test:4'],
+      accept: new Set(['test:1', 'test:2', 'test:3', 'test:4']),
+      over,
+    });
+  }
+
+  it('ranks results by CIEDE2000 nearest to the query colour', async () => {
+    const t = colourFetcher();
+    const { store } = memoryCache();
+    const fed = createFederation({ fetchers: { test: t.fetcher }, cache: store });
+
+    const out = await fed.search({ query: 'x', has_image: true, limit: 10, color: '#1010ee' });
+    // nearest to a blue query is the blue record
+    expect(out.results[0].id).toBe('test:2');
+  });
+
+  it('excludes colourless records from a colour-ranked search', async () => {
+    const t = colourFetcher();
+    const { store } = memoryCache();
+    const fed = createFederation({ fetchers: { test: t.fetcher }, cache: store });
+
+    const out = await fed.search({ query: 'x', has_image: true, limit: 10, color: '#1010ee' });
+    expect(out.results.map((r) => r.id)).not.toContain('test:4');
+  });
+
+  it('filters by color_family', async () => {
+    const t = colourFetcher();
+    const { store } = memoryCache();
+    const fed = createFederation({ fetchers: { test: t.fetcher }, cache: store });
+
+    const out = await fed.search({ query: 'x', has_image: true, limit: 10, color_family: 'red' });
+    expect(out.results.map((r) => r.id)).toEqual(['test:1']);
+  });
+});
+
+describe('createFederation.facets colour', () => {
+  it('aggregates a colorFamily bucket over the sample (skipping colourless)', async () => {
+    const t = fakeFetcher('test', {
+      ids: ['test:1', 'test:2', 'test:3'],
+      accept: new Set(['test:1', 'test:2', 'test:3']),
+      over: {
+        'test:1': { colorFamily: 'blue' },
+        'test:2': { colorFamily: 'blue' },
+        'test:3': { colorFamily: 'red' },
+      },
+    });
+    const { store } = memoryCache();
+    const fed = createFederation({ fetchers: { test: t.fetcher }, cache: store });
+
+    const f = await fed.facets({ query: 'x', has_image: true, limit: 10 });
+    expect(f.colorFamily).toContainEqual({ value: 'blue', count: 2 });
+    expect(f.colorFamily).toContainEqual({ value: 'red', count: 1 });
+  });
+});

--- a/tests/federation.test.ts
+++ b/tests/federation.test.ts
@@ -539,3 +539,52 @@ describe('createFederation.facets colour', () => {
     expect(f.colorFamily).toContainEqual({ value: 'red', count: 1 });
   });
 });
+
+describe('createFederation colour backfill on cached records', () => {
+  it('backfills colour onto an already-cached colourless record when an extractor is present', async () => {
+    const t = fakeFetcher('test', { ids: ['test:1'], accept: new Set(['test:1']) });
+    const { store, objects } = memoryCache();
+    // a record cached before colour existed (pre-v0.8b row, or a sharp-less write)
+    objects.set('test:1', makeArtwork('test:1'));
+    const fed = createFederation({
+      fetchers: { test: t.fetcher },
+      cache: store,
+      extractColor: async () => ({
+        dominantColor: '#3a5f7d',
+        palette: [{ hex: '#3a5f7d', weight: 1 }],
+        colorFamily: 'blue',
+        lab: { l: 40, a: -5, b: -20 },
+      }),
+    });
+    const getRawSpy = vi.spyOn(t.fetcher, 'getRaw');
+
+    const out = await fed.getArtwork('test:1');
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.artwork.colorFamily).toBe('blue');
+    // persisted back to the cache
+    expect(objects.get('test:1')?.colorFamily).toBe('blue');
+    // served from cache, not re-fetched upstream — only enriched
+    expect(getRawSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not re-enrich a cached record that already has colour', async () => {
+    const { store, objects } = memoryCache();
+    objects.set(
+      'test:1',
+      makeArtwork('test:1', {
+        dominantColor: '#111111',
+        colorFamily: 'black',
+        palette: [{ hex: '#111111', weight: 1 }],
+      }),
+    );
+    const extractColor = vi.fn(async () => {
+      throw new Error('extractor must not be called for an already-coloured record');
+    });
+    const fed = createFederation({ fetchers: {}, cache: store, extractColor });
+
+    const out = await fed.getArtwork('test:1');
+    expect(out.ok).toBe(true);
+    expect(extractColor).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Builds **v0.8b colour** on the richer-facets design. **Bundled with the unpublished 0.8.0 medium work into one npm publish → versioned 0.9.0.** Held for review; not merging.

## What ships (engine capability)

- **Node-side colour extraction**, lazy-at-ingest after the rights gate, from the **thumbnail**, **fail-open**. Stores additive `Artwork` fields: `dominantColor` (hex), `palette` (`[{hex,weight}]`), `colorFamily` (one of 11 perceptual bins). CIELAB is derived from the hex on demand. Reserved `Tradition`/`obscurityScore` untouched.
- **`search_artworks` colour**: `color` (hex) re-ranks by **CIEDE2000** nearness (colourless records excluded from a colour-ranked search); `color_family` filters post-fetch like medium.
- **`facets()` colorFamily bucket** over the same bounded sample window.
- **Workers-safe colour read API** exported from the core (`ciede2000`, `hexToLab`, `nearestColorFamily`, `quantizeColors`, `COLOR_FAMILIES`, types).

## Architecture flags (both handled)

1. **`sharp` will not break the `.mcpb` or Workers.** It's an **optionalDependency**, **lazily** dynamic-imported via a variable specifier (so typecheck/`.mcpb`/Workers never resolve it). The `.mcpb` staging manifest copies only `dependencies`, so sharp is excluded from the bundle. Absent sharp (bundle, Workers, sharp-less CI) → extraction **fails open**: colour fields stay null, record still valid. Extraction lives in Node-only `src/color/extract.ts`, never imported by the core; the core imports only pure colour math. A guard test asserts `src/core/**` + `colorMath` import **zero** `sharp`/`node:`/extractor.
2. **Execution context.** The Node MCP server's `node:sqlite` cache is **not** the web app's Cloudflare KV — extracting in the MCP server does not by itself populate the web app. This PR scopes to the **engine capability** (extraction + storage + colour search + colour facet + Workers-safe read path). A Node enrichment path / scheduled job to write precomputed colour into KV is documented as a **follow-up** (CHANGELOG), not built here.

## Tests (no live image bytes, no native dep required)

- CIEDE2000 validated against **Sharma et al.** reference vectors; hex↔Lab anchors; 11-bin nearest-reference binning; quantizer.
- Extractor: fail-open paths (no sharp / no url / fetch fail / decode throw), happy path + alpha-skip via an **injected fake sharp** and fake fetch.
- Federation: injected `extractColor` enrichment (+ fail-open), `color` CIEDE2000 ranking, colourless exclusion, `color_family` filter, `colorFamily` facet.
- Workers-safety guard test (zero sharp/node: in the core).

## Verification

- `tscq --noEmit` → exit 0
- `npm test` → **321 passed**
- `npm run build` → `dist/core` has no `sharp`/`node:` imports; core exports the colour read API
- **Live smoke** (real `sharp` + Met thumbnail): `met:436535` → `dominantColor #889897`, `colorFamily neutral`, palette extracted end-to-end through the federation.

Co-Authored by Pramod Prasanth <pramod@chainalign.com>