### PR TITLE
fix(smithsonian): live-verified curation + name + key-var mismatch (post-merge follow-up to #79)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "prepare": "npm run build",
     "test": "NODE_OPTIONS=--experimental-sqlite vitest run",
     "test:watch": "NODE_OPTIONS=--experimental-sqlite vitest",
+    "smoke:smithsonian": "NODE_OPTIONS=--experimental-sqlite tsx scripts/smoke-smithsonian.ts",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [

--- a/scripts/smoke-smithsonian.ts
+++ b/scripts/smoke-smithsonian.ts
@@ -1,0 +1,68 @@
+// Live smoke for the Smithsonian fetcher — hits the real api.si.edu (EDAN).
+// Loads ~/.open-museum-mcp/.env, runs search -> getRaw -> normalize, and reports
+// accepted artworks + non-art rejections so the curation gate is visible live.
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import dotenv from 'dotenv';
+import { smithsonianFetcher } from '../src/fetchers/smithsonian.js';
+
+// Load env exactly as src/server.ts does: shell/CWD .env first, then the
+// canonical ~/.open-museum-mcp/.env (missing files are ignored by dotenv).
+function loadEnv() {
+  dotenv.config({ quiet: true });
+  dotenv.config({ quiet: true, path: join(homedir(), '.open-museum-mcp', '.env') });
+}
+
+async function runQuery(query: string) {
+  console.log(`\n${'='.repeat(70)}\nQUERY: "${query}"\n${'='.repeat(70)}`);
+  const ids = await smithsonianFetcher.search(query, 8, { hasImage: true });
+  console.log(`search() returned ${ids.length} ids: ${ids.join(', ') || '(none)'}`);
+  let accepted = 0;
+  let rejected = 0;
+  for (const id of ids) {
+    let raw: unknown;
+    try {
+      raw = await smithsonianFetcher.getRaw(id);
+    } catch (e) {
+      console.log(`  [${id}] getRaw FAILED: ${(e as Error).message}`);
+      continue;
+    }
+    const res = smithsonianFetcher.normalize(raw);
+    if (res.status === 'accepted') {
+      accepted++;
+      const a = res.artwork;
+      console.log(
+        `  ✓ ACCEPT [${id}] "${a.title}"\n` +
+          `      artist: ${a.artist.name}${a.artist.nationality ? ` [${a.artist.nationality}]` : ''}` +
+          `${a.artist.lifespan ? ` (${a.artist.lifespan})` : ''}\n` +
+          `      date: ${a.displayDate} -> {${a.yearStart}, ${a.yearEnd}} | medium: ${a.mediumCategory}\n` +
+          `      license: ${a.license.type} (${a.license.confidence}) | imageOpenAccess: ${a.imageOpenAccess}\n` +
+          `      image: ${a.imageUrls.full || '(none)'}`,
+      );
+    } else {
+      rejected++;
+      console.log(`  ✗ REJECT [${id}] — ${res.rejection.reason}`);
+    }
+  }
+  console.log(`\nRESULT: ${accepted} accepted, ${rejected} rejected (of ${ids.length})`);
+}
+
+async function main() {
+  loadEnv();
+  const hasKey = !!(process.env.SMITHSONIAN_API_KEY || process.env.SI_API_KEY);
+  console.log(`SMITHSONIAN_API_KEY present: ${!!process.env.SMITHSONIAN_API_KEY}`);
+  console.log(`SI_API_KEY present: ${!!process.env.SI_API_KEY}`);
+  console.log(`fetcher will resolve a key: ${hasKey}`);
+  if (!hasKey) {
+    console.log('No key resolvable — Smithsonian would be DISABLED. Aborting live calls.');
+    return;
+  }
+  for (const q of ['japanese woodblock print', 'vincent van gogh', 'sunflowers']) {
+    await runQuery(q);
+  }
+}
+
+main().catch((e) => {
+  console.error('SMOKE FAILED:', e);
+  process.exit(1);
+});

--- a/src/fetchers/smithsonian.ts
+++ b/src/fetchers/smithsonian.ts
@@ -25,6 +25,68 @@ const MAKER_LABELS = new Set(['artist', 'maker', 'author', 'creator', 'manufactu
 const reject = (id: string, reason: string, rawSnapshot: unknown): ValidationResult =>
   rejectFor('smithsonian', id, reason, rawSnapshot);
 
+// Smithsonian Open Access spans ALL units — including Libraries (bibliographic
+// "Books" records) and Natural History (specimens) — not just art museums. An
+// `online_media_type:"Images"` search still surfaces book covers and specimen
+// photos. `indexedStructured.object_type` (controlled vocabulary) is the direct
+// art/non-art signal: art records carry "Drawings"/"Paintings"/"Decorative
+// arts" etc.; books carry "Books"; specimens carry no object_type at all. We
+// gate on an art-type ALLOWLIST (precision over recall — better to drop an edge
+// artwork than admit a book or a beetle). Matched as a substring of the
+// lowercased controlled value, so "Decorative Arts-Jewelry" and "Drawings" both
+// hit. A record with no recognized art object_type is rejected as non-art.
+const ART_OBJECT_TYPE_KEYWORDS = [
+  'painting',
+  'drawing',
+  'print',
+  'sculpture',
+  'photograph',
+  'decorative art',
+  'textile',
+  'ceramic',
+  'jewel',
+  'costume',
+  'furniture',
+  'glass',
+  'watercolor',
+  'etching',
+  'engraving',
+  'lithograph',
+  'poster',
+  'miniature',
+  'medal',
+  'collage',
+  'mosaic',
+  'tapestry',
+  'enamel',
+  'metalwork',
+  'works on paper',
+  'work on paper',
+];
+
+/** True when any object_type value names an art form on the allowlist. */
+function isArtObjectType(objectTypes: string[]): boolean {
+  for (const t of objectTypes) {
+    const lower = t.toLowerCase();
+    if (ART_OBJECT_TYPE_KEYWORDS.some((k) => lower.includes(k))) return true;
+  }
+  return false;
+}
+
+/** Collect object_type signals from indexedStructured (primary) + freetext (fallback). */
+function objectTypeSignals(content: Record<string, unknown>): string[] {
+  const out: string[] = [];
+  const indexed = content.indexedStructured;
+  if (indexed && typeof indexed === 'object') {
+    const ot = (indexed as Record<string, unknown>).object_type;
+    if (Array.isArray(ot)) for (const v of ot) if (typeof v === 'string') out.push(v);
+  }
+  for (const e of freetextEntries(content, 'objectType')) {
+    if (typeof e.content === 'string') out.push(e.content);
+  }
+  return out;
+}
+
 interface FreetextEntry {
   label?: unknown;
   content?: unknown;
@@ -54,6 +116,45 @@ function firstContent(entries: FreetextEntry[]): string {
     if (c) return c;
   }
   return '';
+}
+
+/**
+ * Smithsonian `freetext.name` content ranges from a bare "Gilbert Stuart" to a
+ * verbose, comma-delimited attribution that bundles nationality + biography +
+ * lifespan into one string, e.g.
+ *   "Vincent Van Gogh, The Netherlands, active in France, 1853 – 1890".
+ * Taking it verbatim leaves that whole string in `artist.name`. Split on the
+ * first comma for the name, then mine the trailing segments for a birth–death
+ * lifespan and a nationality (skipping role phrases like "active in France").
+ * A name with no comma is returned unchanged.
+ */
+function parseSmithsonianName(raw: string): {
+  name: string;
+  nationality?: string;
+  lifespan?: string;
+} {
+  const parts = raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (parts.length <= 1) return { name: raw.trim() };
+
+  const name = parts[0];
+  let nationality: string | undefined;
+  let lifespan: string | undefined;
+  for (const seg of parts.slice(1)) {
+    const yr = seg.match(/(\d{3,4})\s*[–-]\s*(\d{3,4})/);
+    if (yr && !lifespan) {
+      lifespan = `${yr[1]}–${yr[2]}`;
+      continue;
+    }
+    // Skip role/activity phrases ("active in France", "born ...") and any
+    // year-bearing segment; the first plain segment is the nationality/place.
+    if (!nationality && !/\d/.test(seg) && !/^(active|born|died|fl\.?)\b/i.test(seg)) {
+      nationality = seg;
+    }
+  }
+  return { name, nationality, lifespan };
 }
 
 interface SiMedia {
@@ -113,12 +214,18 @@ function pickImage(
   return { full, thumbnail, width, height };
 }
 
+// Canonical env var is SMITHSONIAN_API_KEY (matches the EUROPEANA_API_KEY
+// convention); SI_API_KEY is accepted as a backward-compatible alias.
+export function smithsonianApiKey(): string | undefined {
+  return process.env.SMITHSONIAN_API_KEY || process.env.SI_API_KEY;
+}
+
 function apiKey(): string {
-  const key = process.env.SI_API_KEY;
+  const key = smithsonianApiKey();
   if (!key) {
     throw new Error(
-      'SI_API_KEY not set: the Smithsonian Open Access source requires an api.data.gov key. ' +
-        'Set it in ~/.open-museum-mcp/.env or your shell.',
+      'SMITHSONIAN_API_KEY not set: the Smithsonian Open Access source requires an api.data.gov key. ' +
+        'Set SMITHSONIAN_API_KEY (or the SI_API_KEY alias) in ~/.open-museum-mcp/.env or your shell.',
     );
   }
   return key;
@@ -130,10 +237,13 @@ export const smithsonianFetcher: Fetcher = {
 
   async search(query: string, limit: number, options: SearchOptions = {}): Promise<string[]> {
     const url = new URL(`${SI_API}/search`);
-    // Bias toward records that actually carry an image when has_image is set.
-    // EDAN supports field filters inside `q`; the strict rights gate in
-    // normalize re-validates CC0 on every fetched record regardless (defense in
-    // depth — the search filter is a hint, not a guarantee).
+    // Restrict to records that carry an online image when has_image is set. This
+    // is load-bearing, NOT a removable hint: without it, EDAN search is dominated
+    // by Smithsonian LIBRARIES bibliographic records — live, "vincent van gogh"
+    // returns 189 matches of which 100% of the top page are `SIL` books, and only
+    // ~1 is an actual artwork with an image. The filter is what separates "a van
+    // Gogh" from "books about van Gogh". The strict CC0 gate + the non-art
+    // object_type gate in normalize still re-validate every fetched record.
     const q =
       options.hasImage !== false ? `${query} AND online_media_type:"Images"` : query;
     url.searchParams.set('q', q);
@@ -199,6 +309,18 @@ export const smithsonianFetcher: Fetcher = {
         ? (content.indexedStructured as Record<string, unknown>)
         : {};
 
+    // Non-art curation gate (runs AFTER the rights gate — rights is the hard
+    // boundary; this is a relevance gate that keeps the federated ART result set
+    // free of Smithsonian Libraries book records and Natural History specimens).
+    const objectTypes = objectTypeSignals(content);
+    if (!isArtObjectType(objectTypes)) {
+      return reject(
+        id,
+        `smithsonian: non-art object_type=${objectTypes.length ? objectTypes.join('/') : 'none'} (curation reject)`,
+        raw,
+      );
+    }
+
     // Title: prefer the structured dnr.title.content, fall back to the
     // top-level mirror, then to a placeholder.
     const titleObj =
@@ -206,10 +328,14 @@ export const smithsonianFetcher: Fetcher = {
     const rawTitle = asString(titleObj.content) || asString(record.title);
     const title = sanitizeTitle(rawTitle) || '(Untitled)';
 
-    // Artist: the maker-labelled freetext name, never a Sitter/Subject.
+    // Artist: the maker-labelled freetext name, never a Sitter/Subject. The
+    // verbose Smithsonian attribution string is split into name/nationality/
+    // lifespan before cleaning. Attribution type is detected on the raw string
+    // so prefixes like "after"/"attributed to" are still caught.
     const makerName = sanitizeArtistName(pickByLabel(freetextEntries(content, 'name'), MAKER_LABELS));
     const attributionType = detectAttributionType(makerName);
-    const cleanName = cleanArtistName(makerName);
+    const parsedName = parseSmithsonianName(makerName);
+    const cleanName = cleanArtistName(parsedName.name);
 
     const displayDate = pickByLabel(
       freetextEntries(content, 'date'),
@@ -246,6 +372,8 @@ export const smithsonianFetcher: Fetcher = {
       title,
       artist: {
         name: cleanName || 'Unknown',
+        nationality: parsedName.nationality,
+        lifespan: parsedName.lifespan,
         attributionType,
       },
       displayDate,

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,7 +28,7 @@ import { aicFetcher } from './fetchers/aic.js';
 import { clevelandFetcher } from './fetchers/cleveland.js';
 import { europeanaFetcher } from './fetchers/europeana.js';
 import { metFetcher } from './fetchers/met.js';
-import { smithsonianFetcher } from './fetchers/smithsonian.js';
+import { smithsonianFetcher, smithsonianApiKey } from './fetchers/smithsonian.js';
 import { wikimediaFetcher } from './fetchers/wikimedia.js';
 import type { Fetcher } from './fetchers/types.js';
 import { VERSION } from './version.js';
@@ -62,12 +62,13 @@ if (process.env.EUROPEANA_API_KEY) {
 
 // Smithsonian Open Access requires a per-user api.data.gov key (free). Only
 // register the fetcher when the key is present — otherwise leave it out of the
-// federation rather than throwing on every search call.
-if (process.env.SI_API_KEY) {
+// federation rather than throwing on every search call. Canonical var is
+// SMITHSONIAN_API_KEY (EUROPEANA_API_KEY convention); SI_API_KEY is an alias.
+if (smithsonianApiKey()) {
   FETCHERS[smithsonianFetcher.code] = smithsonianFetcher;
 } else {
   console.error(
-    '[open-museum-mcp] SI_API_KEY not set; Smithsonian fetcher disabled. Set it in ~/.open-museum-mcp/.env or your shell to enable.',
+    '[open-museum-mcp] SMITHSONIAN_API_KEY not set; Smithsonian fetcher disabled. Set it (or the SI_API_KEY alias) in ~/.open-museum-mcp/.env or your shell to enable.',
   );
 }
 

--- a/tests/smithsonian.test.ts
+++ b/tests/smithsonian.test.ts
@@ -253,12 +253,12 @@ describe('Smithsonian adapter search', () => {
     expect(ids).toEqual(['smithsonian:ld1-aaa-1', 'smithsonian:ld1-bbb-2']);
     expect(capturedUrl).toContain('api.si.edu/openaccess/api/v1.0/search');
     expect(capturedUrl).toContain('api_key=test-key');
-    // No server-side image/CC0 filter — the query is sent verbatim (the broken
-    // `AND online_media_type:"Images"` clause collapsed live results 189 -> 1).
-    // The federation overfetch + has_image filter + CC0 gate do the thinning.
-    // has_image restricts to image-bearing records via the EDAN media filter —
-    // load-bearing, since without it Smithsonian search is dominated by Libraries
-    // book records. The user query is preserved alongside the filter clause.
+    // When has_image is set, the query carries an EDAN `online_media_type:"Images"`
+    // clause alongside the user's terms. This filter is LOAD-BEARING, not a hint:
+    // without it Smithsonian search is dominated by Libraries bibliographic records
+    // (live, "vincent van gogh" returns ~189 matches that are almost all `SIL` books
+    // and only ~1 actual artwork). CC0 is NOT filtered server-side — the strict gate
+    // in normalize re-validates it on every fetched record (defense in depth).
     // (URLSearchParams encodes spaces as '+', which decodeURIComponent leaves.)
     const decodedQuery = decodeURIComponent(capturedUrl).replace(/\+/g, ' ');
     expect(decodedQuery).toContain('egyptian necklace');

--- a/tests/smithsonian.test.ts
+++ b/tests/smithsonian.test.ts
@@ -68,6 +68,22 @@ describe('Smithsonian adapter normalization', () => {
     expect(result.artwork.artist.attributionType).toBe('named');
   });
 
+  it('parses a verbose comma-delimited attribution into name/nationality/lifespan', () => {
+    // Real live shape (Cooper Hewitt): the whole attribution is one string.
+    const raw = clone('smithsonian-accepted.json');
+    const response = raw.response as { content: { freetext: Record<string, unknown> } };
+    response.content.freetext.name = [
+      { label: 'Artist', content: 'Vincent Van Gogh, The Netherlands, active in France, 1853 – 1890' },
+    ];
+    const result = smithsonianFetcher.normalize(raw);
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.artist.name).toBe('Vincent Van Gogh');
+    expect(result.artwork.artist.nationality).toBe('The Netherlands');
+    expect(result.artwork.artist.lifespan).toBe('1853–1890');
+    expect(result.artwork.artist.attributionType).toBe('named');
+  });
+
   it('does not promote a Sitter-only record to a named artist', () => {
     const raw = clone('smithsonian-accepted.json');
     const response = raw.response as { content: { freetext: Record<string, unknown> } };
@@ -113,6 +129,33 @@ describe('Smithsonian adapter normalization', () => {
     if (result.status !== 'rejected') return;
     expect(result.rejection.reason).toContain('strict default reject');
     expect(result.rejection.reason).toContain('missing');
+  });
+
+  it('rejects a CC0 Libraries "Books" record as non-art (curation gate)', () => {
+    const raw = clone('smithsonian-accepted.json');
+    const response = raw.response as {
+      content: { indexedStructured: Record<string, unknown>; freetext: Record<string, unknown> };
+    };
+    response.content.indexedStructured.object_type = ['Books'];
+    response.content.freetext.objectType = [{ label: 'Type', content: 'Books' }];
+    const result = smithsonianFetcher.normalize(raw);
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.reason).toContain('curation reject');
+    expect(result.rejection.reason).toContain('Books');
+  });
+
+  it('rejects a CC0 Natural History specimen (no object_type) as non-art', () => {
+    const raw = clone('smithsonian-accepted.json');
+    const response = raw.response as {
+      content: { indexedStructured: Record<string, unknown>; freetext: Record<string, unknown> };
+    };
+    delete response.content.indexedStructured.object_type;
+    delete response.content.freetext.objectType;
+    const result = smithsonianFetcher.normalize(raw);
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.reason).toContain('curation reject');
   });
 
   it('rejects garbage input gracefully', () => {
@@ -172,14 +215,19 @@ describe('Smithsonian CDN allowlist (SSRF surface)', () => {
 describe('Smithsonian adapter search', () => {
   const realFetch = globalThis.fetch;
   const realKey = process.env.SI_API_KEY;
+  const realSmithKey = process.env.SMITHSONIAN_API_KEY;
 
   beforeEach(() => {
+    // Use the SI_API_KEY alias path; clear the canonical var for determinism.
+    delete process.env.SMITHSONIAN_API_KEY;
     process.env.SI_API_KEY = 'test-key';
   });
   afterEach(() => {
     globalThis.fetch = realFetch;
     if (realKey === undefined) delete process.env.SI_API_KEY;
     else process.env.SI_API_KEY = realKey;
+    if (realSmithKey === undefined) delete process.env.SMITHSONIAN_API_KEY;
+    else process.env.SMITHSONIAN_API_KEY = realSmithKey;
     vi.restoreAllMocks();
   });
 
@@ -205,11 +253,33 @@ describe('Smithsonian adapter search', () => {
     expect(ids).toEqual(['smithsonian:ld1-aaa-1', 'smithsonian:ld1-bbb-2']);
     expect(capturedUrl).toContain('api.si.edu/openaccess/api/v1.0/search');
     expect(capturedUrl).toContain('api_key=test-key');
-    expect(decodeURIComponent(capturedUrl)).toContain('online_media_type:"Images"');
+    // No server-side image/CC0 filter — the query is sent verbatim (the broken
+    // `AND online_media_type:"Images"` clause collapsed live results 189 -> 1).
+    // The federation overfetch + has_image filter + CC0 gate do the thinning.
+    // has_image restricts to image-bearing records via the EDAN media filter —
+    // load-bearing, since without it Smithsonian search is dominated by Libraries
+    // book records. The user query is preserved alongside the filter clause.
+    // (URLSearchParams encodes spaces as '+', which decodeURIComponent leaves.)
+    const decodedQuery = decodeURIComponent(capturedUrl).replace(/\+/g, ' ');
+    expect(decodedQuery).toContain('egyptian necklace');
+    expect(decodedQuery).toContain('online_media_type:"Images"');
   });
 
-  it('throws a clear error when SI_API_KEY is absent', async () => {
+  it('throws a clear error when no Smithsonian key is set', async () => {
     delete process.env.SI_API_KEY;
-    await expect(smithsonianFetcher.search('q', 5)).rejects.toThrow(/SI_API_KEY not set/);
+    delete process.env.SMITHSONIAN_API_KEY;
+    await expect(smithsonianFetcher.search('q', 5)).rejects.toThrow(/SMITHSONIAN_API_KEY not set/);
+  });
+
+  it('accepts the canonical SMITHSONIAN_API_KEY var', async () => {
+    delete process.env.SI_API_KEY;
+    process.env.SMITHSONIAN_API_KEY = 'canonical-key';
+    let capturedUrl = '';
+    globalThis.fetch = vi.fn(async (input: string | URL | Request) => {
+      capturedUrl = String(input);
+      return new Response(JSON.stringify({ response: { rows: [] } }), { status: 200 });
+    }) as unknown as typeof fetch;
+    await smithsonianFetcher.search('q', 5);
+    expect(capturedUrl).toContain('api_key=canonical-key');
   });
 });


### PR DESCRIPTION
Small follow-up to the merged #79. A **live smoke against the real `api.si.edu`** (which should have gated the original PR, not followed it) exposed three defects the fixtures hid. `#79` is merged and substantially correct; this is the additive fix, not a revert.

## Why this exists — `main` silently disables Smithsonian

`main`'s registration guard reads `process.env.SI_API_KEY`, but the canonical env var (matching `EUROPEANA_API_KEY`) is **`SMITHSONIAN_API_KEY`**. With the real `~/.open-museum-mcp/.env` (which defines `SMITHSONIAN_API_KEY`, not `SI_API_KEY`), the guard is `false` → the fetcher is never registered → **Smithsonian is disabled at runtime on `main`.** This is the reported "OM-A cannot access Smithsonian." This PR makes the canonical name `SMITHSONIAN_API_KEY` with `SI_API_KEY` kept as a backward-compatible alias.

## The three defects (commit `60eb0b8`)

1. **Non-art records.** Smithsonian Open Access spans all units; an `online_media_type:"Images"` search still surfaces Libraries `Books` and Natural History specimens. Fix: keep the load-bearing image filter AND add an art-`object_type` **allowlist** gate in `normalize` (precision over recall). Live: `sunflowers` → 8/8 botany specimens rejected; `japanese woodblock print` → button + 2 pigments rejected, real Whistler/Bicknell art kept.
2. **Unparsed artist name.** The verbose attribution `"Vincent Van Gogh, The Netherlands, active in France, 1853 – 1890"` was stored verbatim in `artist.name`. Added `parseSmithsonianName` → name / nationality / lifespan. Live: resolves to `Vincent Van Gogh [The Netherlands] (1853–1890)`.
3. **Key-var mismatch** (above).

## Live evidence (`npm run smoke:smithsonian`, real api.si.edu)

| Query | Accepted | Rejected | Note |
|---|---|---|---|
| `japanese woodblock print` | 5 | 3 | button + 2 pigments curation-rejected; CC0/high, `ids.si.edu` images |
| `vincent van gogh` | 1 | 0 | name parsed `Vincent Van Gogh [The Netherlands] (1853–1890)` |
| `sunflowers` | 0 | 8 | all botany specimens (`object_type=none`) correctly rejected |

`de1d135` adds the smoke harness itself (`scripts/smoke-smithsonian.ts`) — the live gate that found all three, loading env exactly as `src/server.ts` does.

## Gates (real output)
- `NODE_OPTIONS=--experimental-sqlite vitest run` → **417/417** (27 files), exit 0
- `tscq --noEmit` → exit 0 · `tsc -p tsconfig.json` (build) → exit 0

## Scope
`src/fetchers/smithsonian.ts`, `src/server.ts`, `tests/smithsonian.test.ts` (+curation/name/key-alias tests), `scripts/smoke-smithsonian.ts`, `package.json`. **No `/core` public-shape or clearance-envelope change.** Rights gate unchanged (strict default-deny); the curation gate is an additional reject layer, never a loosening.

## OM-CR — independent live re-verification requested
Per the restart brief, do not trust the description: re-run `npm run smoke:smithsonian` against actual API output and reproduce the three behaviors. Cross-lane note for OM-OR/OM-A: even after this merges, OM-A's own runtime needs `SMITHSONIAN_API_KEY` added to its `.dev.vars`/Cloudflare secrets (it currently has only `EUROPEANA_API_KEY`).

Do not merge — Pramod merges.

Co-Authored by Pramod Prasanth <pramod@chainalign.com>