### PR TITLE
fix(fetchers): send a compliant User-Agent (fixes Wikimedia/AIC/Cleveland 403 from datacenter IPs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] — 2026-06-08
+
+### Fixed
+
+- **Fetchers now send a compliant, descriptive `User-Agent`.** All outbound museum-API requests previously sent no `User-Agent`, which Wikimedia answers with HTTP 403 (its policy mandates a descriptive UA with a contact URL), and which also caused AIC/Cleveland failures from shared datacenter IPs — e.g. a Cloudflare Worker — leaving only the Met working. A shared `httpGet` wrapper in `src/fetchers/helpers.ts` now attaches `open-museum-mcp (+https://open-museum.art; +https://github.com/cfpramod/open-museum-mcp)` to every museum-API request (Met, Cleveland, AIC, Wikimedia, Europeana) and to the colour-enrichment image fetch. Caller-supplied headers still win.
+
 ## [0.10.0] — 2026-06-07
 
 ### Changed (breaking — `clearance_record` output)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-museum-mcp",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "MCP server for license-verified search across open-access museum collections (The Met, Cleveland, AIC, Wikimedia Commons, Europeana).",
   "type": "module",
   "main": "dist/server.js",

--- a/src/color/extract.ts
+++ b/src/color/extract.ts
@@ -9,6 +9,7 @@
  * gate, which fails closed). Image-fetch and decode failures fail open too.
  */
 
+import { httpGet } from '../fetchers/helpers.js';
 import type { Artwork } from '../types.js';
 import { quantizeColors, type ColorData, type Rgb } from './colorMath.js';
 
