### PR TITLE
fix(federation): interleave museums so search isn't Met-only (0.10.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.2] — 2026-06-10
+
+### Fixed
+
+- **Federated search now interleaves museums round-robin instead of concatenating them.** `createFederation.search` merged the per-museum candidate ID lists with `flat()`, which concatenated them in fetcher order, so whichever fetcher ran first (the Met) filled the limited result page before the other museums' results were ever fetched. Search was effectively Met-only even though every museum returned matches. The lists are now interleaved round-robin (each museum's first result, then each museum's second, ...), preserving each museum's own relevance order while guaranteeing a multi-museum mix on the page.
+
 ## [0.10.1] — 2026-06-08
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-museum-mcp",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "MCP server for license-verified search across open-access museum collections (The Met, Cleveland, AIC, Wikimedia Commons, Europeana).",
   "type": "module",
   "main": "dist/server.js",

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -211,6 +211,24 @@ function searchCacheKey(
   return JSON.stringify({ q: query, m: museum ?? '*', hi: hasImage, of: overFetch });
 }
 
+// Merge per-museum ID lists round-robin (museum 0's first, museum 1's first,
+// ... then everyone's second, ...) so a federated search returns a museum MIX.
+// `flat()` would concatenate the lists in fetcher order, letting whichever
+// fetcher runs first (Met) fill the limited result page before the others are
+// ever fetched — the cause of "search is Met-only" even when every museum
+// returns matches. Each museum's own list stays in its relevance order; we just
+// interleave across museums. Empty lists contribute nothing and are skipped.
+function interleaveRoundRobin<T>(lists: T[][]): T[] {
+  const merged: T[] = [];
+  const longest = lists.reduce((max, list) => Math.max(max, list.length), 0);
+  for (let rank = 0; rank < longest; rank++) {
+    for (const list of lists) {
+      if (rank < list.length) merged.push(list[rank]);
+    }
+  }
+  return merged;
+}
+
 // --- Facet aggregation (pure, Workers-safe) ---
 
 function sortByCountThenName(a: FacetCount, b: FacetCount): number {
@@ -363,7 +381,7 @@ export function createFederation(opts: FederationOptions): Federation {
           f.search(params.query, overFetch, { hasImage: params.has_image }).catch(() => [] as string[]),
         ),
       );
-      allIds = idLists.flat();
+      allIds = interleaveRoundRobin(idLists);
       await cache.putQuery(cacheKey, allIds);
     }
 

--- a/tests/federation.test.ts
+++ b/tests/federation.test.ts
@@ -100,6 +100,28 @@ describe('createFederation.search', () => {
     expect(out.results.map((r) => r.id)).toEqual(['test:1', 'test:2']);
   });
 
+  it('interleaves museums round-robin so no single fetcher fills the page', async () => {
+    // Two museums each return 4 accepted candidates. With flat() concatenation,
+    // the first fetcher (met) would fill the limit-4 page entirely. Round-robin
+    // interleaving must yield an alternating mix.
+    const met = fakeFetcher('met', {
+      ids: ['met:1', 'met:2', 'met:3', 'met:4'],
+      accept: new Set(['met:1', 'met:2', 'met:3', 'met:4']),
+    });
+    const cle = fakeFetcher('cleveland', {
+      ids: ['cleveland:1', 'cleveland:2', 'cleveland:3', 'cleveland:4'],
+      accept: new Set(['cleveland:1', 'cleveland:2', 'cleveland:3', 'cleveland:4']),
+    });
+    const { store } = memoryCache();
+    const fed = createFederation({ fetchers: { met: met.fetcher, cleveland: cle.fetcher }, cache: store });
+
+    const out = await fed.search({ query: 'x', has_image: true, limit: 4 });
+    expect(out.results.map((r) => r.id)).toEqual(['met:1', 'cleveland:1', 'met:2', 'cleveland:2']);
+    const codes = out.results.map((r) => r.museum.code);
+    expect(codes.filter((c) => c === 'met')).toHaveLength(2);
+    expect(codes.filter((c) => c === 'cleveland')).toHaveLength(2);
+  });
+
   it('reuses the cached id list on a second identical search (no second fetcher.search)', async () => {
     const t = fakeFetcher('test', { ids: ['test:1', 'test:2'], accept: new Set(['test:1', 'test:2']) });
     const { store } = memoryCache();


### PR DESCRIPTION
## Summary
- Replaces `flat()` concatenation of per-museum candidate ID lists with a **round-robin interleave** in `createFederation.search` (`src/core/federation.ts`).
- Fixes federated search returning **Met-only** results: `flat()` concatenated the lists in fetcher order, so the first fetcher (Met) filled the limited result page before Cleveland/AIC/Wikimedia were ever fetched. Verified each museum returns matches for "landscape" individually, yet the federated page was 12/12 Met.
- Each museum keeps its own relevance order; the page is now a guaranteed multi-museum mix.
- Bumps 0.10.1 to 0.10.2 + CHANGELOG.

## Test Plan
- [x] New test `interleaves museums round-robin so no single fetcher fills the page` (fails under the old `flat()`)
- [x] Full suite green: 331 tests, 24 files
- [x] Project type checks clean
- [ ] After publish + OMA redeploy: confirm `/api/search?q=landscape` returns a museum mix (met + cleveland + aic), not Met-only

## Notes
Round-robin gives equal museum representation. Relevance-weighted cross-museum ranking (e.g. blending each API's score) is a future refinement; equal representation is the correct first step and unblocks the multi-museum search the print catalog depends on.

Co-Authored by Pramod Prasanth <pramod@chainalign.com>