### PR TITLE
fix(federation): don't cache search results when a fetcher throws

### DIFF
--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -376,13 +376,28 @@ export function createFederation(opts: FederationOptions): Federation {
 
     let allIds = await cache.getQuery(cacheKey);
     if (!allIds) {
+      // A fetcher's search can throw (museum outage, rate limit, network). We
+      // degrade gracefully — a throwing fetcher contributes no ids and the rest
+      // of the federation still answers — but we must NOT cache a partial result:
+      // `putQuery` has a 14-day TTL, so caching a list that's missing a museum's
+      // contributions (or empty, if the only fetcher failed) would serve that
+      // degraded result for two weeks. Track failures and skip the write when any
+      // search threw, so the next call retries upstream.
+      let anySearchFailed = false;
       const idLists = await Promise.all(
         fetcherList.map((f) =>
-          f.search(params.query, overFetch, { hasImage: params.has_image }).catch(() => [] as string[]),
+          f.search(params.query, overFetch, { hasImage: params.has_image }).catch(() => {
+            anySearchFailed = true;
+            return [] as string[];
+          }),
         ),
       );
       allIds = interleaveRoundRobin(idLists);
-      await cache.putQuery(cacheKey, allIds);
+      // A genuine empty result (every fetcher resolved with no matches) is still
+      // cacheable; only an actual failure suppresses the write.
+      if (!anySearchFailed) {
+        await cache.putQuery(cacheKey, allIds);
+      }
     }
 
     const fetched = await withConcurrency(allIds, concurrency, (id) =>

--- a/tests/federation.test.ts
+++ b/tests/federation.test.ts
@@ -132,6 +132,45 @@ describe('createFederation.search', () => {
     expect(t.searchCalls).toBe(1);
   });
 
+  it('does not cache the id list when a fetcher search throws (no 14-day poisoning)', async () => {
+    // One museum is down; the federation should degrade (return the healthy
+    // museum's results) but NOT persist the partial id list, so the next call
+    // retries the failed search instead of serving a degraded result for the
+    // full query-cache TTL.
+    const healthy = fakeFetcher('cleveland', {
+      ids: ['cleveland:1', 'cleveland:2'],
+      accept: new Set(['cleveland:1', 'cleveland:2']),
+    });
+    let metSearchCalls = 0;
+    const downMet: Fetcher = {
+      code: 'met',
+      name: 'MET',
+      async search() {
+        metSearchCalls++;
+        throw new Error('met: upstream 503');
+      },
+      async getRaw(id: string) {
+        return { id };
+      },
+      normalize(raw: unknown): ValidationResult {
+        return { status: 'accepted', artwork: makeArtwork((raw as { id: string }).id) };
+      },
+    };
+    const { store, queries } = memoryCache();
+    const fed = createFederation({ fetchers: { met: downMet, cleveland: healthy.fetcher }, cache: store });
+
+    const first = await fed.search({ query: 'x', has_image: true, limit: 4 });
+    // Degrades to the healthy museum's results.
+    expect(first.results.map((r) => r.id)).toEqual(['cleveland:1', 'cleveland:2']);
+    // The partial result was NOT cached.
+    expect(queries.size).toBe(0);
+
+    // A second identical search re-runs both searches (no poisoned cache hit).
+    await fed.search({ query: 'x', has_image: true, limit: 4 });
+    expect(metSearchCalls).toBe(2);
+    expect(healthy.searchCalls).toBe(2);
+  });
+
   it('excludes image-less records when has_image is true', async () => {
     const t = fakeFetcher('test', {
       ids: ['test:1', 'test:2'],


### PR DESCRIPTION
## Problem

`gatherCandidates` caught each fetcher's `search()` failure as an empty id list (`.catch(() => [])`), then wrote the interleaved result to the query cache **unconditionally**.

The query cache has a **14-day TTL**, so a single transient museum outage poisoned the cache: that query returned a result missing the failed museum's contributions (or fully empty, if the only fetcher failed) for two weeks — `getQuery` treats an empty list as a valid hit, so it never retried.

## Fix

Track whether any search threw, and skip the `putQuery` write when it did. Behaviour:
- The current request still **degrades gracefully** (a throwing fetcher contributes no ids; the rest of the federation answers).
- The next call **retries upstream** instead of serving a poisoned cache entry.
- A genuine empty result (every fetcher resolved with zero matches, no error) is still cached.

## Verification

- `npm test` — 332/332 pass, including a new regression test: one museum throws on `search()`, the federation returns the healthy museum's results, the partial list is **not** cached (`queries.size === 0`), and a second identical search re-runs both searches.
- `tsc --noEmit` clean.