### PR TITLE
feat(clearance): keyless Tier-1 delegated-attestor library (prepare + fail-closed verify)

### DIFF
--- a/src/core/clearance/c2paClaim.ts
+++ b/src/core/clearance/c2paClaim.ts
@@ -1,0 +1,182 @@
+/**
+ * Keyless construction of the Tier-1 C2PA claim and its COSE_Sign1 to-be-signed
+ * input. This is the deterministic half of the attestor seam: the lib emits the
+ * claim bytes (`claimToBeSigned`); the OMA signing service signs them by wrapping
+ * them in the pinned COSE Sig_structure below — VERBATIM, no re-canonicalization
+ * (contract C2). Nothing here needs a private key.
+ *
+ * Seam realization (the precise byte boundary OM-A must mirror):
+ *  - `claimToBeSigned` = the canonical CBOR bytes of the C2PA claim (the COSE
+ *    payload). The lib is the sole authority on these bytes.
+ *  - The signing service constructs COSE_Sign1 with the FIXED protected header
+ *    `{1:-8}` (alg = EdDSA, CBOR `a10127`), an EMPTY external_aad, and these claim
+ *    bytes used verbatim as the payload; it signs the resulting Sig_structure with
+ *    Ed25519 and wraps. There is zero canonicalization freedom — every byte of the
+ *    signed input is pinned by `coseSigStructure()` here.
+ *
+ * Claim minimality: the claim contains ONLY fields a verifier can reconstruct from
+ * the locked Tier-1 envelope (the exact payload bytes, the bound-asset hash, the
+ * claim generator) plus fixed constants. Descriptive, non-security-bearing metadata
+ * (e.g. `dc:format`) is deliberately NOT in the signed claim — the binding to the
+ * asset is by content hash (the hard-binding assertion), not by MIME label. This is
+ * what lets `verifyTier1` recompute `claimToBeSigned` byte-for-byte from the
+ * envelope alone.
+ */
+import {
+  type CborValue,
+  type DecodedCbor,
+  asBufferSource,
+  cborBytes,
+  cborMap,
+  decodeCanonicalCbor,
+  encodeCanonicalCbor,
+} from './cbor.js';
+
+const SHA256_LABEL = 'sha256';
+
+/** Label of the C2PA assertion whose data is the exact clearance payload bytes. */
+export const CLEARANCE_ASSERTION_LABEL = 'org.openclearance.clearance-manifest';
+/** Label of the C2PA hard-binding (content-hash) assertion. */
+export const HARD_BINDING_ASSERTION_LABEL = 'c2pa.hash.data';
+
+/** JUMBF self-reference URI for an assertion of the given label. */
+function assertionUri(label: string): string {
+  return `self#jumbf=c2pa.assertions/${label}`;
+}
+
+async function sha256(bytes: Uint8Array): Promise<Uint8Array> {
+  const digest = await crypto.subtle.digest('SHA-256', asBufferSource(bytes));
+  return new Uint8Array(digest);
+}
+
+/**
+ * The C2PA hard-binding (`c2pa.hash.data`) assertion, reduced to its
+ * deterministic, key-independent essence: the SHA-256 of the bound asset bytes
+ * with no exclusions. Reconstructable by a verifier from the envelope's
+ * `boundAsset.hash` alone.
+ */
+export function hardBindingAssertionBytes(imageHash: Uint8Array): Uint8Array {
+  const assertion: CborValue = cborMap([
+    ['alg', SHA256_LABEL],
+    ['exclusions', []],
+    ['hash', cborBytes(imageHash)],
+  ]);
+  return encodeCanonicalCbor(assertion);
+}
+
+/** A C2PA `hashed_uri`: a reference to an assertion bound by the hash of its bytes. */
+function hashedUri(label: string, assertionHash: Uint8Array): CborValue {
+  return cborMap([
+    ['url', assertionUri(label)],
+    ['alg', SHA256_LABEL],
+    ['hash', cborBytes(assertionHash)],
+  ]);
+}
+
+/**
+ * Deterministic instance identifier, derived from the payload digest so the claim
+ * is a pure function of its inputs (no randomness — the lib, the service, and the
+ * verifier must all reproduce the same bytes).
+ */
+function instanceId(payloadHash: Uint8Array): string {
+  const hex = Array.from(payloadHash.slice(0, 16))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  return `xmp:iid:${hex}`;
+}
+
+export interface ClaimInput {
+  /** The EXACT UTF-8 bytes of the v0.1 clearance payload. */
+  payloadBytes: Uint8Array;
+  /** SHA-256 of the delivered/print-ready image asset bytes (the hard-binding target). */
+  imageHash: Uint8Array;
+  /** C2PA claim generator string, e.g. "open-museum.art". */
+  claimGenerator: string;
+}
+
+/**
+ * Build the canonical C2PA claim bytes = `claimToBeSigned`. Pure + deterministic
+ * in its inputs; async only because it hashes the two assertions the claim
+ * references by hash.
+ */
+export async function buildC2paClaim(input: ClaimInput): Promise<Uint8Array> {
+  const payloadHash = await sha256(input.payloadBytes);
+  const hardBinding = hardBindingAssertionBytes(input.imageHash);
+  const hardBindingHash = await sha256(hardBinding);
+
+  const claim: CborValue = cborMap([
+    ['claim_generator', input.claimGenerator],
+    ['instanceID', instanceId(payloadHash)],
+    ['alg', SHA256_LABEL],
+    [
+      'assertions',
+      [
+        // clearance assertion data == the EXACT payload bytes, bound by their hash
+        hashedUri(CLEARANCE_ASSERTION_LABEL, payloadHash),
+        // hard-binding to the image asset
+        hashedUri(HARD_BINDING_ASSERTION_LABEL, hardBindingHash),
+      ],
+    ],
+    ['signature', 'self#jumbf=c2pa.signature'],
+  ]);
+  return encodeCanonicalCbor(claim);
+}
+
+/** COSE protected header for EdDSA: `{1: -8}` (alg label 1 → EdDSA -8). */
+export const COSE_PROTECTED_EDDSA = encodeCanonicalCbor(cborMap([[1, -8]]));
+
+/**
+ * The COSE_Sign1 Sig_structure — the exact Ed25519 to-be-signed input:
+ *   ["Signature1", bstr(protected-header), bstr(external_aad=""), bstr(payload=claim)]
+ * The signing service must sign THESE bytes; the verifier reconstructs and checks
+ * the same. external_aad is empty.
+ */
+export function coseSigStructure(claimBytes: Uint8Array): Uint8Array {
+  const structure: CborValue = [
+    'Signature1',
+    cborBytes(COSE_PROTECTED_EDDSA),
+    cborBytes(new Uint8Array(0)),
+    cborBytes(claimBytes),
+  ];
+  return encodeCanonicalCbor(structure);
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  return a.length === b.length && a.every((x, i) => x === b[i]);
+}
+
+/**
+ * Assemble a COSE_Sign1 structure (RFC 8152): `[protected, {}, payload, signature]`
+ * with the pinned EdDSA protected header and an empty unprotected map. Pure +
+ * keyless — the signing service calls this AFTER producing `signature` over
+ * `coseSigStructure(claimBytes)`. The claim payload rides verbatim.
+ */
+export function assembleCoseSign1(claimBytes: Uint8Array, signature: Uint8Array): Uint8Array {
+  const sign1: CborValue = [
+    cborBytes(COSE_PROTECTED_EDDSA),
+    cborMap([]),
+    cborBytes(claimBytes),
+    cborBytes(signature),
+  ];
+  return encodeCanonicalCbor(sign1);
+}
+
+/**
+ * Decode a COSE_Sign1, returning the claim payload + raw signature. Strict and
+ * fail-closed: throws unless the structure is a 4-element array carrying the
+ * pinned EdDSA protected header, a byte-string payload, and a byte-string
+ * signature. Used by the verifier to extract what it needs from the manifest store.
+ */
+export function decodeCoseSign1(bytes: Uint8Array): { claim: Uint8Array; signature: Uint8Array } {
+  const { value } = decodeCanonicalCbor(bytes);
+  if (!Array.isArray(value) || value.length !== 4) {
+    throw new Error('cose: not a 4-element COSE_Sign1 array');
+  }
+  const [protectedHeader, , payload, signature] = value as DecodedCbor[];
+  if (!(protectedHeader instanceof Uint8Array) || !bytesEqual(protectedHeader, COSE_PROTECTED_EDDSA)) {
+    throw new Error('cose: protected header is not the pinned EdDSA header');
+  }
+  if (!(payload instanceof Uint8Array)) throw new Error('cose: payload is not a byte string');
+  if (!(signature instanceof Uint8Array)) throw new Error('cose: signature is not a byte string');
+  return { claim: payload, signature };
+}