@@ -59,7 +60,9 @@ async function defaultLoadSharp(): Promise<SharpLike | null> {
 
 async function defaultFetchImage(url: string): Promise<Uint8Array | null> {
   try {
-    const res = await fetch(url);
+    // Museum CDNs can also 403 a UA-less request from datacenter IPs; send the
+    // descriptive UA on the enrichment image fetch too. See helpers.USER_AGENT.
+    const res = await httpGet(url);
     if (!res.ok) return null;
     const declared = Number(res.headers.get('content-length'));
     if (Number.isFinite(declared) && declared > MAX_IMAGE_BYTES) return null;

--- a/src/fetchers/aic.ts
+++ b/src/fetchers/aic.ts
@@ -7,6 +7,7 @@ import {
   asFiniteNumber,
   asOptionalString,
   asString,
+  httpGet,
   isValidPositiveInt,
   rejectFor,
 } from './helpers.js';
@@ -84,7 +85,7 @@ export const aicFetcher: Fetcher = {
     url.searchParams.set('limit', String(limit));
     url.searchParams.set('fields', 'id');
 
-    const res = await fetch(url);
+    const res = await httpGet(url);
     if (!res.ok) throw new Error(`AIC search failed: ${res.status}`);
     const json = (await res.json()) as { data?: Array<{ id?: unknown }> };
     const data = json.data ?? [];
@@ -98,7 +99,7 @@ export const aicFetcher: Fetcher = {
     const numeric = id.replace(/^aic:/, '');
     const url = new URL(`${AIC_API}/artworks/${numeric}`);
     url.searchParams.set('fields', AIC_FIELDS);
-    const res = await fetch(url);
+    const res = await httpGet(url);
     if (!res.ok) throw new Error(`AIC get failed for ${id}: ${res.status}`);
     return res.json();
   },

--- a/src/fetchers/cleveland.ts
+++ b/src/fetchers/cleveland.ts
@@ -7,6 +7,7 @@ import {
   asFiniteNumber,
   asOptionalString,
   asString,
+  httpGet,
   isValidPositiveInt,
   rejectFor,
 } from './helpers.js';
@@ -52,7 +53,7 @@ export const clevelandFetcher: Fetcher = {
     url.searchParams.set('limit', String(limit));
     url.searchParams.set('fields', 'id');
 
-    const res = await fetch(url);
+    const res = await httpGet(url);
     if (!res.ok) throw new Error(`Cleveland search failed: ${res.status}`);
     const json = (await res.json()) as { data?: Array<{ id?: unknown }> };
     const data = json.data ?? [];
@@ -64,7 +65,7 @@ export const clevelandFetcher: Fetcher = {
 
   async getRaw(id: string): Promise<unknown> {
     const numeric = id.replace(/^cleveland:/, '');
-    const res = await fetch(`${CLEVELAND_API}/artworks/${numeric}`);
+    const res = await httpGet(`${CLEVELAND_API}/artworks/${numeric}`);
     if (!res.ok) throw new Error(`Cleveland get failed for ${id}: ${res.status}`);
     return res.json();
   },

--- a/src/fetchers/europeana.ts
+++ b/src/fetchers/europeana.ts
@@ -3,7 +3,7 @@ import { validateEuropeanaLicense } from '../licenseGate.js';
 import { cleanArtistName, detectAttributionType, normalizeRegion } from '../mappings.js';
 import { normalizeMedium } from '../medium.js';
 import type { Artwork, ValidationResult } from '../types.js';
-import { asOptionalString, asString } from './helpers.js';
+import { asOptionalString, asString, httpGet } from './helpers.js';
 import type { Fetcher, SearchOptions } from './types.js';
 
 const EUROPEANA_API = 'https://api.europeana.eu/record/v2';
@@ -151,7 +151,7 @@ export const europeanaFetcher: Fetcher = {
     // Bandwidth cost is small relative to the gate-rejection ratio.
     url.searchParams.set('profile', 'standard');
 
-    const res = await fetch(url);
+    const res = await httpGet(url);
     if (!res.ok) throw new Error(`Europeana search failed: ${res.status}`);
     const json = (await res.json()) as { items?: Array<{ id?: unknown }> };
     const items = json.items ?? [];
@@ -176,7 +176,7 @@ export const europeanaFetcher: Fetcher = {
     // dcDescriptionLangAware) and other EDM properties cite needs.
     // Bandwidth cost is small relative to the gate-rejection ratio.
     url.searchParams.set('profile', 'standard');
-    const res = await fetch(url);
+    const res = await httpGet(url);
     if (!res.ok) throw new Error(`Europeana get failed for ${id}: ${res.status}`);
     return res.json();
   },

--- a/src/fetchers/helpers.ts
+++ b/src/fetchers/helpers.ts
@@ -9,6 +9,35 @@
 
 import type { ValidationResult } from '../types.js';
 
+/**
+ * Descriptive User-Agent for all outbound museum-API requests.
+ *
+ * Wikimedia's User-Agent policy MANDATES a descriptive UA with a contact URL;
+ * requests without one are answered with HTTP 403 — and that block bites hardest
+ * from shared datacenter IPs (e.g. a Cloudflare Worker), where an empty/default
+ * UA looks like an anonymous bot. AIC and Cleveland are likewise unreliable from
+ * those IP ranges without a UA. Sending a stable, contactable identifier is the
+ * polite-and-required fix. See https://meta.wikimedia.org/wiki/User-Agent_policy
+ */
+export const USER_AGENT =
+  'open-museum-mcp (+https://open-museum.art; +https://github.com/cfpramod/open-museum-mcp)';
+
+/**
+ * `fetch` wrapper that attaches the descriptive {@link USER_AGENT} to every
+ * outbound museum-API request, while letting any caller-supplied header win.
+ *
+ * It deliberately calls the GLOBAL `fetch` (not a captured reference) so test
+ * suites that stub `globalThis.fetch` still intercept these requests.
+ */
+export function httpGet(url: string | URL, init?: RequestInit): Promise<Response> {
+  const headers = new Headers(init?.headers);
+  // Caller-supplied headers win: only set our UA if none was provided.
+  if (!headers.has('User-Agent')) {
+    headers.set('User-Agent', USER_AGENT);
+  }
+  return fetch(url, { ...init, headers });
+}
+
 /** Returns the string value, or "" for any non-string input. */
 export function asString(v: unknown): string {
   return typeof v === 'string' ? v : '';

--- a/src/fetchers/met.ts
+++ b/src/fetchers/met.ts
@@ -3,7 +3,7 @@ import { validateMetLicense } from '../licenseGate.js';
 import { cleanArtistName, detectAttributionType, normalizeRegion } from '../mappings.js';
 import { normalizeMedium } from '../medium.js';
 import type { Artwork, ValidationResult } from '../types.js';
-import { asOptionalString, asString, isValidPositiveInt, rejectFor } from './helpers.js';
+import { asOptionalString, asString, httpGet, isValidPositiveInt, rejectFor } from './helpers.js';
 import type { Fetcher, SearchOptions } from './types.js';
 
 const MET_API = 'https://collectionapi.metmuseum.org/public/collection/v1';
@@ -27,7 +27,7 @@ export const metFetcher: Fetcher = {
     // search would only hide the engine's actual rights behaviour behind the
     // upstream API's quirk.
 
-    const res = await fetch(url);
+    const res = await httpGet(url);
     if (!res.ok) throw new Error(`Met search failed: ${res.status}`);
     const json = (await res.json()) as { objectIDs?: number[] | null; total?: number };
     const ids = json.objectIDs ?? [];
@@ -36,7 +36,7 @@ export const metFetcher: Fetcher = {
 
   async getRaw(id: string): Promise<unknown> {
     const numeric = id.replace(/^met:/, '');
-    const res = await fetch(`${MET_API}/objects/${numeric}`);
+    const res = await httpGet(`${MET_API}/objects/${numeric}`);
     if (!res.ok) throw new Error(`Met get failed for ${id}: ${res.status}`);
     return res.json();
   },

--- a/src/fetchers/wikimedia.ts
+++ b/src/fetchers/wikimedia.ts
@@ -3,7 +3,7 @@ import { validateWikimediaLicense } from '../licenseGate.js';
 import { cleanArtistName, detectAttributionType } from '../mappings.js';
 import { normalizeMedium } from '../medium.js';
 import type { Artwork, ValidationResult } from '../types.js';
-import { asFiniteNumber, asString, isValidPositiveInt, rejectFor } from './helpers.js';
+import { asFiniteNumber, asString, httpGet, isValidPositiveInt, rejectFor } from './helpers.js';
 import type { Fetcher, SearchOptions } from './types.js';
 
 const COMMONS_API = 'https://commons.wikimedia.org/w/api.php';
@@ -202,7 +202,7 @@ export const wikimediaFetcher: Fetcher = {
     url.searchParams.set('format', 'json');
     url.searchParams.set('formatversion', '2');
 
-    const res = await fetch(url);
+    const res = await httpGet(url);
     if (!res.ok) throw new Error(`Wikimedia search failed: ${res.status}`);
     const json = (await res.json()) as { query?: { search?: Array<{ pageid?: unknown }> } };
     const results = json.query?.search ?? [];
@@ -231,7 +231,7 @@ export const wikimediaFetcher: Fetcher = {
     url.searchParams.set('format', 'json');
     url.searchParams.set('formatversion', '2');
 
-    const res = await fetch(url);
+    const res = await httpGet(url);
     if (!res.ok) throw new Error(`Wikimedia get failed for ${id}: ${res.status}`);
     return res.json();
   },


### PR DESCRIPTION
## Problem

The museum-API fetchers sent **no `User-Agent`**. From a Cloudflare Worker's datacenter IPs this means:

- **Wikimedia returns 403** — its [User-Agent policy](https://meta.wikimedia.org/wiki/User-Agent_policy) mandates a descriptive UA with a contact URL.
- **AIC and Cleveland also fail** from shared datacenter IP ranges without a UA.
- Only the Met survived.

## Fix

- Added an exported `USER_AGENT` constant and a strict-typed `httpGet(url, init?)` wrapper to `src/fetchers/helpers.ts`. The wrapper attaches the UA via `Headers`, letting any caller-supplied header win, and calls the **global** `fetch` (not a captured reference) so test stubs still intercept it.
- Replaced every bare museum-API `fetch(` with `httpGet(` across `met.ts`, `cleveland.ts`, `aic.ts`, `wikimedia.ts`, `europeana.ts` (10 call sites).
- Added the UA to the colour-enrichment image fetch in `src/color/extract.ts` (museum CDNs can 403 too).

UA string used:

```
open-museum-mcp (+https://open-museum.art; +https://github.com/cfpramod/open-museum-mcp)
```

## Verification

- `tscq --noEmit` → 0 errors
- `npx vitest run` → 24 files, 330 tests, all green
- `npm run build` → clean

Tests stub `fetch` via `vi.stubGlobal('fetch', ...)`; since `httpGet` calls the global `fetch`, the stubs intercept it unchanged (the added headers option is ignored by the stubs).

Bumps version `0.10.0` → `0.10.1` and adds a CHANGELOG entry.

Co-Authored by Pramod Prasanth <pramod@chainalign.com>