### PR TITLE
chore(release): 0.11.0 — ship the keyless Tier-1 attestor library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-museum-mcp",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-museum-mcp",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-museum-mcp",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "MCP server for license-verified search across open-access museum collections (The Met, Cleveland, AIC, Wikimedia Commons, Europeana).",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
Release prep for **open-museum-mcp@0.11.0**. Bumps `0.10.2 → 0.11.0` (minor — additive Tier-1 exports, no breaking change). Unblocks the OMA Tier-1 signing service (OM-A), which imports the pinned COSE primitives from this package.

**Diff is the version bump only** (`package.json` + `package-lock.json`); the Tier-1 code itself already merged via #84. `dist/` is gitignored and rebuilt at publish.

## Gates (real output, on this branch = main + bump)
- `NODE_OPTIONS=--experimental-sqlite vitest run` → **474/474** (32 files), exit 0
- `tscq --noEmit` → 0 · `npm run build` (tsc) → 0 (clean rebuild)

## Tier-1 exports verified reachable from the `./core` entry
Resolved `dist/core/index.js` as a consumer would — all 9 present:
`prepareTier1`, `verifyTier1`, `coseSigStructure`, `assembleCoseSign1`, `COSE_PROTECTED_EDDSA` (= `a10127`), `decodeCoseSign1`, `hardBindingAssertionBytes`, `CLEARANCE_ASSERTION_LABEL`, `HARD_BINDING_ASSERTION_LABEL`. `prepareTier1`/`verifyTier1` are callable functions.

## `npm pack --dry-run` summary
- `open-museum-mcp-0.11.0.tgz` — 113 files, 138.8KB tarball / 498.2KB unpacked
- Ships: `dist/core/index.{js,d.ts}` + `dist/core/clearance/{tier1,cbor,c2paClaim}.{js,d.ts}` (+ source maps) + `dist/server.js`
- `REQUIRED-MISSING: (none)` · no `*.test.*` / `tests/` leak into the tarball
- `package.json` exports map intact: `"./core"` → `dist/core/index.{d.ts,js}`

## To publish (Pramod runs this after merging the bump)
```
git checkout main && git pull
npm run build        # prepare also runs build; ensures a fresh dist/
npm publish          # publishes open-museum-mcp@0.11.0 (public)
```

**READY TO PUBLISH.** Do not merge or publish via agent — Pramod merges the bump and runs `npm publish`.

Co-Authored by Pramod Prasanth <pramod@chainalign.com>