### PR TITLE
fix(region): word-boundary alias matching to stop substring mis-classification

### DIFF
--- a/src/data/regions.json
+++ b/src/data/regions.json
@@ -1,6 +1,6 @@
 {
   "japan": ["japan", "japanese", "edo", "kyoto", "tokyo", "osaka"],
-  "china": ["china", "chinese", "tang", "song", "ming", "qing", "tibet"],
+  "china": ["china", "chinese", "tang", "song", "ming", "qing", "tibet", "tibetan"],
   "korea": ["korea", "korean", "joseon", "goryeo"],
   "iran": ["iran", "iranian", "persian", "persia", "safavid", "qajar"],
   "india": ["india", "indian", "mughal", "rajasthani", "punjabi"],

--- a/src/mappings.ts
+++ b/src/mappings.ts
@@ -2,13 +2,27 @@ import regionsData from './data/regions.json' with { type: 'json' };
 
 const regionMap = regionsData as Record<string, string[]>;
 
+// Flatten every (canonical, alias) pair into a word-boundary regex, longest
+// alias first. Two reasons, mirroring the dynasty matcher in dateParser.ts:
+//   1. Word boundaries (`\b`) stop an alias matching a substring of an unrelated
+//      word. The old `includes()` mapped "Toledo"/"Macedonian" → japan (both
+//      contain "edo") and "Mustang" → china (contains "tang").
+//   2. Longest-first ordering stops a shorter alias shadowing a longer, more
+//      specific one it is contained in: "roman renaissance" (→ italy) must be
+//      tested before "roman" (→ rome), or every Roman-Renaissance string would
+//      resolve to rome.
+const REGION_MATCHERS: Array<{ canonical: string; re: RegExp }> = Object.entries(regionMap)
+  .flatMap(([canonical, aliases]) => aliases.map((alias) => ({ canonical, alias })))
+  .sort((a, b) => b.alias.length - a.alias.length)
+  .map(({ canonical, alias }) => ({
+    canonical,
+    re: new RegExp(`\\b${alias.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i'),
+  }));
+
 export function normalizeRegion(input: string | null | undefined): string | null {
   if (!input) return null;
-  const lower = input.toLowerCase();
-  for (const [canonical, aliases] of Object.entries(regionMap)) {
-    if (aliases.some((alias) => lower.includes(alias))) {
-      return canonical;
-    }
+  for (const { canonical, re } of REGION_MATCHERS) {
+    if (re.test(input)) return canonical;
   }
   return null;
 }

--- a/tests/mappings.test.ts
+++ b/tests/mappings.test.ts
@@ -12,9 +12,26 @@ describe('normalizeRegion', () => {
     expect(normalizeRegion('Dutch')).toBe('netherlands');
   });
 
-  it('matches by substring (culture string with extra words)', () => {
+  it('matches an alias as a whole word inside a longer culture string', () => {
     expect(normalizeRegion('Tang dynasty')).toBe('china');
     expect(normalizeRegion('Edo period, Kyoto')).toBe('japan');
+    expect(normalizeRegion('Tibetan thangka')).toBe('china');
+  });
+
+  it('does not match an alias that is only a substring of another word', () => {
+    // The old includes()-based matcher mapped all of these wrongly:
+    // "Toledo"/"Macedonian" contain "edo" (japan); "Mustang" contains "tang"
+    // (china). Word-boundary matching must reject the substring hit.
+    expect(normalizeRegion('Toledo')).toBe(null);
+    expect(normalizeRegion('Macedonian')).toBe(null);
+    expect(normalizeRegion('Mustang')).toBe(null);
+  });
+
+  it('prefers the longer, more specific alias over a shorter one it contains', () => {
+    // "roman renaissance" (→ italy) contains "roman" (→ rome); longest-first
+    // ordering must resolve it to italy, while a bare "Roman" stays rome.
+    expect(normalizeRegion('Roman Renaissance')).toBe('italy');
+    expect(normalizeRegion('Roman')).toBe('rome');
   });
 
   it('returns null for null/empty/undefined input', () => {


### PR DESCRIPTION
## Problem

`normalizeRegion` used `lower.includes(alias)`, so an alias matched any substring of the input:

- "Toledo" and "Macedonian" both contain `edo` → classified as **japan**
- "Mustang" contains `tang` → classified as **china**

This corrupts the indexed `region` column, the region search filter, and tradition coverage.

A second, related bug: `"roman renaissance"` (→ italy) was unreachable because the shorter `"roman"` (→ rome) matched first in iteration order.

## Fix

- Pre-compile each `(canonical, alias)` pair into a word-boundary regex (`\balias\b`), so an alias only matches a whole word — mirroring the dynasty matcher in `dateParser.ts`.
- Sort longest alias first, so a longer, more specific alias (`roman renaissance`) is tested before a shorter one it contains (`roman`).
- Add `tibetan` to the china aliases to preserve the one root-form (`tibet`) that previously relied on substring matching to catch "Tibetan".

## Verification

- `npm test` — 333/333 pass, including new cases: substring false positives (Toledo / Macedonian / Mustang) now return `null`; `Roman Renaissance` → italy while bare `Roman` → rome; `Tibetan thangka` → china.
- `tsc --noEmit` clean.