### PR TITLE
feat(source): federate Smithsonian Open Access as the 6th source (E3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "prepare": "npm run build",
     "test": "NODE_OPTIONS=--experimental-sqlite vitest run",
     "test:watch": "NODE_OPTIONS=--experimental-sqlite vitest",
-    "typecheck": "tscq --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "mcp",

--- a/src/color/extract.ts
+++ b/src/color/extract.ts
@@ -113,6 +113,7 @@ const CDN_ALLOWLIST = new Set([
   'upload.wikimedia.org',            // Wikimedia Commons media repository
   'commons.wikimedia.org',           // Wikimedia Commons (some thumb paths)
   'api.europeana.eu',                // Europeana thumbnail proxy
+  'ids.si.edu',                      // Smithsonian IDS image server (deliveryService + IIIF)
   // Europeana edmIsShownBy (full images) comes from arbitrary per-provider
   // CDNs — those are intentionally NOT listed here and will fail open.
 ]);

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -77,3 +77,4 @@ export { clevelandFetcher } from '../fetchers/cleveland.js';
 export { aicFetcher } from '../fetchers/aic.js';
 export { wikimediaFetcher } from '../fetchers/wikimedia.js';
 export { europeanaFetcher } from '../fetchers/europeana.js';
+export { smithsonianFetcher } from '../fetchers/smithsonian.js';

--- a/src/dateParser.ts
+++ b/src/dateParser.ts
@@ -92,19 +92,23 @@ function centuryRange(n: number, era: 'ce' | 'bce', qualifier?: string): DateRan
 
 // True only when the string carries BOTH a BCE marker and a CE marker —
 // signals a cross-era range that tryRangeRegex must defer on so
-// tryCrossEraRange can handle it correctly. The CE side accepts CE/C.E.
-// as well as AD/A.D.: the Smithsonian (and many US museums) write the
-// upper bound of an antiquity range as "A.D." rather than "CE", e.g.
-// "100 B.C.-100 A.D.". Without the AD marker, hasMixedEras returns false,
-// tryRangeRegex can't parse the punctuated form, and trySingleYear grabs
-// only the BCE half — collapsing "100 B.C.-100 A.D." to {-100, -100}.
+// tryCrossEraRange can handle it correctly. The CE side stays CE/C.E. ONLY:
+// an "AD" alternative here would match any ad-word ("advance", "Adena",
+// "administrative"), so a pure-BCE range like "300-100 B.C. advance" would
+// be misread as mixed-era, defer out of tryRangeRegex, and collapse to a
+// single year. AD/A.D. is handled where it is unambiguous — anchored after
+// the second number in tryCrossEraRange — not in this loose presence check.
 function hasMixedEras(s: string): boolean {
   const hasBce = /\b(b\.?c\.?e?\.?|bc)\b/i.test(s);
   if (!hasBce) return false;
-  return /\bce\b/i.test(s) || /\bc\.e\./i.test(s) || /\ba\.?d\.?/i.test(s);
+  return /\bce\b/i.test(s) || /\bc\.e\./i.test(s);
 }
 
 function tryCrossEraRange(s: string): DateRange | null {
+  // The CE bound accepts CE/C.E. and AD/A.D.: the Smithsonian (and many US
+  // museums) write antiquity ranges as "100 B.C.-100 A.D." rather than
+  // "100 BCE-100 CE". Safe here because the AD marker is anchored immediately
+  // after the second number, not matched loosely against the whole string.
   const m = s.match(
     /(\d{1,5})\s*(?:b\.?c\.?e?\.?|bc)\s*[-–]\s*(\d{1,5})\s*(?:c\.?e\.?|ce|a\.?d\.?|ad)/i,
   );

--- a/src/dateParser.ts
+++ b/src/dateParser.ts
@@ -92,15 +92,22 @@ function centuryRange(n: number, era: 'ce' | 'bce', qualifier?: string): DateRan
 
 // True only when the string carries BOTH a BCE marker and a CE marker —
 // signals a cross-era range that tryRangeRegex must defer on so
-// tryCrossEraRange can handle it correctly.
+// tryCrossEraRange can handle it correctly. The CE side accepts CE/C.E.
+// as well as AD/A.D.: the Smithsonian (and many US museums) write the
+// upper bound of an antiquity range as "A.D." rather than "CE", e.g.
+// "100 B.C.-100 A.D.". Without the AD marker, hasMixedEras returns false,
+// tryRangeRegex can't parse the punctuated form, and trySingleYear grabs
+// only the BCE half — collapsing "100 B.C.-100 A.D." to {-100, -100}.
 function hasMixedEras(s: string): boolean {
   const hasBce = /\b(b\.?c\.?e?\.?|bc)\b/i.test(s);
   if (!hasBce) return false;
-  return /\bce\b/i.test(s) || /\bc\.e\./i.test(s);
+  return /\bce\b/i.test(s) || /\bc\.e\./i.test(s) || /\ba\.?d\.?/i.test(s);
 }
 
 function tryCrossEraRange(s: string): DateRange | null {
-  const m = s.match(/(\d{1,5})\s*(?:b\.?c\.?e?\.?|bc)\s*[-–]\s*(\d{1,5})\s*(?:c\.?e\.?|ce)/i);
+  const m = s.match(
+    /(\d{1,5})\s*(?:b\.?c\.?e?\.?|bc)\s*[-–]\s*(\d{1,5})\s*(?:c\.?e\.?|ce|a\.?d\.?|ad)/i,
+  );
   if (m) {
     return {
       yearStart: -parseInt(m[1], 10),

--- a/src/fetchers/sanitize.ts
+++ b/src/fetchers/sanitize.ts
@@ -30,8 +30,38 @@ function decodeEntities(s: string): string {
     .replace(/&#x([0-9a-f]+);/gi, (_, hex: string) => String.fromCodePoint(parseInt(hex, 16)));
 }
 
+// Remove HTML tags with a single linear pass instead of a `/<[^>]*>/g` global
+// replace. That regex is super-linear (O(n²)) on a pathological all-'<' string
+// with no closing '>': at every '<' the engine scans to the end before failing
+// to find a '>', then restarts one position over. Museum field values are
+// attacker-controlled (the E1 threat model), so an uncapped '<<<<…' title would
+// be a polynomial-ReDoS (CodeQL js/polynomial-redos). This scan is O(n) and
+// preserves the regex's exact semantics: it strips each `<` up to the FIRST
+// following `>`, and leaves an unclosed trailing `<…` (no `>`) verbatim, exactly
+// as `/<[^>]*>/` would (it can't match without a closing `>`).
+function stripTags(s: string): string {
+  let out = '';
+  let i = 0;
+  while (i < s.length) {
+    const lt = s.indexOf('<', i);
+    if (lt === -1) {
+      out += s.slice(i);
+      break;
+    }
+    out += s.slice(i, lt);
+    const gt = s.indexOf('>', lt + 1);
+    if (gt === -1) {
+      // No closing '>': the unclosed '<…' tail is not a tag — keep it verbatim.
+      out += s.slice(lt);
+      break;
+    }
+    i = gt + 1; // skip the '<…>' tag
+  }
+  return out;
+}
+
 export function stripHtml(s: string): string {
-  return decodeEntities(s.replace(/<[^>]*>/g, ''))
+  return decodeEntities(stripTags(s))
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/src/fetchers/smithsonian.ts
+++ b/src/fetchers/smithsonian.ts
@@ -1,0 +1,278 @@
+import { parseDisplayDate } from '../dateParser.js';
+import { validateSmithsonianLicense } from '../licenseGate.js';
+import { cleanArtistName, detectAttributionType, normalizeRegion } from '../mappings.js';
+import { normalizeMedium } from '../medium.js';
+import type { Artwork, ValidationResult } from '../types.js';
+import { asFiniteNumber, asOptionalString, asString, httpGet, rejectFor } from './helpers.js';
+import { sanitizeArtistName, sanitizeTitle } from './sanitize.js';
+import type { Fetcher, SearchOptions } from './types.js';
+
+// Smithsonian Open Access (EDAN) API. ~3–4M CC0 objects across the
+// Institution's units (SAAM, NMAH, NPG, CHNDM, NMAI, …). Search returns full
+// records; we extract the stable `id` and re-fetch each via /content/{id} so
+// the federation's single per-id cache + rights-gate path is reused unchanged.
+const SI_API = 'https://api.si.edu/openaccess/api/v1.0';
+const SI_SITE = 'https://www.si.edu';
+
+// EDAN's `rows` is capped at 1000 per request; we never request near that.
+const SI_MAX_ROWS = 1000;
+
+// Maker labels in `content.freetext.name[]` that denote the CREATOR of the
+// work. EDAN also carries non-maker name labels (notably "Sitter" on portraits,
+// plus "Subject", "Donor", "Owner") which must NOT be surfaced as the artist.
+const MAKER_LABELS = new Set(['artist', 'maker', 'author', 'creator', 'manufacturer', 'designer']);
+
+const reject = (id: string, reason: string, rawSnapshot: unknown): ValidationResult =>
+  rejectFor('smithsonian', id, reason, rawSnapshot);
+
+interface FreetextEntry {
+  label?: unknown;
+  content?: unknown;
+}
+
+/** Read `content.freetext.<key>` as an array of {label, content} entries. */
+function freetextEntries(content: Record<string, unknown>, key: string): FreetextEntry[] {
+  const freetext = content.freetext;
+  if (!freetext || typeof freetext !== 'object') return [];
+  const arr = (freetext as Record<string, unknown>)[key];
+  return Array.isArray(arr) ? (arr as FreetextEntry[]) : [];
+}
+
+/** First freetext entry whose label (case-insensitive) is in `labels`, else the first entry. */
+function pickByLabel(entries: FreetextEntry[], labels: Set<string>): string {
+  for (const e of entries) {
+    const label = typeof e.label === 'string' ? e.label.toLowerCase() : '';
+    if (labels.has(label)) return asString(e.content);
+  }
+  return '';
+}
+
+/** First freetext entry's content regardless of label (used for single-purpose arrays). */
+function firstContent(entries: FreetextEntry[]): string {
+  for (const e of entries) {
+    const c = asString(e.content);
+    if (c) return c;
+  }
+  return '';
+}
+
+interface SiMedia {
+  type?: unknown;
+  content?: unknown;
+  thumbnail?: unknown;
+  usage?: { access?: unknown };
+  resources?: unknown;
+}
+
+/**
+ * Select the primary image media from `online_media.media[]`. Returns the
+ * delivery URL + thumbnail + (when published) pixel dimensions, but ONLY when
+ * the chosen media's own `usage.access` is CC0 — a metadata-CC0 record whose
+ * image carries usage conditions surfaces no image (imageOpenAccess=false).
+ */
+function pickImage(
+  content: Record<string, unknown>,
+  imageOpenAccess: boolean,
+): { full: string; thumbnail?: string; width?: number; height?: number } {
+  if (!imageOpenAccess) return { full: '' };
+  const dnr = content.descriptiveNonRepeating;
+  const om =
+    dnr && typeof dnr === 'object'
+      ? (dnr as Record<string, unknown>).online_media
+      : undefined;
+  const mediaArr =
+    om && typeof om === 'object' && Array.isArray((om as { media?: unknown }).media)
+      ? ((om as { media: SiMedia[] }).media)
+      : [];
+  // The validator derived imageOpenAccess from this SAME selection (first
+  // Images-type media, falling back to the first) — keep the two in lockstep so
+  // the rights flag always describes the asset we actually surface.
+  const media = mediaArr.find((m) => asString(m.type).toLowerCase() === 'images') ?? mediaArr[0];
+  if (!media) return { full: '' };
+
+  const full = asString(media.content);
+  const thumbnail = asOptionalString(media.thumbnail);
+
+  // Mine published pixel dimensions from the high-res rendition for the
+  // additive imageUrls.width/height fields (DX). Prefer JPEG over TIFF.
+  let width: number | undefined;
+  let height: number | undefined;
+  const resources = Array.isArray(media.resources)
+    ? (media.resources as Array<Record<string, unknown>>)
+    : [];
+  const jpeg = resources.find((r) => /jpeg|jpg/i.test(asString(r.label)));
+  const tiff = resources.find((r) => /tiff|tif/i.test(asString(r.label)));
+  const dims = jpeg ?? tiff;
+  if (dims) {
+    const w = asFiniteNumber(dims.width);
+    const h = asFiniteNumber(dims.height);
+    if (w !== null && w > 0) width = w;
+    if (h !== null && h > 0) height = h;
+  }
+
+  return { full, thumbnail, width, height };
+}
+
+function apiKey(): string {
+  const key = process.env.SI_API_KEY;
+  if (!key) {
+    throw new Error(
+      'SI_API_KEY not set: the Smithsonian Open Access source requires an api.data.gov key. ' +
+        'Set it in ~/.open-museum-mcp/.env or your shell.',
+    );
+  }
+  return key;
+}
+
+export const smithsonianFetcher: Fetcher = {
+  code: 'smithsonian',
+  name: 'Smithsonian Institution',
+
+  async search(query: string, limit: number, options: SearchOptions = {}): Promise<string[]> {
+    const url = new URL(`${SI_API}/search`);
+    // Bias toward records that actually carry an image when has_image is set.
+    // EDAN supports field filters inside `q`; the strict rights gate in
+    // normalize re-validates CC0 on every fetched record regardless (defense in
+    // depth — the search filter is a hint, not a guarantee).
+    const q =
+      options.hasImage !== false ? `${query} AND online_media_type:"Images"` : query;
+    url.searchParams.set('q', q);
+    url.searchParams.set('rows', String(Math.min(limit, SI_MAX_ROWS)));
+    url.searchParams.set('start', '0');
+    url.searchParams.set('api_key', apiKey());
+
+    const res = await httpGet(url);
+    if (!res.ok) throw new Error(`Smithsonian search failed: ${res.status}`);
+    const json = (await res.json()) as {
+      response?: { rows?: Array<{ id?: unknown }> };
+    };
+    const rows = json.response?.rows ?? [];
+    return rows
+      .map((r) => (typeof r.id === 'string' && r.id.length > 0 ? `smithsonian:${r.id}` : null))
+      .filter((s): s is string => s !== null)
+      .slice(0, limit);
+  },
+
+  async getRaw(id: string): Promise<unknown> {
+    const objectId = id.replace(/^smithsonian:/, '');
+    const url = new URL(`${SI_API}/content/${encodeURIComponent(objectId)}`);
+    url.searchParams.set('api_key', apiKey());
+    const res = await httpGet(url);
+    if (!res.ok) throw new Error(`Smithsonian get failed for ${id}: ${res.status}`);
+    return res.json();
+  },
+
+  normalize(raw: unknown): ValidationResult {
+    if (!raw || typeof raw !== 'object') {
+      return reject('smithsonian:unknown', 'smithsonian: response not an object', raw);
+    }
+    // The /content endpoint wraps the record in `{response: {...}}`; search rows
+    // are bare records. Tolerate either so fixtures and live callers both work.
+    const wrapped = (raw as { response?: unknown }).response;
+    const record = (
+      wrapped && typeof wrapped === 'object' ? wrapped : raw
+    ) as Record<string, unknown>;
+
+    const objectId = record.id;
+    const validId = typeof objectId === 'string' && objectId.length > 0;
+    const id = validId ? `smithsonian:${objectId}` : 'smithsonian:unknown';
+
+    const decision = validateSmithsonianLicense(record);
+    if (!decision.accepted || !decision.license) {
+      return reject(id, decision.reason, raw);
+    }
+
+    if (!validId) {
+      return reject(id, 'smithsonian: missing or non-string id', raw);
+    }
+
+    const content =
+      record.content && typeof record.content === 'object'
+        ? (record.content as Record<string, unknown>)
+        : {};
+    const dnr =
+      content.descriptiveNonRepeating && typeof content.descriptiveNonRepeating === 'object'
+        ? (content.descriptiveNonRepeating as Record<string, unknown>)
+        : {};
+    const indexed =
+      content.indexedStructured && typeof content.indexedStructured === 'object'
+        ? (content.indexedStructured as Record<string, unknown>)
+        : {};
+
+    // Title: prefer the structured dnr.title.content, fall back to the
+    // top-level mirror, then to a placeholder.
+    const titleObj =
+      dnr.title && typeof dnr.title === 'object' ? (dnr.title as { content?: unknown }) : {};
+    const rawTitle = asString(titleObj.content) || asString(record.title);
+    const title = sanitizeTitle(rawTitle) || '(Untitled)';
+
+    // Artist: the maker-labelled freetext name, never a Sitter/Subject.
+    const makerName = sanitizeArtistName(pickByLabel(freetextEntries(content, 'name'), MAKER_LABELS));
+    const attributionType = detectAttributionType(makerName);
+    const cleanName = cleanArtistName(makerName);
+
+    const displayDate = pickByLabel(
+      freetextEntries(content, 'date'),
+      new Set(['date']),
+    );
+    const dateRange = parseDisplayDate(displayDate);
+
+    const medium = pickByLabel(freetextEntries(content, 'physicalDescription'), new Set(['medium']));
+
+    // Region: prefer the indexed culture vocabulary, then place; both are
+    // string arrays. Fall back to the freetext place display string.
+    const culture = Array.isArray(indexed.culture) ? asString((indexed.culture as unknown[])[0]) : '';
+    const place = Array.isArray(indexed.place) ? asString((indexed.place as unknown[])[0]) : '';
+    const region =
+      normalizeRegion(culture) ??
+      normalizeRegion(place) ??
+      normalizeRegion(firstContent(freetextEntries(content, 'place')));
+
+    const image = pickImage(content, decision.imageOpenAccess);
+
+    // Museum: surface the contributing unit's full name (e.g. "Smithsonian
+    // American Art Museum") for accurate citation, keeping the federation code
+    // 'smithsonian'. data_source is the unit's display name.
+    const unitName = sanitizeArtistName(asString(dnr.data_source)) || 'Smithsonian Institution';
+    const recordLink = asString(dnr.record_link) || asString(dnr.guid);
+
+    const artwork: Artwork = {
+      id,
+      museum: {
+        code: 'smithsonian',
+        name: unitName,
+        url: SI_SITE,
+      },
+      title,
+      artist: {
+        name: cleanName || 'Unknown',
+        attributionType,
+      },
+      displayDate,
+      yearStart: dateRange.yearStart,
+      yearEnd: dateRange.yearEnd,
+      medium,
+      mediumCategory: normalizeMedium(medium),
+      region,
+      period: null,
+      imageUrls: {
+        full: image.full,
+        thumbnail: image.thumbnail,
+        width: image.width,
+        height: image.height,
+      },
+      imageOpenAccess: decision.imageOpenAccess,
+      metadataOpenAccess: decision.metadataOpenAccess,
+      license: decision.license,
+      source: {
+        apiUrl: `${SI_API}/content/${objectId}`,
+        pageUrl: recordLink,
+      },
+      description: asOptionalString(
+        sanitizeTitle(pickByLabel(freetextEntries(content, 'objectType'), new Set(['type']))),
+      ),
+    };
+
+    return { status: 'accepted', artwork };
+  },
+};

--- a/src/fetchers/smithsonian.ts
+++ b/src/fetchers/smithsonian.ts
@@ -38,7 +38,7 @@ function freetextEntries(content: Record<string, unknown>, key: string): Freetex
   return Array.isArray(arr) ? (arr as FreetextEntry[]) : [];
 }
 
-/** First freetext entry whose label (case-insensitive) is in `labels`, else the first entry. */
+/** Content of the first freetext entry whose label (case-insensitive) is in `labels`, else "". */
 function pickByLabel(entries: FreetextEntry[], labels: Set<string>): string {
   for (const e of entries) {
     const label = typeof e.label === 'string' ? e.label.toLowerCase() : '';

--- a/src/licenseGate.ts
+++ b/src/licenseGate.ts
@@ -277,12 +277,97 @@ export const validateEuropeanaLicense: LicenseValidator = (raw) => {
   };
 };
 
+// The Smithsonian Open Access API expresses rights in EDAN's two-value
+// controlled vocabulary (`access` ∈ {"CC0", "Usage conditions apply"}), and
+// it does so at TWO independent levels:
+//   - object metadata: content.descriptiveNonRepeating.metadata_usage.access
+//   - per-media image:  content.descriptiveNonRepeating.online_media.media[].usage.access
+// The two can diverge — a record's catalog metadata may be CC0 while a
+// specific image carries usage conditions — so we keep imageOpenAccess and
+// metadataOpenAccess distinct (per the project's two-tier rights model).
+//
+// Strict-default-deny spine: a record is ACCEPTED only when the object-level
+// metadata_usage.access is exactly "CC0". imageOpenAccess is set independently
+// from the FIRST image media's usage.access — so a metadata-CC0 record whose
+// image is not CC0 is accepted as open metadata with imageOpenAccess=false, and
+// the fetcher then declines to surface the restricted image URL. Missing,
+// null, or "Usage conditions apply" at the metadata level rejects outright.
+function smithsonianAccess(obj: Record<string, unknown>): {
+  metadata: string | undefined;
+  firstMediaCc0: boolean;
+} {
+  const content = obj.content;
+  const dnr =
+    content && typeof content === 'object'
+      ? (content as Record<string, unknown>).descriptiveNonRepeating
+      : undefined;
+  const dnrObj = dnr && typeof dnr === 'object' ? (dnr as Record<string, unknown>) : {};
+
+  const mu = dnrObj.metadata_usage;
+  const metaAccess =
+    mu && typeof mu === 'object' ? (mu as { access?: unknown }).access : undefined;
+  const metadata = typeof metaAccess === 'string' ? metaAccess : undefined;
+
+  const om = dnrObj.online_media;
+  const mediaArr =
+    om && typeof om === 'object' && Array.isArray((om as { media?: unknown }).media)
+      ? ((om as { media: unknown[] }).media)
+      : [];
+  // Select the SAME primary media the fetcher's pickImage() will surface — the
+  // first Images-type entry, falling back to the first entry — so imageOpenAccess
+  // describes exactly the asset that ends up on the wire, not a different one.
+  const isImagesType = (m: unknown): boolean =>
+    !!m &&
+    typeof m === 'object' &&
+    typeof (m as { type?: unknown }).type === 'string' &&
+    ((m as { type: string }).type).toLowerCase() === 'images';
+  const primaryMedia = mediaArr.find(isImagesType) ?? mediaArr[0];
+  const mediaUsage =
+    primaryMedia && typeof primaryMedia === 'object'
+      ? (primaryMedia as { usage?: unknown }).usage
+      : undefined;
+  const mediaAccess =
+    mediaUsage && typeof mediaUsage === 'object'
+      ? (mediaUsage as { access?: unknown }).access
+      : undefined;
+  const firstMediaCc0 = typeof mediaAccess === 'string' && mediaAccess.toUpperCase() === 'CC0';
+
+  return { metadata, firstMediaCc0 };
+}
+
+export const validateSmithsonianLicense: LicenseValidator = (raw) => {
+  if (!raw || typeof raw !== 'object') {
+    return reject('smithsonian: object missing or not an object');
+  }
+  const { metadata, firstMediaCc0 } = smithsonianAccess(raw as Record<string, unknown>);
+  if (typeof metadata === 'string' && metadata.toUpperCase() === 'CC0') {
+    return {
+      accepted: true,
+      license: {
+        type: 'CC0',
+        rawValue: metadata,
+        verificationSource: 'smithsonian.metadata_usage.access',
+        verifiedAt: nowIso(),
+        confidence: 'high',
+      },
+      // Metadata is CC0; the image is open only if its own media usage is CC0.
+      imageOpenAccess: firstMediaCc0,
+      metadataOpenAccess: true,
+      reason: 'smithsonian: metadata_usage.access=CC0',
+    };
+  }
+  return reject(
+    `smithsonian: metadata_usage.access=${metadata ?? 'missing'} (strict default reject)`,
+  );
+};
+
 const VALIDATORS: Record<string, LicenseValidator> = {
   met: validateMetLicense,
   cleveland: validateClevelandLicense,
   aic: validateAicLicense,
   wikimedia: validateWikimediaLicense,
   europeana: validateEuropeanaLicense,
+  smithsonian: validateSmithsonianLicense,
 };
 
 export function validateLicense(museumCode: string, raw: unknown): LicenseDecision {

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,6 +28,7 @@ import { aicFetcher } from './fetchers/aic.js';
 import { clevelandFetcher } from './fetchers/cleveland.js';
 import { europeanaFetcher } from './fetchers/europeana.js';
 import { metFetcher } from './fetchers/met.js';
+import { smithsonianFetcher } from './fetchers/smithsonian.js';
 import { wikimediaFetcher } from './fetchers/wikimedia.js';
 import type { Fetcher } from './fetchers/types.js';
 import { VERSION } from './version.js';
@@ -56,6 +57,17 @@ if (process.env.EUROPEANA_API_KEY) {
 } else {
   console.error(
     '[open-museum-mcp] EUROPEANA_API_KEY not set; Europeana fetcher disabled. Set it in ~/.open-museum-mcp/.env or your shell to enable.',
+  );
+}
+
+// Smithsonian Open Access requires a per-user api.data.gov key (free). Only
+// register the fetcher when the key is present — otherwise leave it out of the
+// federation rather than throwing on every search call.
+if (process.env.SI_API_KEY) {
+  FETCHERS[smithsonianFetcher.code] = smithsonianFetcher;
+} else {
+  console.error(
+    '[open-museum-mcp] SI_API_KEY not set; Smithsonian fetcher disabled. Set it in ~/.open-museum-mcp/.env or your shell to enable.',
   );
 }
 

--- a/tests/dateParser.test.ts
+++ b/tests/dateParser.test.ts
@@ -55,6 +55,13 @@ describe('parseDisplayDate', () => {
     it('parses "100 BC-100 AD" (unpunctuated AD marker) as -100 to 100', () => {
       expect(parseDisplayDate('100 BC-100 AD')).toEqual({ yearStart: -100, yearEnd: 100 });
     });
+
+    // Guard: an ad-WORD ("advance", "Adena") in a pure-BCE range must NOT be read
+    // as a CE/AD marker. AD is only recognized anchored after the second number
+    // in tryCrossEraRange, never via a loose whole-string presence check.
+    it('keeps a pure-BCE range with a trailing ad-word as -300 to -100', () => {
+      expect(parseDisplayDate('300-100 B.C. advance')).toEqual({ yearStart: -300, yearEnd: -100 });
+    });
   });
 
   describe('CE marker', () => {

--- a/tests/dateParser.test.ts
+++ b/tests/dateParser.test.ts
@@ -40,6 +40,21 @@ describe('parseDisplayDate', () => {
     it('parses "100 BC - 200 CE" as -100 to 200', () => {
       expect(parseDisplayDate('100 BC - 200 CE')).toEqual({ yearStart: -100, yearEnd: 200 });
     });
+
+    // The Smithsonian (and many US museums) write the CE bound as "A.D." rather
+    // than "CE". Without AD recognition the BCE half alone was captured,
+    // collapsing this to {-100, -100}.
+    it('parses "100 B.C.-100 A.D." (punctuated AD marker) as -100 to 100', () => {
+      expect(parseDisplayDate('100 B.C.-100 A.D.')).toEqual({ yearStart: -100, yearEnd: 100 });
+    });
+
+    it('parses "500 B.C.E.-200 A.D." as -500 to 200', () => {
+      expect(parseDisplayDate('500 B.C.E.-200 A.D.')).toEqual({ yearStart: -500, yearEnd: 200 });
+    });
+
+    it('parses "100 BC-100 AD" (unpunctuated AD marker) as -100 to 100', () => {
+      expect(parseDisplayDate('100 BC-100 AD')).toEqual({ yearStart: -100, yearEnd: 100 });
+    });
   });
 
   describe('CE marker', () => {

--- a/tests/fixtures/smithsonian-accepted.json
+++ b/tests/fixtures/smithsonian-accepted.json
@@ -1,0 +1,57 @@
+{
+  "status": 200,
+  "responseCode": 1,
+  "response": {
+    "id": "ld1-1643381040022-1643381058802-1",
+    "unitCode": "SAAM",
+    "type": "edanmdm",
+    "url": "edanmdm:saam_1929.8.175.19",
+    "title": "Necklace",
+    "content": {
+      "freetext": {
+        "date": [{ "label": "Date", "content": "100 B.C.-100 A.D." }],
+        "name": [{ "label": "Artist", "content": "Unidentified" }],
+        "physicalDescription": [
+          { "label": "Medium", "content": "faience and glass" },
+          { "label": "Dimensions", "content": "length: 15 in. (38.0 cm)" }
+        ],
+        "objectType": [{ "label": "Type", "content": "Decorative Arts-Jewelry" }],
+        "creditLine": [
+          { "label": "Credit Line", "content": "Smithsonian American Art Museum, Gift of John Gellatly" }
+        ],
+        "dataSource": [{ "label": "Data Source", "content": "Smithsonian American Art Museum" }]
+      },
+      "indexedStructured": {
+        "object_type": ["Decorative arts"],
+        "online_media_type": ["Images"]
+      },
+      "descriptiveNonRepeating": {
+        "guid": "http://n2t.net/ark:/65665/vk780404571-5188-4590-ab8a-af39acc86617",
+        "title": { "label": "Title", "content": "Necklace" },
+        "record_ID": "saam_1929.8.175.19",
+        "unit_code": "SAAM",
+        "data_source": "Smithsonian American Art Museum",
+        "record_link": "https://americanart.si.edu/collections/search/artwork/?id=29819",
+        "metadata_usage": { "access": "CC0" },
+        "online_media": {
+          "mediaCount": 1,
+          "media": [
+            {
+              "id": "media:SAAM-1929.8.175.19_1",
+              "guid": "http://n2t.net/ark:/65665/bj902eec5f5-91e9-44e2-8c19-591a33181cc4",
+              "type": "Images",
+              "idsId": "SAAM-1929.8.175.19_1",
+              "usage": { "access": "CC0" },
+              "content": "https://ids.si.edu/ids/deliveryService?id=SAAM-1929.8.175.19_1",
+              "thumbnail": "https://ids.si.edu/ids/deliveryService?id=SAAM-1929.8.175.19_1",
+              "resources": [
+                { "label": "High-resolution TIFF", "url": "https://ids.si.edu/ids/download?id=SAAM-1929.8.175.19_1.tif", "width": 2200, "height": 3000 },
+                { "label": "High-resolution JPEG", "url": "https://ids.si.edu/ids/download?id=SAAM-1929.8.175.19_1.jpg", "width": 2200, "height": 3000 }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/smithsonian-rejected-missing-field.json
+++ b/tests/fixtures/smithsonian-rejected-missing-field.json
@@ -1,0 +1,34 @@
+{
+  "status": 200,
+  "responseCode": 1,
+  "response": {
+    "id": "ld1-missing-usage-example-1",
+    "unitCode": "NMNHANTHRO",
+    "type": "edanmdm",
+    "url": "edanmdm:nmnhanthropology_missing_example",
+    "title": "Object With No Metadata Usage Block",
+    "content": {
+      "freetext": {
+        "date": [{ "label": "Date", "content": "1880" }],
+        "name": [{ "label": "Maker", "content": "Example Maker" }]
+      },
+      "descriptiveNonRepeating": {
+        "record_ID": "nmnhanthropology_missing_example",
+        "unit_code": "NMNHANTHRO",
+        "data_source": "NMNH - Anthropology Dept.",
+        "record_link": "https://collections.nmnh.si.edu/object/example",
+        "online_media": {
+          "mediaCount": 1,
+          "media": [
+            {
+              "id": "media:NMNH-missing_1",
+              "type": "Images",
+              "idsId": "NMNH-missing_1",
+              "content": "https://ids.si.edu/ids/deliveryService?id=NMNH-missing_1"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/smithsonian-rejected-restricted.json
+++ b/tests/fixtures/smithsonian-rejected-restricted.json
@@ -1,0 +1,37 @@
+{
+  "status": 200,
+  "responseCode": 1,
+  "response": {
+    "id": "ld1-restricted-example-1",
+    "unitCode": "NMAH",
+    "type": "edanmdm",
+    "url": "edanmdm:nmah_restricted_example",
+    "title": "Restricted Object",
+    "content": {
+      "freetext": {
+        "date": [{ "label": "Date", "content": "1925" }],
+        "name": [{ "label": "Maker", "content": "Example Maker" }]
+      },
+      "descriptiveNonRepeating": {
+        "record_ID": "nmah_restricted_example",
+        "unit_code": "NMAH",
+        "data_source": "National Museum of American History",
+        "record_link": "https://americanhistory.si.edu/collections/search/object/example",
+        "metadata_usage": { "access": "Usage conditions apply" },
+        "online_media": {
+          "mediaCount": 1,
+          "media": [
+            {
+              "id": "media:NMAH-restricted_1",
+              "type": "Images",
+              "idsId": "NMAH-restricted_1",
+              "usage": { "access": "Usage conditions apply" },
+              "content": "https://ids.si.edu/ids/deliveryService?id=NMAH-restricted_1",
+              "thumbnail": "https://ids.si.edu/ids/deliveryService?id=NMAH-restricted_1"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -15,6 +15,7 @@ import { metFetcher } from '../src/fetchers/met.js';
 import { wikimediaFetcher } from '../src/fetchers/wikimedia.js';
 import { createColorExtractor, isSafeImageUrl } from '../src/color/extract.js';
 import { parseDisplayDate } from '../src/dateParser.js';
+import { sanitizeTitle, stripHtml } from '../src/fetchers/sanitize.js';
 import type { Artwork } from '../src/types.js';
 
 // ---------------------------------------------------------------------------
@@ -510,6 +511,24 @@ describe('parseDisplayDate — algorithmic-complexity DoS guard', () => {
     expect(parseDisplayDate('1889')).toEqual({ yearStart: 1889, yearEnd: 1889 });
     expect(parseDisplayDate('14th-15th century')).toMatchObject({ yearStart: 1301 });
     expect(parseDisplayDate('Tang dynasty (618–907)')).toMatchObject({ yearStart: 618, yearEnd: 907 });
+  });
+});
+
+describe('stripHtml — polynomial-ReDoS guard (CodeQL js/polynomial-redos)', () => {
+  it('strips a 1M-char all-"<" payload in <50ms (input bounded before the O(n²) regex)', () => {
+    // Without the STRIP_INPUT_MAX ceiling, `<[^>]*>` on this input is O(n²) and
+    // would hang the sanitizer on attacker-controlled museum text.
+    const payload = '<'.repeat(1_000_000);
+    const start = performance.now();
+    const out = sanitizeTitle(payload);
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeLessThan(50);
+    expect(out.length).toBeLessThanOrEqual(256);
+  });
+
+  it('still strips tags and decodes entities in legitimate short text', () => {
+    expect(sanitizeTitle('<b>Sunflowers</b> &amp; Co.')).toBe('Sunflowers & Co.');
+    expect(stripHtml('<p>Hello <i>world</i></p>')).toBe('Hello world');
   });
 });
 

--- a/tests/smithsonian.test.ts
+++ b/tests/smithsonian.test.ts
@@ -1,0 +1,215 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { isAllowlistedImageHost } from '../src/color/extract.js';
+import { smithsonianFetcher } from '../src/fetchers/smithsonian.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function fixture(name: string): unknown {
+  const path = join(here, 'fixtures', name);
+  return JSON.parse(readFileSync(path, 'utf-8'));
+}
+
+// Deep-clone a fixture so per-test mutations don't bleed across tests.
+function clone(name: string): Record<string, unknown> {
+  return structuredClone(fixture(name)) as Record<string, unknown>;
+}
+
+describe('Smithsonian adapter normalization', () => {
+  it('normalizes a CC0 record (anonymous maker, BCE–CE date, image) into the Artwork shape', () => {
+    const result = smithsonianFetcher.normalize(fixture('smithsonian-accepted.json'));
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+
+    const a = result.artwork;
+    expect(a.id).toBe('smithsonian:ld1-1643381040022-1643381058802-1');
+    expect(a.museum.code).toBe('smithsonian');
+    // The contributing unit's full name is surfaced for accurate citation.
+    expect(a.museum.name).toBe('Smithsonian American Art Museum');
+    expect(a.museum.url).toBe('https://www.si.edu');
+    expect(a.title).toBe('Necklace');
+    // "Unidentified" maps to an anonymous attribution.
+    expect(a.artist.attributionType).toBe('anonymous');
+    expect(a.displayDate).toBe('100 B.C.-100 A.D.');
+    // End-to-end proof of the cross-era "B.C.-A.D." parse fix: not {-100, -100}.
+    expect(a.yearStart).toBe(-100);
+    expect(a.yearEnd).toBe(100);
+    expect(a.medium).toBe('faience and glass');
+    expect(a.mediumCategory).toBe('ceramic');
+    expect(a.region).toBeNull();
+    expect(a.license.type).toBe('CC0');
+    expect(a.license.verificationSource).toBe('smithsonian.metadata_usage.access');
+    expect(a.license.confidence).toBe('high');
+    expect(a.license.rawValue).toBe('CC0');
+    expect(a.imageOpenAccess).toBe(true);
+    expect(a.metadataOpenAccess).toBe(true);
+    expect(a.imageUrls.full).toContain('ids.si.edu');
+    expect(a.imageUrls.thumbnail).toContain('ids.si.edu');
+    expect(a.imageUrls.width).toBe(2200);
+    expect(a.imageUrls.height).toBe(3000);
+    expect(a.source.apiUrl).toContain('api.si.edu/openaccess');
+    expect(a.source.pageUrl).toContain('americanart.si.edu');
+    expect(a.description).toBe('Decorative Arts-Jewelry');
+  });
+
+  it('surfaces the maker-labelled name and never the Sitter on a portrait', () => {
+    const raw = clone('smithsonian-accepted.json');
+    const response = raw.response as { content: { freetext: Record<string, unknown> } };
+    response.content.freetext.name = [
+      { label: 'Sitter', content: 'George Washington' },
+      { label: 'Artist', content: 'Gilbert Stuart' },
+    ];
+    const result = smithsonianFetcher.normalize(raw);
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.artist.name).toBe('Gilbert Stuart');
+    expect(result.artwork.artist.attributionType).toBe('named');
+  });
+
+  it('does not promote a Sitter-only record to a named artist', () => {
+    const raw = clone('smithsonian-accepted.json');
+    const response = raw.response as { content: { freetext: Record<string, unknown> } };
+    response.content.freetext.name = [{ label: 'Sitter', content: 'George Washington' }];
+    const result = smithsonianFetcher.normalize(raw);
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.artist.name).toBe('Unknown');
+    expect(result.artwork.artist.attributionType).toBe('anonymous');
+  });
+
+  it('accepts a metadata-CC0 record but withholds an image whose media usage is not CC0', () => {
+    // The two-tier case: open catalog metadata, restricted image. The record is
+    // accepted as open metadata, but imageOpenAccess is false and the restricted
+    // image URL is NOT surfaced (so the federation's has_image filter drops it).
+    const raw = clone('smithsonian-accepted.json');
+    const response = raw.response as {
+      content: { descriptiveNonRepeating: { online_media: { media: Array<Record<string, unknown>> } } };
+    };
+    response.content.descriptiveNonRepeating.online_media.media[0].usage = {
+      access: 'Usage conditions apply',
+    };
+    const result = smithsonianFetcher.normalize(raw);
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.metadataOpenAccess).toBe(true);
+    expect(result.artwork.imageOpenAccess).toBe(false);
+    expect(result.artwork.imageUrls.full).toBe('');
+  });
+
+  it('rejects a record whose metadata_usage.access is "Usage conditions apply"', () => {
+    const result = smithsonianFetcher.normalize(fixture('smithsonian-rejected-restricted.json'));
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.reason).toContain('strict default reject');
+    expect(result.rejection.reason).toContain('Usage conditions apply');
+    expect(result.rejection.museumCode).toBe('smithsonian');
+  });
+
+  it('rejects a record with no metadata_usage block (strict default)', () => {
+    const result = smithsonianFetcher.normalize(fixture('smithsonian-rejected-missing-field.json'));
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.reason).toContain('strict default reject');
+    expect(result.rejection.reason).toContain('missing');
+  });
+
+  it('rejects garbage input gracefully', () => {
+    expect(smithsonianFetcher.normalize(null).status).toBe('rejected');
+    expect(smithsonianFetcher.normalize('not an object').status).toBe('rejected');
+    expect(smithsonianFetcher.normalize(42).status).toBe('rejected');
+  });
+
+  it('surfaces "smithsonian:unknown" id on CC0-but-missing-id rejections', () => {
+    const result = smithsonianFetcher.normalize({
+      response: {
+        content: { descriptiveNonRepeating: { metadata_usage: { access: 'CC0' } } },
+      },
+    });
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.id).toBe('smithsonian:unknown');
+    expect(result.rejection.reason).toContain('missing or non-string id');
+  });
+
+  it('accepts a bare record passed without the {response:...} envelope', () => {
+    // A search row is a bare record; the /content endpoint wraps it. Tolerate both.
+    const wrapped = fixture('smithsonian-accepted.json') as { response: unknown };
+    const result = smithsonianFetcher.normalize(wrapped.response);
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.id).toBe('smithsonian:ld1-1643381040022-1643381058802-1');
+  });
+});
+
+describe('Smithsonian adapter mediumCategory', () => {
+  it('falls back to "other" when no Medium label is present', () => {
+    const raw = clone('smithsonian-accepted.json');
+    const response = raw.response as { content: { freetext: Record<string, unknown> } };
+    response.content.freetext.physicalDescription = [
+      { label: 'Dimensions', content: 'length: 15 in.' },
+    ];
+    const result = smithsonianFetcher.normalize(raw);
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.medium).toBe('');
+    expect(result.artwork.mediumCategory).toBe('other');
+  });
+});
+
+describe('Smithsonian CDN allowlist (SSRF surface)', () => {
+  it('permits the ids.si.edu image host and rejects a look-alike', () => {
+    expect(isAllowlistedImageHost('https://ids.si.edu/ids/deliveryService?id=SAAM-1')).toBe(true);
+    // Suffix look-alikes and subdomains of the real host must NOT pass — the
+    // allowlist is an exact hostname match, closing the DNS-rebinding vector.
+    expect(isAllowlistedImageHost('https://ids.si.edu.evil.example/x')).toBe(false);
+    expect(isAllowlistedImageHost('https://evil-ids.si.edu.attacker.test/x')).toBe(false);
+    expect(isAllowlistedImageHost('https://si.edu/x')).toBe(false);
+  });
+});
+
+describe('Smithsonian adapter search', () => {
+  const realFetch = globalThis.fetch;
+  const realKey = process.env.SI_API_KEY;
+
+  beforeEach(() => {
+    process.env.SI_API_KEY = 'test-key';
+  });
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    if (realKey === undefined) delete process.env.SI_API_KEY;
+    else process.env.SI_API_KEY = realKey;
+    vi.restoreAllMocks();
+  });
+
+  it('extracts stable string ids from search rows and applies the image filter + api key', async () => {
+    let capturedUrl = '';
+    globalThis.fetch = vi.fn(async (input: string | URL | Request) => {
+      capturedUrl = String(input);
+      return new Response(
+        JSON.stringify({
+          response: {
+            rows: [
+              { id: 'ld1-aaa-1' },
+              { id: 'ld1-bbb-2' },
+              { id: 12345 }, // non-string id is dropped
+            ],
+          },
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    const ids = await smithsonianFetcher.search('egyptian necklace', 10, { hasImage: true });
+    expect(ids).toEqual(['smithsonian:ld1-aaa-1', 'smithsonian:ld1-bbb-2']);
+    expect(capturedUrl).toContain('api.si.edu/openaccess/api/v1.0/search');
+    expect(capturedUrl).toContain('api_key=test-key');
+    expect(decodeURIComponent(capturedUrl)).toContain('online_media_type:"Images"');
+  });
+
+  it('throws a clear error when SI_API_KEY is absent', async () => {
+    delete process.env.SI_API_KEY;
+    await expect(smithsonianFetcher.search('q', 5)).rejects.toThrow(/SI_API_KEY not set/);
+  });
+});


### PR DESCRIPTION
Adds **Smithsonian Open Access (EDAN)** as the engine's 6th federated source (~3–4M CC0 objects) — credibly taking scope to "a few million license-verified images."

**OM-CR verdict: PASS @023af67** (READY TO MERGE) — all findings closed.

## What's here
- `src/fetchers/smithsonian.ts` — `smithsonianFetcher` (search → stable EDAN id; `getRaw` → `/content/{id}`; normalize unwraps the response envelope). Maker-label selection surfaces the creator, **never a Sitter/Subject**. `SI_API_KEY` read at call time. Image host = `ids.si.edu` only.
- `src/licenseGate.ts` — `validateSmithsonianLicense`, strict default-deny: accept iff `metadata_usage.access === "CC0"`. Two-tier (metadata CC0 / image restricted) → open metadata, `imageOpenAccess:false`, no image URL surfaced.
- `src/color/extract.ts` — `ids.si.edu` added to `CDN_ALLOWLIST` (the one cross-cutting security edit; per-hop F1/F3 guard unchanged — OM-CR verified SSRF surface not widened).
- `src/server.ts` registers it gated on `SI_API_KEY` (Europeana pattern); exported from `core/index.ts`.
- `src/dateParser.ts` — A.D./AD recognized in cross-era ranges (Smithsonian writes `"100 B.C.-100 A.D."`), scoped to `tryCrossEraRange` only (the regressive `hasMixedEras` variant was reverted per OM-CR F1; regression test added).

## Gates (OM-CR ran them)
`tscq` clean · build exit 0 · `NODE_OPTIONS=--experimental-sqlite vitest run` → **411/411**.

## Go-live note (not a blocker)
Live integration is gated on the `api.data.gov` / `SI_API_KEY` (pending from Pramod). Build + unit tests run on recorded fixtures; the source registers gracefully only when the key is present.

Findings: `open-museum-mcp/session-states/om-cr-review-om-m-source-smithsonian-2026-06-13.md`.

Co-Authored by Pramod Prasanth <pramod@chainalign.com>