### PR TITLE
docs(clearance): remove em-dashes from v0.1 spec prose + schema

### DIFF
--- a/spec/clearance/VERSIONING.md
+++ b/spec/clearance/VERSIONING.md
@@ -12,14 +12,14 @@ Clearance Manifest versions are `MAJOR.MINOR.PATCH`:
   OPTIONAL fields, and other backward-compatible changes that no conforming
   consumer needs to react to.
 - **MINOR** (e.g. a future `v0.x`): additive, backward-compatible vocabulary or
-  field changes — new optional fields and expanded recommended-rule baselines
+  field changes: new optional fields and expanded recommended-rule baselines
   that older validators can safely ignore. Requires a real use case and a public
   review window.
 - **MAJOR** (e.g. an eventual `v1.0`): breaking changes. Requires demonstrated
   implementation experience, broad review, and a migration story.
 
 A version's schema validates documents that declare that version (`specVersion`),
-but the `@context` IRI — not `specVersion` — is the normative authority for term
+but the `@context` IRI (not `specVersion`) is the normative authority for term
 expansion.
 
 ## Permanent, immutable, stable URLs
@@ -66,7 +66,7 @@ The Tier-0 integrity hash is **byte-exact**: it is the SHA-256 of the exact UTF-
 bytes of the `payload` string carried in the envelope (no canonicalization).
 There is therefore no canonicalization step to version. Any future change to how
 the hashed bytes are derived would change the integrity contract, so it MUST be
-introduced with an explicit envelope-version marker or deferred to a major bump —
+introduced with an explicit envelope-version marker or deferred to a major bump,
 never by silently changing the derivation. (Pre-publication, v0.1 replaced an
 earlier RFC 8785 / JCS canonicalization with this byte-exact form; since v0.1 is
 not yet served and has no adopters, the change was made in place.)

--- a/spec/clearance/v0.1/clearance-manifest.schema.json
+++ b/spec/clearance/v0.1/clearance-manifest.schema.json
@@ -12,12 +12,12 @@
       "minItems": 1,
       "items": { "type": "string" },
       "contains": { "const": "https://openclearance.org/v0.1/context.jsonld" },
