### PR TITLE
fix(version): read server version from package.json so it can't drift

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -30,6 +30,7 @@ import { europeanaFetcher } from './fetchers/europeana.js';
 import { metFetcher } from './fetchers/met.js';
 import { wikimediaFetcher } from './fetchers/wikimedia.js';
 import type { Fetcher } from './fetchers/types.js';
+import { VERSION } from './version.js';
 
 // Load env vars before reading any keys. Cwd `.env` (developer flow) wins
 // over `~/.open-museum-mcp/.env` (production / MCP-client-launched flow);
@@ -61,9 +62,9 @@ if (process.env.EUROPEANA_API_KEY) {
 const CACHE_PATH = process.env.OMM_CACHE_PATH ?? join(homedir(), '.open-museum-mcp', 'cache.db');
 const cache = new Cache({ path: CACHE_PATH });
 
-// Single source for the server version. Stamped into the MCP handshake and into
-// each Clearance Manifest's `verification.tool` provenance field.
-const VERSION = '0.10.0';
+// Server version, read from package.json (see ./version.ts) so it can't drift
+// from the published release. Stamped into the MCP handshake and into each
+// Clearance Manifest's `verification.tool` provenance field.
 
 // The federation engine is transport-agnostic. The MCP server is one front
 // door over it (stdio JSON-RPC); the web app is another (HTTP + KV cache).

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+
+// Single source of truth for the server version: read it straight from
+// package.json at load time so the value stamped into the MCP handshake and
+// into every Clearance Manifest's `verification.tool` provenance field can
+// never drift from the actual published release.
+//
+// package.json sits one level above this module in every shipping layout:
+//   - src/version.ts (tsx dev)        -> ../package.json (repo root)
+//   - dist/version.js (npm install)   -> ../package.json (the package root;
+//                                        npm always includes package.json)
+//   - dist/version.js (.mcpb bundle)  -> ../package.json (staged at the bundle
+//                                        root by scripts/build-mcpb.mjs)
+// so the relative URL resolves in all of them. This module has no side effects,
+// so it is safe to import from tests.
+const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8')) as {
+  version: string;
+};
+
+export const VERSION: string = pkg.version;

--- a/tests/version.test.ts
+++ b/tests/version.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { VERSION } from '../src/version.js';
+
+describe('VERSION', () => {
+  it('matches the package.json version (no drift)', () => {
+    const pkg = JSON.parse(
+      readFileSync(new URL('../package.json', import.meta.url), 'utf-8'),
+    ) as { version: string };
+    expect(VERSION).toBe(pkg.version);
+  });
+
+  it('is a non-empty semver-shaped string', () => {
+    expect(VERSION).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});


### PR DESCRIPTION
## Problem

The server `VERSION` constant was hardcoded to `'0.10.0'` while `package.json` was at `0.10.2`. That constant is stamped into the MCP handshake **and** into every Clearance Manifest's `verification.tool` provenance field — which lives inside the hash-protected payload — so manifests were misattributing the determining tool version.

## Fix

- Introduce `src/version.ts`, which reads the version from `package.json` at load time via `import.meta.url`. `package.json` sits one level above the module in all three shipping layouts (tsx dev, npm install, `.mcpb` bundle — the bundle stages `package.json` at its root), so the relative URL resolves everywhere. The module is side-effect-free.
- `src/server.ts` imports `VERSION` instead of a literal.
- Add a test asserting `VERSION` matches `package.json` (no drift) and is semver-shaped.

## Verification

- `npm test` — 335/335 pass.
- `npm run build` clean; `dist/version.js` resolves `VERSION` to `0.10.2` at runtime.
- `tsc --noEmit` clean.