--- a/src/core/clearance/cbor.ts
+++ b/src/core/clearance/cbor.ts
@@ -1,0 +1,232 @@
+/**
+ * Minimal canonical (deterministic) CBOR encoder — RFC 8949 §4.2 Core
+ * Deterministic Encoding profile, limited to the types the Tier-1 C2PA claim
+ * needs: unsigned/negative integers, text strings, byte strings, arrays, and
+ * maps. No floats, no tags, no indefinite-length items.
+ *
+ * Why hand-rolled and zero-dependency: the Tier-1 seam is byte-exact — the
+ * keyless lib emits `claimToBeSigned` and the signing service signs those exact
+ * bytes verbatim (contract C2). A deterministic encoder we fully control, with
+ * pinned known-answer vectors, is the integrity anchor for that seam; a general
+ * CBOR library would be a heavier dependency and a larger trust surface for a
+ * zero-infra OSS engine.
+ *
+ * Determinism rules enforced here:
+ *  - integers use the shortest possible encoding;
+ *  - all lengths are definite and minimally encoded;
+ *  - map keys are sorted by their canonical encoded bytes (bytewise lexical),
+ *    RFC 8949 §4.2.1 — independent of insertion order.
+ */
+
+/** Marker for a CBOR byte string (major type 2), distinguishing it from text. */
+export interface CborBytes {
+  readonly __cbor: 'bytes';
+  readonly value: Uint8Array;
+}
+
+/** Marker for a CBOR map (major type 5) with explicit, possibly non-string keys. */
+export interface CborMap {
+  readonly __cbor: 'map';
+  readonly entries: ReadonlyArray<readonly [CborValue, CborValue]>;
+}
+
+export type CborValue = number | string | CborBytes | CborMap | CborValue[];
+
+export function cborBytes(value: Uint8Array): CborBytes {
+  return { __cbor: 'bytes', value };
+}
+
+export function cborMap(entries: ReadonlyArray<readonly [CborValue, CborValue]>): CborMap {
+  return { __cbor: 'map', entries };
+}
+
+function isBytes(v: CborValue): v is CborBytes {
+  return typeof v === 'object' && v !== null && (v as CborBytes).__cbor === 'bytes';
+}
+
+function isMap(v: CborValue): v is CborMap {
+  return typeof v === 'object' && v !== null && (v as CborMap).__cbor === 'map';
+}
+
+/** Encode a major type (0-7) and an unsigned argument with the shortest head. */
+function head(major: number, arg: number): Uint8Array {
+  const mt = major << 5;
+  if (arg < 24) return new Uint8Array([mt | arg]);
+  if (arg < 0x100) return new Uint8Array([mt | 24, arg]);
+  if (arg < 0x10000) return new Uint8Array([mt | 25, arg >> 8, arg & 0xff]);
+  if (arg < 0x100000000) {
+    return new Uint8Array([mt | 26, (arg >>> 24) & 0xff, (arg >> 16) & 0xff, (arg >> 8) & 0xff, arg & 0xff]);
+  }
+  // 64-bit argument — use BigInt to stay exact above 2^32.
+  const big = BigInt(arg);
+  const out = new Uint8Array(9);
+  out[0] = mt | 27;
+  for (let i = 0; i < 8; i++) out[8 - i] = Number((big >> BigInt(8 * i)) & 0xffn);
+  return out;
+}
+
+function concat(chunks: Uint8Array[]): Uint8Array {
+  let len = 0;
+  for (const c of chunks) len += c.length;
+  const out = new Uint8Array(len);
+  let off = 0;
+  for (const c of chunks) {
+    out.set(c, off);
+    off += c.length;
+  }
+  return out;
+}
+
+const textEncoder = new TextEncoder();
+
+/**
+ * Narrow a `Uint8Array` to one whose backing store is a plain `ArrayBuffer`, as
+ * the WebCrypto `BufferSource` type requires (it excludes `SharedArrayBuffer`).
+ * Our byte arrays are always ArrayBuffer-backed, so this is a no-op cast in
+ * practice; it copies only in the impossible SharedArrayBuffer case.
+ */
+export function asBufferSource(u: Uint8Array): Uint8Array<ArrayBuffer> {
+  return (u.buffer instanceof ArrayBuffer ? u : new Uint8Array(u)) as Uint8Array<ArrayBuffer>;
+}
+
+/** Bytewise lexicographic comparison of two byte arrays (RFC 8949 §4.2.1). */
+function compareBytes(a: Uint8Array, b: Uint8Array): number {
+  const n = Math.min(a.length, b.length);
+  for (let i = 0; i < n; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return a.length - b.length;
+}
+
+export function encodeCanonicalCbor(value: CborValue): Uint8Array {
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value)) {
+      throw new Error(`cbor: only integers are supported in the deterministic profile, got ${value}`);
+    }
+    return value >= 0 ? head(0, value) : head(1, -value - 1);
+  }
+
+  if (typeof value === 'string') {
+    const bytes = textEncoder.encode(value);
+    return concat([head(3, bytes.length), bytes]);
+  }
+
+  if (isBytes(value)) {
+    return concat([head(2, value.value.length), value.value]);
+  }
+
+  if (Array.isArray(value)) {
+    return concat([head(4, value.length), ...value.map(encodeCanonicalCbor)]);
+  }
+
+  if (isMap(value)) {
+    const encoded = value.entries.map(([k, v]) => ({
+      k: encodeCanonicalCbor(k),
+      v: encodeCanonicalCbor(v),
+    }));
+    encoded.sort((a, b) => compareBytes(a.k, b.k));
+    return concat([head(5, encoded.length), ...encoded.flatMap((e) => [e.k, e.v])]);
+  }
+
+  throw new Error('cbor: unsupported value type');
+}
+
+/** Decoded CBOR: ints -> number, text -> string, bytes -> Uint8Array, arrays/maps recursively. */
+export type DecodedCbor = number | string | Uint8Array | DecodedCbor[] | Map<DecodedCbor, DecodedCbor>;
+
+const textDecoder = new TextDecoder('utf-8', { fatal: true });
+
+/**
+ * Decode the deterministic CBOR profile produced by `encodeCanonicalCbor`. Strict
+ * and fail-closed: rejects trailing bytes, indefinite-length items, floats, tags,
+ * and truncated input. Used to extract the signature (and confirm the claim
+ * payload) from a COSE_Sign1 during Tier-1 verification.
+ */
+export function decodeCanonicalCbor(bytes: Uint8Array): { value: DecodedCbor } {
+  const [value, offset] = decodeAt(bytes, 0);
+  if (offset !== bytes.length) {
+    throw new Error('cbor: trailing bytes after top-level item');
+  }
+  return { value };
+}
+
+function readArg(bytes: Uint8Array, pos: number, info: number): [number, number] {
+  if (info < 24) return [info, pos];
+  if (info === 24) {
+    if (pos >= bytes.length) throw new Error('cbor: truncated 1-byte argument');
+    return [bytes[pos], pos + 1];
+  }
+  if (info === 25) {
+    if (pos + 2 > bytes.length) throw new Error('cbor: truncated 2-byte argument');
+    return [(bytes[pos] << 8) | bytes[pos + 1], pos + 2];
+  }
+  if (info === 26) {
+    if (pos + 4 > bytes.length) throw new Error('cbor: truncated 4-byte argument');
+    return [
+      (bytes[pos] * 0x1000000) + (bytes[pos + 1] << 16) + (bytes[pos + 2] << 8) + bytes[pos + 3],
+      pos + 4,
+    ];
+  }
+  if (info === 27) {
+    if (pos + 8 > bytes.length) throw new Error('cbor: truncated 8-byte argument');
+    let big = 0n;
+    for (let i = 0; i < 8; i++) big = (big << 8n) | BigInt(bytes[pos + i]);
+    if (big > BigInt(Number.MAX_SAFE_INTEGER)) throw new Error('cbor: integer exceeds safe range');
+    return [Number(big), pos + 8];
+  }
+  throw new Error('cbor: indefinite-length or reserved additional-info not supported');
+}
+
+function decodeAt(bytes: Uint8Array, pos: number): [DecodedCbor, number] {
+  if (pos >= bytes.length) throw new Error('cbor: truncated input');
+  const ib = bytes[pos];
+  const major = ib >> 5;
+  const info = ib & 0x1f;
+  let p = pos + 1;
+
+  switch (major) {
+    case 0: {
+      const [arg, np] = readArg(bytes, p, info);
+      return [arg, np];
+    }
+    case 1: {
+      const [arg, np] = readArg(bytes, p, info);
+      return [-1 - arg, np];
+    }
+    case 2: {
+      const [len, np] = readArg(bytes, p, info);
+      if (np + len > bytes.length) throw new Error('cbor: truncated byte string');
+      return [bytes.slice(np, np + len), np + len];
+    }
+    case 3: {
+      const [len, np] = readArg(bytes, p, info);
+      if (np + len > bytes.length) throw new Error('cbor: truncated text string');
+      return [textDecoder.decode(bytes.slice(np, np + len)), np + len];
+    }
+    case 4: {
+      const [len, np] = readArg(bytes, p, info);
+      p = np;
+      const arr: DecodedCbor[] = [];
+      for (let i = 0; i < len; i++) {
+        const [v, q] = decodeAt(bytes, p);
+        arr.push(v);
+        p = q;
+      }
+      return [arr, p];
+    }
+    case 5: {
+      const [len, np] = readArg(bytes, p, info);
+      p = np;
+      const map = new Map<DecodedCbor, DecodedCbor>();
+      for (let i = 0; i < len; i++) {
+        const [k, q] = decodeAt(bytes, p);
+        const [v, r] = decodeAt(bytes, q);
+        map.set(k, v);
+        p = r;
+      }
+      return [map, p];
+    }
+    default:
+      throw new Error(`cbor: unsupported major type ${major}`);
+  }
+}