-      "description": "JSON-LD context. MUST include the openclearance v0.1 context IRI — the sole normative authority for expansion and validation."
+      "description": "JSON-LD context. MUST include the openclearance v0.1 context IRI: the sole normative authority for expansion and validation."
     },
     "type": { "const": "ClearanceManifest" },
     "specVersion": {
       "const": "0.1",
-      "description": "Human-readable version convenience. Not normative — the @context IRI fixes the actual vocabulary."
+      "description": "Human-readable version convenience. Not normative: the @context IRI fixes the actual vocabulary."
     },
     "work": {
       "type": "object",
@@ -34,7 +34,7 @@
           "properties": {
             "name": { "type": "string" },
             "nationality": { "type": "string" },
-            "lifespan": { "type": "string", "description": "Display-form life dates (e.g. '1853–1890'); not a structured date." },
+            "lifespan": { "type": "string", "description": "Display-form life dates (e.g. '1853-1890'); not a structured date." },
             "attributionType": {
               "type": "string",
               "enum": ["named", "anonymous", "workshop", "after", "attributed", "circle", "follower"]
@@ -89,7 +89,7 @@
       "properties": {
         "statement": {
           "type": ["string", "null"],
-          "description": "Rights-statement URI (CC / rightsstatements.org). null on a deny — no positive open-rights statement applies."
+          "description": "Rights-statement URI (CC / rightsstatements.org). null on a deny: no positive open-rights statement applies."
         },
         "sourceApiValue": {
           "type": ["object", "null"],
@@ -174,7 +174,7 @@
         "rule": {
           "type": "string",
           "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
-          "description": "Bare kebab-case determination-rule id resolving to https://openclearance.org/v0.1/rules#<rule>. NOT a closed enum — an unrecognised id is valid and yields an 'unrecognised_rule' advisory."
+          "description": "Bare kebab-case determination-rule id resolving to https://openclearance.org/v0.1/rules#<rule>. NOT a closed enum: an unrecognised id is valid and yields an 'unrecognised_rule' advisory."
         },
         "inputs": {
           "type": "array",

--- a/spec/clearance/v0.1/rules.md
+++ b/spec/clearance/v0.1/rules.md
@@ -21,16 +21,16 @@ The spec normatively defines only the **shape** of `basis`:
 
 ```jsonc
 "basis": {
-  "rule":    "cc0-grants-commercial",          // string, required — a stable rule id
-  "inputs":  [{ "field": "license.type", "value": "CC0" }],  // array, required — the evidence
+  "rule":    "cc0-grants-commercial",          // string, required: a stable rule id
+  "inputs":  [{ "field": "license.type", "value": "CC0" }],  // array, required: the evidence
   "summary": "CC0 public-domain dedication permits all uses, including commercial."  // required
 }
 ```
 
-`rule`, `inputs`, and `summary` are all **required** — honesty-by-architecture. A determination
+`rule`, `inputs`, and `summary` are all **required**: honesty-by-architecture. A determination
 that cannot name its rule, cite its inputs, and state its reasoning is not a valid determination.
 
-This registry — the *meaning* of each rule id and its truth-table outcome — is **not** part of the
+This registry (the *meaning* of each rule id and its truth-table outcome) is **not** part of the
 schema. The set of rule ids is **open, not a closed enum**:
 
 - A `basis.rule` whose id is listed below is a recognised v0.1-baseline determination.
@@ -55,7 +55,7 @@ schema. The set of rule ids is **open, not a closed enum**:
 
 ---
 
-## CC0 — Creative Commons Zero (`https://creativecommons.org/publicdomain/zero/1.0/`)
+## CC0: Creative Commons Zero (`https://creativecommons.org/publicdomain/zero/1.0/`)
 
 The rights holder has waived all copyright and related rights worldwide. All downstream uses are
 permitted; no attribution is legally required.
@@ -66,11 +66,11 @@ permitted; no attribution is legally required.
 | `cc0-grants-derivatives` | `clearance.derivatives.permitted` | `license.type = CC0` | `true` |
 | `cc0-waives-attribution` | `clearance.attributionRequired.required` | `license.type = CC0` | `false` |
 
-## Public Domain — Public Domain Mark (`https://creativecommons.org/publicdomain/mark/1.0/`)
+## Public Domain: Public Domain Mark (`https://creativecommons.org/publicdomain/mark/1.0/`)
 
 The work carries no known worldwide copyright (Creative Commons Public Domain Mark). The engine
 emits `license.type = PD` only for the worldwide Public Domain Mark (Europeana `rights`) and the
-Wikimedia PD/PDM templates — never a jurisdiction-scoped `rightsstatements.org` value such as
+Wikimedia PD/PDM templates, never a jurisdiction-scoped `rightsstatements.org` value such as
 NoC-US, which claims a narrower (US) scope the gate does not assert. All downstream uses are
 permitted; no attribution is legally required.
 
@@ -91,7 +91,7 @@ engine could not resolve at all).
 | `default-deny` | all of `commercialReproduction.permitted`, `derivatives.permitted`, `attributionRequired.required` | the unrecognised or absent license value, carried verbatim | `false` |
 
 Under `default-deny`, `attributionRequired.required` is `false` not because attribution is waived
-but because there is no cleared use to attribute — the deny is total. `confidence` is always `low`
+but because there is no cleared use to attribute: the deny is total. `confidence` is always `low`
 and the `summary` names the exact value that failed to clear.
 
 ---
@@ -102,5 +102,5 @@ v0.1 of the reference engine only emits `CC0` and `PD` with `confidence: high`. 
 share-alike-bearing licenses (`CC-BY`, `CC-BY-SA`) require additional clearance facets
 (`attributionRequired: true` with a specific credit string, a `shareAlikeRequired` facet) that the
 v0.1 truth tables do not yet model. Until those facets and their rules are defined, such licenses
-resolve to `default-deny` — fail-closed, never a partial guess. Adding them is a future registry
+resolve to `default-deny`: fail-closed, never a partial guess. Adding them is a future registry
 PR, not a schema change.

--- a/spec/clearance/v0.1/spec.md
+++ b/spec/clearance/v0.1/spec.md
@@ -28,7 +28,7 @@ booleans. A manifest is emitted for cleared **and** non-cleared works alike: a
 ## Design principles
 
 1. **Compose, don't reinvent.** The format binds existing standards through its
-   JSON-LD `@context`: Creative Commons rights URIs (rights status — v0.1 emits
+   JSON-LD `@context`: Creative Commons rights URIs (rights status; v0.1 emits
    the CC0 and Public Domain Mark URIs; the model also accommodates
    rightsstatements.org URIs for vocabularies a future version may admit),
    schema.org and Dublin Core (descriptive and provenance metadata), and W3C PROV
@@ -50,10 +50,10 @@ booleans. A manifest is emitted for cleared **and** non-cleared works alike: a
 
 A manifest has two parts that never mix:
 
-- **The payload** — pure JSON-LD describing the work, its source, the rights
+- **The payload:** pure JSON-LD describing the work, its source, the rights
   determination, the clearance booleans, the determination event, and (when the
   work is identified) its citations.
-- **The envelope** — a thin wrapper holding integrity (and, in higher tiers,
+- **The envelope:** a thin wrapper holding integrity (and, in higher tiers,
   authenticity) over the payload. The envelope references the payload; the
   payload never references the envelope.
 
@@ -78,15 +78,15 @@ That IRI is the **sole normative authority** for term expansion and validation.
 `specVersion` (`"0.1"`) is a human-readable convenience for log-grepping and
 quick inspection; a consumer MUST NOT rely on it for vocabulary resolution.
 
-### `clearance` — the instant answer
+### `clearance`: the instant answer
 
-`clearance` exposes binary, machine-actionable facets — `commercialReproduction`
-and `derivatives` (`permitted`), and `attributionRequired` (`required`) — each
+`clearance` exposes binary, machine-actionable facets: `commercialReproduction`
+and `derivatives` (`permitted`), and `attributionRequired` (`required`), each
 paired with a structured `basis`. `attributionRequired` is explicit so reuse
 engines never parse strings to decide a credit line. The pattern extends (e.g. a
 future `shareAlikeRequired`) without breaking older consumers.
 
-### `basis` — structured, auditable reasoning
+### `basis`: structured, auditable reasoning
 
 Each clearance facet carries a `basis`:
 
@@ -98,7 +98,7 @@ Each clearance facet carries a `basis`:
 }
 ```
 
-`rule`, `inputs`, and `summary` are all REQUIRED — honesty-by-architecture. The
+`rule`, `inputs`, and `summary` are all REQUIRED: honesty-by-architecture. The
 **shape** of `basis` is normative; the set of `rule` ids is **open, not a closed
 enum**. A `rule` id is a bare kebab-case token resolving as a fragment under
 [`rules.md`](rules.md) (`https://openclearance.org/v0.1/rules#<rule>`). The
@@ -113,13 +113,13 @@ A `basis.rule` whose id is **not** in the current registry baseline is still a
 validity (schema) is independent of determination-rule recognition (advisory).
 See [`advisory-entry.schema.json`](advisory-entry.schema.json).
 
-### `verification` — the determination as an auditable event
+### `verification`: the determination as an auditable event
 
 `verification` records *how the rights determination was reached*, distinct from
 how the clearance booleans were derived (that is `basis`). `determinedBy.actor`
 names who made the call and `role` their relationship to it; on a cleared record
 the actor is the rights source (`museum:<code>`), and on a **deny** the actor is
-the engine rights-gate (`engine:<tool>`) — the museum never asserted the deny,
+the engine rights-gate (`engine:<tool>`): the museum never asserted the deny,
 the gate did. `determinationSource` points at the evidence relied upon.
 
 ## The envelope
@@ -135,7 +135,7 @@ fields inside it.
   a keyless distributor (e.g. the reference MCP server) emits by default.
 - **Tier 1/2 (C2PA):** the payload bytes are carried as a C2PA assertion and the
   manifest's claim is signed. The payload is unchanged across tiers. These tiers
-  are **defined here but not implemented in the reference engine** — no signing
+  are **defined here but not implemented in the reference engine**; no signing
   code ships in v0.1.
 
 ### Canonical form & integrity (normative)
@@ -150,7 +150,7 @@ of the UTF-8 bytes of that `payload` string, as lowercase hex.
 Consumers MUST hash the `payload` string's UTF-8 bytes **verbatim**, compare
 against `integrity.hash`, and only THEN `JSON.parse` the string to read the
 manifest. Consumers MUST NOT re-serialize or re-canonicalize the payload before
-hashing — doing so would compute a different hash and break verification.
+hashing; doing so would compute a different hash and break verification.
 
 This is the shape DSSE, JWS, COSE, and C2PA all use: integrity is defined over
 bytes, never over a re-parsed object (a consumer that re-serializes on parse is
@@ -174,13 +174,13 @@ determination; the *signer/attestor* cryptographically vouches. This lets an
 actor without PKI participate (an attestor signs; the actor is named; the
 `determinationSource` records the evidence the attestor relied on).
 
-Verification produces a standardized **`VerificationState`** — the single
+Verification produces a standardized **`VerificationState`**, the single
 variable a downstream engine checks:
 
-- `REJECTED` — hash mismatch or broken certificate chain.
-- `UNVERIFIED_SIGNAL` — Tier 0, valid hash, no attestation.
-- `ATTESTED_DELEGATE` — Tier 1, valid signature.
-- `ATTESTED_DIRECT` — Tier 2, valid domain-bound signature.
+- `REJECTED`: hash mismatch or broken certificate chain.
+- `UNVERIFIED_SIGNAL`: Tier 0, valid hash, no attestation.
+- `ATTESTED_DELEGATE`: Tier 1, valid signature.
+- `ATTESTED_DIRECT`: Tier 2, valid domain-bound signature.
 
 A Tier-0 consumer MUST recompute the SHA-256 over the exact bytes of the
 `payload` string (see *Canonical form & integrity*) and independently resolve
@@ -224,7 +224,7 @@ envelopes in [`examples/`](examples/) (one accepted, one deny) are the reference
 fixtures; the schemas, the byte-exact hash check, and freshly-emitted accept and
 deny manifests are exercised by the ajv harness in
 `tests/clearance/conformance.test.ts`. A *verifier* conforms if it agrees with
-that suite on every case — including recomputing the byte-exact hash and emitting
+that suite on every case, including recomputing the byte-exact hash and emitting
 the declared advisories for structurally-valid documents with unrecognised rule
 ids. URL stability and the versioning promise are described in
 [`../VERSIONING.md`](../VERSIONING.md).


### PR DESCRIPTION
Strips all em-dashes (and one stray en-dash in a date-range example) from the published v0.1 spec artifacts: `spec.md`, `rules.md`, `clearance-manifest.schema.json` (description strings only), and `VERSIONING.md`. Replacements are contextual (colon / semicolon / comma / parentheses); no rule, field, RFC-2119 keyword, URL, or schema structure changed.

These files ship inside the npm package (`files: ["spec/clearance", ...]`), so this needs to land on main **before** the 0.10.0 npm publish. Already re-synced byte-identically to the openclearance vendored copies (openclearance PR #1, `9627c7f`).

Verified: engine `tests/clearance` 41/41 green; openclearance conformance + build green; engine↔site parity confirmed.

Co-Authored by Pramod Prasanth <pramod@chainalign.com>