--- a/src/core/clearance/tier1.ts
+++ b/src/core/clearance/tier1.ts
@@ -1,0 +1,311 @@
+/**
+ * Tier-1 delegated-attestor envelope/format library — KEYLESS.
+ *
+ * This is the engine half of the openclearance COA honesty chain (build contract
+ * `om-c-tier1-attestor-build-contract-2026-06-18`, OM-CR lock-verified + C1/C2).
+ * It builds the Tier-1 envelope structure, the C2PA claim/assertions (image
+ * hard-binding + a clearance assertion carrying the EXACT payload bytes), and all
+ * hashes, and it verifies signed envelopes with PUBLIC KEYS ONLY. It never sees a
+ * private key, never signs, never hosts a secret.
+ *
+ * The seam with the OMA signing service is the signature operation, and only that:
+ *   prepareTier1(payloadString, imageBytes) -> Tier1SigningRequest   (this lib)
+ *   sign(Tier1SigningRequest)               -> Tier1Envelope          (OMA service)
+ * The lib emits `claimToBeSigned` (canonical C2PA claim bytes); the service signs
+ * them VERBATIM inside the pinned COSE Sig_structure (see c2paClaim.ts) and
+ * assembles/embeds the manifest store. No re-canonicalization (contract C2).
+ */
+import {
+  CLEARANCE_ASSERTION_LABEL,
+  buildC2paClaim,
+  coseSigStructure,
+  decodeCoseSign1,
+  hardBindingAssertionBytes,
+} from './c2paClaim.js';
+import { asBufferSource } from './cbor.js';
+
+const PAYLOAD_TYPE = 'application/clearance-manifest+json' as const;
+const DEFAULT_CLAIM_GENERATOR = 'open-museum.art';
+
+/** The keyless signing request the lib emits; only its COSE signature needs a key. */
+export interface Tier1SigningRequest {
+  payloadType: typeof PAYLOAD_TYPE;
+  /** The EXACT UTF-8 JSON string of the v0.1 payload — byte-identical across tiers. */
+  payload: string;
+  /** Inner integrity over the payload bytes — tier-stable (identical to Tier-0). */
+  integrity: { alg: 'sha-256'; hash: string };
+  /** The image asset the C2PA manifest hard-binds to (OMA's delivered rendition). */
+  boundAsset: { assetType: 'image'; alg: 'sha-256'; hash: string };
+  c2pa: {
+    claimGenerator: string;
+    clearanceAssertionLabel: typeof CLEARANCE_ASSERTION_LABEL;
+    /** base64 of the deterministic C2PA hard-binding (`c2pa.hash.data`) assertion bytes. */
+    hardBindingAssertion: string;
+    /** base64 of the canonical C2PA claim bytes the service signs verbatim. */
+    claimToBeSigned: string;
+  };
+}
+
+export interface PrepareTier1Options {
+  /** C2PA claim generator string (default "open-museum.art"). */
+  claimGenerator?: string;
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', asBufferSource(bytes));
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+const b64 = (u: Uint8Array): string => Buffer.from(u).toString('base64');
+
+/**
+ * Construct a keyless Tier-1 signing request from the exact payload STRING (the
+ * byte-exact v0.1 manifest, as the engine emits it) and the delivered image
+ * bytes. Pure + deterministic — no key, no randomness, no I/O.
+ *
+ * The payload is taken as a STRING, never re-serialized: byte-exact integrity is
+ * impossible over a re-parsed object, and the clearance assertion must carry the
+ * producer's exact bytes (contract §2). Callers holding an object should serialize
+ * it once and pass that string (the same string they hash for Tier-0).
+ */
+export async function prepareTier1(
+  payload: string,
+  imageBytes: Uint8Array,
+  opts: PrepareTier1Options = {},
+): Promise<Tier1SigningRequest> {
+  const claimGenerator = opts.claimGenerator ?? DEFAULT_CLAIM_GENERATOR;
+  const payloadBytes = new TextEncoder().encode(payload);
+  const imageDigest = await crypto.subtle.digest('SHA-256', asBufferSource(imageBytes));
+  const imageHash = new Uint8Array(imageDigest);
+
+  const claim = await buildC2paClaim({ payloadBytes, imageHash, claimGenerator });
+
+  return {
+    payloadType: PAYLOAD_TYPE,
+    payload,
+    integrity: { alg: 'sha-256', hash: await sha256Hex(payloadBytes) },
+    boundAsset: { assetType: 'image', alg: 'sha-256', hash: await sha256Hex(imageBytes) },
+    c2pa: {
+      claimGenerator,
+      clearanceAssertionLabel: CLEARANCE_ASSERTION_LABEL,
+      hardBindingAssertion: b64(hardBindingAssertionBytes(imageHash)),
+      claimToBeSigned: b64(claim),
+    },
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Verification — KEYLESS, fail-closed (contract §4 + OM-CR C1)
+// ----------------------------------------------------------------------------
+
+/**
+ * The completed Tier-1 envelope (the OMA service's output; verifier's input).
+ * Mirrors `tier1-envelope.schema.json` v0.2. The verification STATE is never a
+ * field here — it is derived by `verifyTier1`.
+ */
+export interface Tier1Envelope {
+  tier: 1;
+  payloadType: typeof PAYLOAD_TYPE;
+  payload: string;
+  integrity: { alg: 'sha-256'; hash: string };
+  attestation: {
+    attestor: { did: string; role: 'delegated-attestor' };
+    actor: string;
+    boundAsset: {
+      assetType: 'image';
+      alg: 'sha-256';
+      hash: string;
+      binding: 'c2pa-hard-binding';
+      locator?: string;
+    };
+    c2pa: {
+      claimGenerator: string;
+      clearanceAssertionLabel: typeof CLEARANCE_ASSERTION_LABEL;
+      manifest: { format: 'embedded' | 'detached'; value?: string; url?: string };
+      signature: { alg: 'ed25519' };
+      identityBinding: { method: 'cawg-identity-assertion' };
+    };
+  };
+}
+
+/**
+ * Output of verification. Tier-1 yields `ATTESTED_DELEGATE` or `REJECTED`; the
+ * other states are reserved for sibling tiers (`ATTESTED_DIRECT` = Tier-2 self
+ * signing; `UNVERIFIED_SIGNAL` = Tier-0). A broken Tier-1 is REJECTED, NEVER
+ * silently demoted to `UNVERIFIED_SIGNAL`.
+ */
+export type VerificationState =
+  | 'ATTESTED_DELEGATE'
+  | 'ATTESTED_DIRECT'
+  | 'UNVERIFIED_SIGNAL'
+  | 'REJECTED';
+
+export interface VerificationResult {
+  state: VerificationState;
+  /** Present on REJECTED — a short machine-stable reason for diagnostics. */
+  reason?: string;
+}
+
+export interface VerifyTier1Options {
+  /**
+   * Resolve the attestor DID to its raw 32-byte Ed25519 public key (e.g. from the
+   * DID document at `/.well-known/did.json`). Return null if it cannot be resolved.
+   * Injected so the lib stays keyless + does no network I/O itself.
+   */
+  resolveSigner: (did: string) => Promise<Uint8Array | null> | Uint8Array | null;
+  /**
+   * OPTIONAL: the delivered image bytes. When provided, the verifier checks
+   * `SHA-256(assetBytes) === boundAsset.hash` (external hard-binding proof). When
+   * omitted, the binding is still enforced INTRINSICALLY: the signature is
+   * verified over a claim reconstructed from `boundAsset.hash`, so a valid
+   * signature proves the attestor signed THIS bound hash.
+   */
+  assetBytes?: Uint8Array;
+  /**
+   * OPTIONAL: the COSE_Sign1 manifest-store bytes, when the envelope uses
+   * `manifest.format='embedded'`/`url` and the caller has fetched/extracted the
+   * store (the keyless lib does no network I/O). For `manifest.format='detached'`
+   * with a `value`, this is read from the envelope automatically.
+   */
+  coseSign1?: Uint8Array;
+}
+
+const reject = (reason: string): VerificationResult => ({ state: 'REJECTED', reason });
+
+async function sha256HexBytes(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', asBufferSource(bytes));
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  return out;
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  return a.length === b.length && a.every((x, i) => x === b[i]);
+}
+
+function structurallyTier1(e: Tier1Envelope): boolean {
+  return (
+    !!e &&
+    e.tier === 1 &&
+    e.payloadType === PAYLOAD_TYPE &&
+    typeof e.payload === 'string' &&
+    !!e.integrity &&
+    e.integrity.alg === 'sha-256' &&
+    /^[0-9a-f]{64}$/.test(e.integrity.hash ?? '') &&
+    !!e.attestation &&
+    !!e.attestation.attestor &&
+    typeof e.attestation.attestor.did === 'string' &&
+    e.attestation.attestor.role === 'delegated-attestor' &&
+    typeof e.attestation.actor === 'string' &&
+    !!e.attestation.boundAsset &&
+    /^[0-9a-f]{64}$/.test(e.attestation.boundAsset.hash ?? '') &&
+    !!e.attestation.c2pa
+  );
+}
+
+/** Extract the v0.1 payload's determining actor, or null if it cannot be read. */
+function payloadActor(payload: string): string | null {
+  try {
+    const obj = JSON.parse(payload) as { verification?: { determinedBy?: { actor?: unknown } } };
+    const actor = obj?.verification?.determinedBy?.actor;
+    return typeof actor === 'string' ? actor : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Verify a Tier-1 delegated-attestor envelope. FAIL-CLOSED: any failed check
+ * returns `REJECTED` (never a silent downgrade). Returns `ATTESTED_DELEGATE` iff
+ * ALL hold: integrity matches the payload bytes; the envelope's `actor` equals the
+ * payload's `verification.determinedBy.actor` (C1); the attestor is a genuine
+ * delegate (`attestor.did !== actor`); the attestor DID resolves to a public key;
+ * the COSE_Sign1 signature validates over the claim reconstructed from the
+ * envelope; and (when asset bytes are supplied) the bound asset matches.
+ */
+export async function verifyTier1(
+  envelope: Tier1Envelope,
+  opts: VerifyTier1Options,
+): Promise<VerificationResult> {
+  // 0. Shape — fail-closed on anything that is not a well-formed Tier-1 envelope.
+  if (!structurallyTier1(envelope)) return reject('not a well-formed Tier-1 envelope');
+  const { attestation } = envelope;
+  const payloadBytes = new TextEncoder().encode(envelope.payload);
+
+  // 1. Inner integrity over the exact payload bytes (tier-stable).
+  if ((await sha256HexBytes(payloadBytes)) !== envelope.integrity.hash) {
+    return reject('integrity hash does not match payload bytes');
+  }
+
+  // 2. C1 — the attested actor must be the actor the determination names.
+  const determinedActor = payloadActor(envelope.payload);
+  if (determinedActor === null) return reject('payload verification.determinedBy.actor not readable');
+  if (determinedActor !== attestation.actor) {
+    return reject('actor mismatch: attestation.actor != payload determinedBy.actor');
+  }
+
+  // 3. Genuine delegation — the attestor must not be the actor.
+  if (attestation.attestor.did === attestation.actor) {
+    return reject('attestor.did == actor: not a delegated attestation');
+  }
+
+  // 4. Resolve the attestor's public key (keyless — injected resolver).
+  const pubRaw = await opts.resolveSigner(attestation.attestor.did);
+  if (!pubRaw) return reject('attestor DID did not resolve to a signer key');
+
+  // 5. Obtain the COSE_Sign1 (detached value in-envelope, else caller-provided).
+  const manifestValue = attestation.c2pa.manifest?.value;
+  const coseBytes = opts.coseSign1 ?? (manifestValue ? new Uint8Array(Buffer.from(manifestValue, 'base64')) : null);
+  if (!coseBytes) return reject('no COSE_Sign1 manifest store available to verify');
+
+  let claim: Uint8Array;
+  let signature: Uint8Array;
+  try {
+    ({ claim, signature } = decodeCoseSign1(coseBytes));
+  } catch (e) {
+    return reject(`malformed COSE_Sign1: ${(e as Error).message}`);
+  }
+
+  // 6. Reconstruct the expected claim from the envelope and confirm the signed
+  //    claim matches it (defense in depth — the signature must cover OUR claim).
+  const expectedClaim = await buildC2paClaim({
+    payloadBytes,
+    imageHash: hexToBytes(attestation.boundAsset.hash),
+    claimGenerator: attestation.c2pa.claimGenerator,
+  });
+  if (!bytesEqual(claim, expectedClaim)) {
+    return reject('signed claim does not match the envelope-reconstructed claim');
+  }
+
+  // 7. Verify the Ed25519 signature over the pinned Sig_structure.
+  let signatureValid = false;
+  try {
+    const key = await crypto.subtle.importKey('raw', asBufferSource(pubRaw), { name: 'Ed25519' }, false, ['verify']);
+    signatureValid = await crypto.subtle.verify(
+      'Ed25519',
+      key,
+      asBufferSource(signature),
+      asBufferSource(coseSigStructure(expectedClaim)),
+    );
+  } catch {
+    return reject('signer key could not be imported for verification');
+  }
+  if (!signatureValid) return reject('COSE_Sign1 signature is invalid for the attestor key');
+
+  // 8. Optional external hard-binding proof against the delivered asset bytes.
+  if (opts.assetBytes) {
+    if ((await sha256HexBytes(opts.assetBytes)) !== attestation.boundAsset.hash) {
+      return reject('bound asset bytes do not match boundAsset.hash');
+    }
+  }
+
+  return { state: 'ATTESTED_DELEGATE' };
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -40,6 +40,31 @@ export {
 } from './clearance/manifest.js';
 export { clearanceForLicense, type ClearanceDecision, type ClearanceBasis } from './clearance/licenseMap.js';
 
+// Tier-1 delegated-attestor envelope/format library — KEYLESS. `prepareTier1`
+// emits a keyless signing request (the only thing the OMA service signs);
+// `verifyTier1` is the fail-closed, public-key-only verifier. The COSE primitives
+// are exported so the signing service reuses the EXACT pinned to-be-signed bytes
+// (contract C2 — no re-canonicalization).
+export {
+  prepareTier1,
+  verifyTier1,
+  type Tier1SigningRequest,
+  type PrepareTier1Options,
+  type Tier1Envelope,
+  type VerificationState,
+  type VerificationResult,
+  type VerifyTier1Options,
+} from './clearance/tier1.js';
+export {
+  COSE_PROTECTED_EDDSA,
+  CLEARANCE_ASSERTION_LABEL,
+  HARD_BINDING_ASSERTION_LABEL,
+  coseSigStructure,
+  assembleCoseSign1,
+  decodeCoseSign1,
+  hardBindingAssertionBytes,
+} from './clearance/c2paClaim.js';
+
 // Pure helpers a front door commonly needs alongside the federation.
 export { cite, type CiteStyle } from '../cite.js';
 export type { Artwork, ArtworkImages, ArtworkSource, ArtworkLicense, ValidationResult } from '../types.js';

--- a/tests/clearance/c2paClaim.test.ts
+++ b/tests/clearance/c2paClaim.test.ts
@@ -1,0 +1,94 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+  COSE_PROTECTED_EDDSA,
+  buildC2paClaim,
+  coseSigStructure,
+  hardBindingAssertionBytes,
+} from '../../src/core/clearance/c2paClaim.js';
+
+const sha256 = (b: Uint8Array): Uint8Array => new Uint8Array(createHash('sha256').update(b).digest());
+const enc = (s: string): Uint8Array => new TextEncoder().encode(s);
+const eqBytes = (a: Uint8Array, b: Uint8Array) =>
+  a.length === b.length && a.every((x, i) => x === b[i]);
+/** naive subsequence search to assert a hash actually rides inside the claim bytes */
+const contains = (hay: Uint8Array, needle: Uint8Array): boolean => {
+  outer: for (let i = 0; i + needle.length <= hay.length; i++) {
+    for (let j = 0; j < needle.length; j++) if (hay[i + j] !== needle[j]) continue outer;
+    return true;
+  }
+  return false;
+};
+
+const payload = enc('{"type":"ClearanceManifest","work":{"id":"met:1"}}');
+const imageHash = sha256(enc('fake-image-bytes'));
+const claimGenerator = 'open-museum.art';
+const input = { payloadBytes: payload, imageHash, claimGenerator };
+
+describe('buildC2paClaim — deterministic, key-independent C2PA claim (claimToBeSigned)', () => {
+  it('is byte-for-byte deterministic for identical inputs', async () => {
+    expect(eqBytes(await buildC2paClaim(input), await buildC2paClaim(input))).toBe(true);
+  });
+
+  it('binds the EXACT payload bytes: the clearance-assertion hash = sha256(payload) rides in the claim', async () => {
+    const claim = await buildC2paClaim(input);
+    expect(contains(claim, sha256(payload))).toBe(true);
+  });
+
+  it('hard-binds the image transitively: the claim references the hard-binding assertion by its hash', async () => {
+    // The claim does NOT carry the raw image hash; it carries the hash of the
+    // hard-binding ASSERTION, which in turn carries the image hash. Binding is
+    // claim -> sha256(hardBindingAssertion) -> assertion{ hash: sha256(image) }.
+    const claim = await buildC2paClaim(input);
+    const hardBindingHash = sha256(hardBindingAssertionBytes(imageHash));
+    expect(contains(claim, hardBindingHash)).toBe(true);
+    // and the raw image hash is NOT directly in the claim (it lives in the assertion)
+    expect(contains(claim, imageHash)).toBe(false);
+  });
+
+  it('changes when the payload changes (tamper-evident foundation)', async () => {
+    const other = await buildC2paClaim({ ...input, payloadBytes: enc('{"type":"ClearanceManifest"}') });
+    expect(eqBytes(await buildC2paClaim(input), other)).toBe(false);
+  });
+
+  it('changes when the bound image changes', async () => {
+    const other = await buildC2paClaim({ ...input, imageHash: sha256(enc('different-image')) });
+    expect(eqBytes(await buildC2paClaim(input), other)).toBe(false);
+  });
+});
+
+describe('hardBindingAssertionBytes — reconstructable from the boundAsset hash alone', () => {
+  it('is deterministic and carries the image hash', () => {
+    const a = hardBindingAssertionBytes(imageHash);
+    expect(eqBytes(a, hardBindingAssertionBytes(imageHash))).toBe(true);
+    expect(contains(a, imageHash)).toBe(true);
+  });
+});
+
+describe('coseSigStructure — the pinned Ed25519 to-be-signed input', () => {
+  it('uses the EdDSA protected header {1:-8} = a10127', () => {
+    expect(
+      Array.from(COSE_PROTECTED_EDDSA)
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join(''),
+    ).toBe('a10127');
+  });
+
+  it('is a 4-element COSE Sig_structure: ["Signature1", bstr(protected), bstr(""), bstr(claim)]', async () => {
+    const claim = await buildC2paClaim(input);
+    const sig = coseSigStructure(claim);
+    // CBOR array of 4: 0x84 ; then text "Signature1" (0x6a 53 69 67 ...)
+    expect(sig[0]).toBe(0x84);
+    expect(sig[1]).toBe(0x6a); // text string length 10
+    expect(new TextDecoder().decode(sig.slice(2, 12))).toBe('Signature1');
+    // the protected header rides bstr-wrapped (0x43 = bstr len 3, then a10127)
+    expect(contains(sig, new Uint8Array([0x43, 0xa1, 0x01, 0x27]))).toBe(true);
+    // the claim bytes ride verbatim inside the structure (the COSE payload)
+    expect(contains(sig, claim)).toBe(true);
+  });
+
+  it('is deterministic', async () => {
+    const claim = await buildC2paClaim(input);
+    expect(eqBytes(coseSigStructure(claim), coseSigStructure(claim))).toBe(true);
+  });
+});

--- a/tests/clearance/cbor-decode.test.ts
+++ b/tests/clearance/cbor-decode.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type CborValue,
+  cborBytes,
+  cborMap,
+  decodeCanonicalCbor,
+  encodeCanonicalCbor,
+} from '../../src/core/clearance/cbor.js';
+
+const bytesFromHex = (h: string): Uint8Array =>
+  new Uint8Array((h.match(/../g) ?? []).map((x) => parseInt(x, 16)));
+
+describe('decodeCanonicalCbor — inverse of the deterministic encoder', () => {
+  it.each([
+    ['00', 0],
+    ['1818', 24],
+    ['1903e8', 1000],
+    ['20', -1],
+    ['3863', -100],
+  ])('decodes integer %s -> %d', (h, n) => {
+    expect(decodeCanonicalCbor(bytesFromHex(h)).value).toBe(n);
+  });
+
+  it('decodes text strings and byte strings', () => {
+    expect(decodeCanonicalCbor(bytesFromHex('6449455446')).value).toBe('IETF');
+    const decoded = decodeCanonicalCbor(bytesFromHex('4401020304')).value as Uint8Array;
+    expect(Array.from(decoded)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('decodes arrays', () => {
+    expect(decodeCanonicalCbor(bytesFromHex('83010203')).value).toEqual([1, 2, 3]);
+  });
+
+  it('decodes a COSE_Sign1-shaped array: [bstr, map, bstr, bstr]', () => {
+    // ["Signature1", h'a10127', h'', h'cafe'] then a separate real Sign1 below
+    const enc = encodeCanonicalCbor([
+      'Signature1',
+      cborBytes(bytesFromHex('a10127')),
+      cborBytes(new Uint8Array(0)),
+      cborBytes(bytesFromHex('cafe')),
+    ]);
+    const arr = decodeCanonicalCbor(enc).value as CborValue[];
+    expect(arr[0]).toBe('Signature1');
+    expect(Array.from(arr[1] as Uint8Array)).toEqual([0xa1, 0x01, 0x27]);
+    expect((arr[2] as Uint8Array).length).toBe(0);
+    expect(Array.from(arr[3] as Uint8Array)).toEqual([0xca, 0xfe]);
+  });
+
+  it('round-trips arbitrary supported structures', () => {
+    const value = cborMap([
+      ['claim_generator', 'open-museum.art'],
+      ['n', 42],
+      ['neg', -7],
+      ['data', cborBytes(bytesFromHex('deadbeef'))],
+      ['list', [1, 'a', cborBytes(new Uint8Array([9]))]],
+    ]);
+    const round = decodeCanonicalCbor(encodeCanonicalCbor(value)).value;
+    // maps decode to a Map keyed by the decoded key
+    expect(round instanceof Map).toBe(true);
+    const m = round as Map<unknown, unknown>;
+    expect(m.get('claim_generator')).toBe('open-museum.art');
+    expect(m.get('n')).toBe(42);
+    expect(m.get('neg')).toBe(-7);
+    expect(Array.from(m.get('data') as Uint8Array)).toEqual([0xde, 0xad, 0xbe, 0xef]);
+  });
+
+  it('rejects trailing garbage (strict, fail-closed parsing)', () => {
+    expect(() => decodeCanonicalCbor(bytesFromHex('0001'))).toThrow();
+  });
+});

--- a/tests/clearance/cbor.test.ts
+++ b/tests/clearance/cbor.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { encodeCanonicalCbor, cborBytes, cborMap } from '../../src/core/clearance/cbor.js';
+
+/** hex helper for readable known-answer assertions */
+const hex = (u: Uint8Array): string =>
+  Array.from(u)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+
+describe('encodeCanonicalCbor — RFC 8949 deterministic encoding (known-answer vectors)', () => {
+  // Vectors straight from RFC 8949 Appendix A. The whole Tier-1 seam rests on
+  // these bytes being reproducible, so they are pinned as known-answers.
+  it.each([
+    [0, '00'],
+    [1, '01'],
+    [10, '0a'],
+    [23, '17'],
+    [24, '1818'],
+    [100, '1864'],
+    [1000, '1903e8'],
+    [-1, '20'],
+    [-10, '29'],
+    [-100, '3863'],
+  ])('encodes integer %d as %s', (n, expected) => {
+    expect(hex(encodeCanonicalCbor(n))).toBe(expected);
+  });
+
+  it.each([
+    ['', '60'],
+    ['a', '6161'],
+    ['IETF', '6449455446'],
+  ])('encodes text string %j as %s', (s, expected) => {
+    expect(hex(encodeCanonicalCbor(s))).toBe(expected);
+  });
+
+  it('encodes byte strings (major type 2)', () => {
+    expect(hex(encodeCanonicalCbor(cborBytes(new Uint8Array([]))))).toBe('40');
+    expect(hex(encodeCanonicalCbor(cborBytes(new Uint8Array([1, 2, 3, 4]))))).toBe('4401020304');
+  });
+
+  it('encodes arrays', () => {
+    expect(hex(encodeCanonicalCbor([]))).toBe('80');
+    expect(hex(encodeCanonicalCbor([1, 2, 3]))).toBe('83010203');
+  });
+
+  it('encodes maps with deterministic (bytewise) key ordering', () => {
+    expect(hex(encodeCanonicalCbor(cborMap([])))).toBe('a0');
+    // {1:2, 3:4}
+    expect(hex(encodeCanonicalCbor(cborMap([[1, 2], [3, 4]])))).toBe('a201020304');
+    // {"a":1, "b":[2,3]}
+    expect(
+      hex(encodeCanonicalCbor(cborMap([['a', 1], ['b', [2, 3]]]))),
+    ).toBe('a26161016162820203');
+  });
+
+  it('sorts map keys by encoded bytes regardless of insertion order (RFC 8949 §4.2.1)', () => {
+    // shorter key encodings sort before longer ones: "a" (0x6161) < "aa" (0x626161)
+    const out = hex(encodeCanonicalCbor(cborMap([['aa', 2], ['a', 1]])));
+    const inOrder = hex(encodeCanonicalCbor(cborMap([['a', 1], ['aa', 2]])));
+    expect(out).toBe(inOrder);
+    // and numeric keys (1 byte) sort before the 2-byte text key
+    expect(hex(encodeCanonicalCbor(cborMap([['z', 9], [1, 8]])))).toBe(
+      hex(encodeCanonicalCbor(cborMap([[1, 8], ['z', 9]]))),
+    );
+  });
+
+  it('rejects non-integer numbers (no floats in the deterministic profile)', () => {
+    expect(() => encodeCanonicalCbor(1.5)).toThrow(/integer/i);
+  });
+});

--- a/tests/clearance/tier1-prepare.test.ts
+++ b/tests/clearance/tier1-prepare.test.ts
@@ -1,0 +1,75 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { wrapTier0 } from '../../src/core/clearance/envelope.js';
+import { buildC2paClaim, hardBindingAssertionBytes } from '../../src/core/clearance/c2paClaim.js';
+import { prepareTier1 } from '../../src/core/clearance/tier1.js';
+
+const sha256hex = (b: Uint8Array | string): string =>
+  createHash('sha256')
+    .update(typeof b === 'string' ? new TextEncoder().encode(b) : b)
+    .digest('hex');
+const b64 = (u: Uint8Array): string => Buffer.from(u).toString('base64');
+
+// a realistic byte-exact payload string (as the engine would emit it)
+const payloadObj = { type: 'ClearanceManifest', work: { id: 'met:1' }, verification: { determinedBy: { actor: 'museum:met', role: 'rights-source' } } };
+const payload = JSON.stringify(payloadObj);
+const imageBytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 1, 2, 3, 4, 5]); // pretend JPEG
+
+describe('prepareTier1 — keyless Tier-1 signing request (the frozen seam)', () => {
+  it('preserves the payload string byte-for-byte', async () => {
+    const req = await prepareTier1(payload, imageBytes);
+    expect(req.payload).toBe(payload);
+    expect(req.payloadType).toBe('application/clearance-manifest+json');
+  });
+
+  it('integrity is the tier-stable sha-256 of the payload bytes (identical to Tier-0)', async () => {
+    const req = await prepareTier1(payload, imageBytes);
+    expect(req.integrity).toEqual({ alg: 'sha-256', hash: sha256hex(payload) });
+    // tier-stability: the same hash a Tier-0 envelope of the same payload carries
+    const tier0 = await wrapTier0(payloadObj);
+    expect(req.integrity.hash).toBe(tier0.integrity.hash);
+  });
+
+  it('boundAsset is the sha-256 hard-binding to the delivered image bytes', async () => {
+    const req = await prepareTier1(payload, imageBytes);
+    expect(req.boundAsset).toEqual({
+      assetType: 'image',
+      alg: 'sha-256',
+      hash: sha256hex(imageBytes),
+    });
+  });
+
+  it('emits claimToBeSigned = the canonical C2PA claim bytes, plus the hard-binding assertion', async () => {
+    const req = await prepareTier1(payload, imageBytes);
+    expect(req.c2pa.clearanceAssertionLabel).toBe('org.openclearance.clearance-manifest');
+
+    const expectedClaim = await buildC2paClaim({
+      payloadBytes: new TextEncoder().encode(payload),
+      imageHash: new Uint8Array(createHash('sha256').update(imageBytes).digest()),
+      claimGenerator: req.c2pa.claimGenerator,
+    });
+    expect(req.c2pa.claimToBeSigned).toBe(b64(expectedClaim));
+    expect(req.c2pa.hardBindingAssertion).toBe(
+      b64(hardBindingAssertionBytes(new Uint8Array(createHash('sha256').update(imageBytes).digest()))),
+    );
+  });
+
+  it('defaults the claim generator to open-museum.art and honors an override', async () => {
+    expect((await prepareTier1(payload, imageBytes)).c2pa.claimGenerator).toBe('open-museum.art');
+    expect((await prepareTier1(payload, imageBytes, { claimGenerator: 'example.org' })).c2pa.claimGenerator).toBe(
+      'example.org',
+    );
+  });
+
+  it('is deterministic (no randomness) — equal inputs give equal requests', async () => {
+    expect(await prepareTier1(payload, imageBytes)).toEqual(await prepareTier1(payload, imageBytes));
+  });
+
+  it('holds NOTHING secret: the request is pure construction (no signature, no key field)', async () => {
+    const req = await prepareTier1(payload, imageBytes);
+    const json = JSON.stringify(req).toLowerCase();
+    expect(json).not.toContain('privatekey');
+    expect(json).not.toContain('signature');
+    expect(req.c2pa.signature).toBeUndefined();
+  });
+});

--- a/tests/clearance/tier1-verify.test.ts
+++ b/tests/clearance/tier1-verify.test.ts
@@ -1,0 +1,161 @@
+import { webcrypto } from 'node:crypto';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { assembleCoseSign1, coseSigStructure } from '../../src/core/clearance/c2paClaim.js';
+import { prepareTier1, verifyTier1, type Tier1Envelope } from '../../src/core/clearance/tier1.js';
+
+const subtle = webcrypto.subtle;
+const b64 = (u: Uint8Array): string => Buffer.from(u).toString('base64');
+const fromB64 = (s: string): Uint8Array => new Uint8Array(Buffer.from(s, 'base64'));
+const enc = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+// A byte-exact v0.1 payload whose determination is by museum:met.
+const payloadObj = {
+  type: 'ClearanceManifest',
+  work: { id: 'met:1' },
+  verification: { determinedBy: { actor: 'museum:met', role: 'rights-source' } },
+};
+const payload = JSON.stringify(payloadObj);
+const imageBytes = enc('delivered-print-ready-image-bytes');
+
+const ATTESTOR_DID = 'did:web:open-museum.art';
+const ACTOR = 'museum:met';
+
+let keyPair: webcrypto.CryptoKeyPair;
+let attestorPubRaw: Uint8Array;
+
+/**
+ * Simulate the OMA signing service (OM-A scope): sign the lib's `claimToBeSigned`
+ * VERBATIM inside the pinned COSE Sig_structure, then assemble a Tier-1 envelope.
+ * Returns the envelope plus a resolver that maps the attestor DID to the public key.
+ */
+async function signAsService(
+  req: Awaited<ReturnType<typeof prepareTier1>>,
+  opts: { attestorDid?: string; actor?: string; signingKey?: webcrypto.CryptoKey; tamperSig?: boolean } = {},
+): Promise<{ envelope: Tier1Envelope; resolveSigner: (did: string) => Promise<Uint8Array | null> }> {
+  const claimBytes = fromB64(req.c2pa.claimToBeSigned);
+  const sigStructure = coseSigStructure(claimBytes);
+  const sig = new Uint8Array(
+    await subtle.sign('Ed25519', opts.signingKey ?? keyPair.privateKey, sigStructure),
+  );
+  if (opts.tamperSig) sig[0] ^= 0xff;
+  const coseSign1 = assembleCoseSign1(claimBytes, sig);
+
+  const envelope: Tier1Envelope = {
+    tier: 1,
+    payloadType: 'application/clearance-manifest+json',
+    payload: req.payload,
+    integrity: req.integrity,
+    attestation: {
+      attestor: { did: opts.attestorDid ?? ATTESTOR_DID, role: 'delegated-attestor' },
+      actor: opts.actor ?? ACTOR,
+      boundAsset: { ...req.boundAsset, binding: 'c2pa-hard-binding' },
+      c2pa: {
+        claimGenerator: req.c2pa.claimGenerator,
+        clearanceAssertionLabel: req.c2pa.clearanceAssertionLabel,
+        manifest: { format: 'detached', value: b64(coseSign1) },
+        signature: { alg: 'ed25519' },
+        identityBinding: { method: 'cawg-identity-assertion' },
+      },
+    },
+  };
+  return { envelope, resolveSigner: async (did) => (did === (opts.attestorDid ?? ATTESTOR_DID) ? attestorPubRaw : null) };
+}
+
+beforeAll(async () => {
+  keyPair = (await subtle.generateKey({ name: 'Ed25519' }, true, ['sign', 'verify'])) as webcrypto.CryptoKeyPair;
+  attestorPubRaw = new Uint8Array(await subtle.exportKey('raw', keyPair.publicKey));
+});
+
+describe('verifyTier1 — fail-closed delegated-attestor verifier', () => {
+  it('ATTESTED_DELEGATE when sig is valid, signer resolves to attestor.did, and attestor != actor', async () => {
+    const req = await prepareTier1(payload, imageBytes);
+    const { envelope, resolveSigner } = await signAsService(req);
+    const result = await verifyTier1(envelope, { resolveSigner, assetBytes: imageBytes });
+    expect(result.state).toBe('ATTESTED_DELEGATE');
+  });
+
+  it('REJECTED on integrity mismatch (payload tampered after hashing)', async () => {
+    const req = await prepareTier1(payload, imageBytes);
+    const { envelope, resolveSigner } = await signAsService(req);
+    envelope.payload = JSON.stringify({ ...payloadObj, work: { id: 'met:999' } }); // swap payload, keep old hash
+    const result = await verifyTier1(envelope, { resolveSigner });
+    expect(result.state).toBe('REJECTED');
+    expect(result.reason).toMatch(/integrity/i);
+  });
+
+  it('REJECTED on a tampered signature (never demoted to UNVERIFIED_SIGNAL)', async () => {
+    const req = await prepareTier1(payload, imageBytes);
+    const { envelope, resolveSigner } = await signAsService(req, { tamperSig: true });
+    const result = await verifyTier1(envelope, { resolveSigner });
+    expect(result.state).toBe('REJECTED');
+    expect(result.reason).toMatch(/signature/i);
+  });
+
+  it('REJECTED when the signer does not resolve to attestor.did (wrong key)', async () => {
+    const req = await prepareTier1(payload, imageBytes);
+    const otherKey = (await subtle.generateKey({ name: 'Ed25519' }, true, ['sign', 'verify'])) as webcrypto.CryptoKeyPair;
+    const { envelope } = await signAsService(req, { signingKey: otherKey.privateKey });
+    // resolver returns the LEGITIMATE attestor key, but the envelope was signed by another key
+    const result = await verifyTier1(envelope, { resolveSigner: async (d) => (d === ATTESTOR_DID ? attestorPubRaw : null) });
+    expect(result.state).toBe('REJECTED');
+    expect(result.reason).toMatch(/signature/i);
+  });
+
+  it('REJECTED when the attestor DID cannot be resolved at all', async () => {
+    const req = await prepareTier1(payload, imageBytes);
+    const { envelope } = await signAsService(req);
+    const result = await verifyTier1(envelope, { resolveSigner: async () => null });
+    expect(result.state).toBe('REJECTED');
+    expect(result.reason).toMatch(/resolve|signer|did/i);
+  });
+
+  it('REJECTED (C1) when attestation.actor != payload.verification.determinedBy.actor', async () => {
+    const req = await prepareTier1(payload, imageBytes);
+    const { envelope, resolveSigner } = await signAsService(req, { actor: 'museum:aic' }); // payload says museum:met
+    const result = await verifyTier1(envelope, { resolveSigner });
+    expect(result.state).toBe('REJECTED');
+    expect(result.reason).toMatch(/actor/i);
+  });
+
+  it('REJECTED when attestor.did == actor (not a genuine delegate)', async () => {
+    // payload actor and attestor both did:web:open-museum.art -> no delegation separation
+    const selfPayload = JSON.stringify({
+      type: 'ClearanceManifest',
+      work: { id: 'met:1' },
+      verification: { determinedBy: { actor: ATTESTOR_DID, role: 'self' } },
+    });
+    const req = await prepareTier1(selfPayload, imageBytes);
+    const { envelope, resolveSigner } = await signAsService(req, { actor: ATTESTOR_DID });
+    const result = await verifyTier1(envelope, { resolveSigner });
+    expect(result.state).toBe('REJECTED');
+    expect(result.reason).toMatch(/delegate|actor/i);
+  });
+
+  it('REJECTED when bound-asset bytes do not match boundAsset.hash', async () => {
+    const req = await prepareTier1(payload, imageBytes);
+    const { envelope, resolveSigner } = await signAsService(req);
+    const result = await verifyTier1(envelope, { resolveSigner, assetBytes: enc('a different image') });
+    expect(result.state).toBe('REJECTED');
+    expect(result.reason).toMatch(/asset|bound/i);
+  });
+
+  it('REJECTED on a non-Tier-1 envelope (fail-closed on shape)', async () => {
+    const req = await prepareTier1(payload, imageBytes);
+    const { envelope, resolveSigner } = await signAsService(req);
+    const broken = { ...envelope, tier: 0 } as unknown as Tier1Envelope;
+    const result = await verifyTier1(broken, { resolveSigner });
+    expect(result.state).toBe('REJECTED');
+  });
+
+  it('REJECTED when the COSE claim payload does not match the envelope-reconstructed claim', async () => {
+    // sign a DIFFERENT claim (different image) but present the original envelope fields
+    const req = await prepareTier1(payload, imageBytes);
+    const otherReq = await prepareTier1(payload, enc('a totally different image'));
+    const { envelope } = await signAsService(otherReq); // COSE binds the other image's claim
+    envelope.payload = req.payload;
+    envelope.integrity = req.integrity;
+    envelope.attestation.boundAsset = { ...req.boundAsset, binding: 'c2pa-hard-binding' };
+    const result = await verifyTier1(envelope, { resolveSigner: async (d) => (d === ATTESTOR_DID ? attestorPubRaw : null) });
+    expect(result.state).toBe('REJECTED');
+  });
+});


### PR DESCRIPTION
Engine half of the openclearance COA honesty chain. Built to the **LOCKED** contract `om-c-tier1-attestor-build-contract-2026-06-18` (OM-CR lock-verified) with refinements **C1** and **C2** landed. **KEYLESS by construction:** no keys, no signing, no secrets, no network I/O. The seam with the OMA signing service is the signature operation and only that — built in parallel against the frozen `Tier1SigningRequest` / `Tier1Envelope` shapes.

## What ships
- **`prepareTier1(payloadString, imageBytes) → Tier1SigningRequest`** — byte-exact payload carriage (string, never re-serialized), **tier-stable** sha-256 integrity (identical to Tier-0), image hard-binding, and the deterministic C2PA claim (`claimToBeSigned`). Clearance assertion binds the EXACT payload bytes; hard-binding assertion binds the delivered image.
- **`verifyTier1(envelope, { resolveSigner, assetBytes?, coseSign1? }) → VerificationResult`** — **public-key-only, FAIL-CLOSED**. `ATTESTED_DELEGATE` iff integrity OK ∧ signature valid ∧ signer resolves to `attestor.did` ∧ `attestor.did != actor` ∧ bound-asset matches; otherwise `REJECTED` — **never demoted to `UNVERIFIED_SIGNAL`**.

## OM-CR refinements landed
- **C1 (the real completeness gap):** verifier REJECTs when `attestation.actor != JSON.parse(payload).verification.determinedBy.actor`. Covered by a conformance vector (accept-signed / reject-tampered-sig / **reject-actor-mismatch**).
- **C2 (sign verbatim):** `claimToBeSigned` is emitted as canonical bytes; the COSE `Sig_structure` is pinned (EdDSA protected header `a10127`, empty external_aad). The COSE primitives are **exported** so the signing service signs identical bytes verbatim — no re-canonicalization, no reimplementation.
- Minor: `signature.alg` is the single const `ed25519`.

## The one seam decision (pinned + flagged to OM-A via OM-OR)
The contract calls `claimToBeSigned` both "canonical C2PA claim bytes" and "the COSE_Sign1 to-be-signed input" — technically distinct. Pinned as: **`claimToBeSigned` = canonical claim CBOR bytes (the COSE payload)**, signed inside the fully-pinned `Sig_structure`. This keeps the frozen seam shape exactly as the contract lists and gives OM-A zero canonicalization freedom. OM-A imports `coseSigStructure` / `assembleCoseSign1` / `COSE_PROTECTED_EDDSA` from this package rather than reimplementing.

## Implementation
Zero-dependency deterministic **CBOR encoder + decoder** (RFC 8949 core-deterministic profile, pinned known-answer vectors), the C2PA claim/assertions, and COSE_Sign1 assemble/decode. Ed25519 verification via WebCrypto — **no new dependencies**.

## Gates (real output)
- `NODE_OPTIONS=--experimental-sqlite vitest run` → **474/474** (32 files), exit 0 — **54 new** Tier-1 tests (cbor 18, cbor-decode 10, c2paClaim 9, tier1-prepare 7, tier1-verify 10), incl. a full Ed25519 sign→verify round-trip and every REJECT vector.
- `tscq --noEmit` → 0 · `tsc -p tsconfig.json` (build) → 0.

## Scope / safety
New files under `src/core/clearance/` (`cbor.ts`, `c2paClaim.ts`, `tier1.ts`) + exports in `src/core/index.ts`. **No `/core` repurposing, no v0.1 artifact touched, no existing behavior changed.** The byte-exact payload contract is preserved across tiers (integrity is identical to Tier-0). Strict-default-deny verifier discipline.

## OM-CR — independent verification requested
Re-run the gates; adversarially probe the fail-closed verifier (every REJECT path); confirm the CBOR encoder against the RFC 8949 vectors; confirm `claimToBeSigned` determinism and that the exported COSE primitives reproduce the signed bytes. Cross-lane (OM-OR/OM-A): the seam pin + recommended service flow are in the gitignored `session-states/om-m-tier1-seam-2026-06-18.md`.

Do not merge — Pramod merges.

Co-Authored by Pramod Prasanth <pramod@chainalign.com>