### PR TITLE
feat(curation): non-art filter for Wikimedia + Europeana (BASEL-URGENT)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test": "NODE_OPTIONS=--experimental-sqlite vitest run",
     "test:watch": "NODE_OPTIONS=--experimental-sqlite vitest",
     "smoke:smithsonian": "NODE_OPTIONS=--experimental-sqlite tsx scripts/smoke-smithsonian.ts",
+    "smoke:curation": "NODE_OPTIONS=--experimental-sqlite tsx scripts/smoke-curation.ts",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [

--- a/scripts/smoke-curation.ts
+++ b/scripts/smoke-curation.ts
@@ -1,0 +1,64 @@
+// Live smoke for the non-art curation gate (Wikimedia + Europeana) — hits the
+// real Commons + Europeana APIs through the actual fetchers and prints a
+// before/after sample: junk filtered, genuine art kept.
+//   npm run smoke:curation
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import dotenv from 'dotenv';
+import { europeanaFetcher } from '../src/fetchers/europeana.js';
+import { wikimediaFetcher } from '../src/fetchers/wikimedia.js';
+import type { Fetcher } from '../src/fetchers/types.js';
+
+dotenv.config({ quiet: true });
+dotenv.config({ quiet: true, path: join(homedir(), '.open-museum-mcp', '.env') });
+
+async function sample(fetcher: Fetcher, query: string, limit: number) {
+  console.log(`\n===== ${fetcher.code} · search "${query}" =====`);
+  const ids = await fetcher.search(query, limit, { hasImage: true });
+  let accepted = 0;
+  let curationRejected = 0;
+  for (const id of ids) {
+    const raw = await fetcher.getRaw(id);
+    const res = fetcher.normalize(raw);
+    if (res.status === 'accepted') {
+      accepted++;
+      console.log(`  ✓ ACCEPT ${id} "${res.artwork.title}"`);
+    } else {
+      if (/curation reject/.test(res.rejection.reason)) curationRejected++;
+      console.log(`  ✗ reject ${id} — ${res.rejection.reason}`);
+    }
+  }
+  console.log(
+    `  -> ${accepted} accepted, ${curationRejected} CURATION-rejected (of ${ids.length}). ` +
+      `Before the gate the curation-rejected, rights-valid records were accepted.`,
+  );
+}
+
+async function checkIds(fetcher: Fetcher, ids: string[]) {
+  console.log(`\n===== ${fetcher.code} · flagship junk IDs (direct) =====`);
+  for (const id of ids) {
+    const res = fetcher.normalize(await fetcher.getRaw(id));
+    console.log(
+      `  ${id}: ${res.status === 'accepted' ? `ACCEPT "${res.artwork.title}"` : `reject -> ${res.rejection.reason}`}`,
+    );
+  }
+}
+
+async function main() {
+  // The reported non-art junk: the SUPSI open-access publishing diagram set.
+  await checkIds(wikimediaFetcher, ['wikimedia:157318642', 'wikimedia:175537332', 'wikimedia:157318588']);
+  // "open access" is the brand term people type — worst-hit by non-art noise.
+  await sample(wikimediaFetcher, 'open access', 12);
+  // genuine art must survive untouched (no curation false positives).
+  await sample(wikimediaFetcher, 'sunflowers painting', 12);
+  if (process.env.EUROPEANA_API_KEY) {
+    await sample(europeanaFetcher, 'sunflowers painting', 10);
+  } else {
+    console.log('\n(EUROPEANA_API_KEY not set — skipping Europeana live sample)');
+  }
+}
+
+main().catch((e) => {
+  console.error('SMOKE FAILED:', e);
+  process.exit(1);
+});

--- a/src/fetchers/curation.ts
+++ b/src/fetchers/curation.ts
@@ -1,0 +1,156 @@
+/**
+ * Non-art CURATION gate for the noisy federated sources (Wikimedia Commons,
+ * Europeana). These are NOT curated art museums: they hold diagrams, charts,
+ * logos, maps, flags, publication pages and specimens alongside genuine art, all
+ * correctly licensed. The rights gate (licenseGate.ts) is satisfied for that
+ * junk — this is a SEPARATE gate that keeps artworks and rejects non-art.
+ *
+ * Same idea as the Smithsonian object_type gate (smithsonian.ts): the curated
+ * museums (Met/AIC/Cleveland) need no such gate; the federations do. Posture is
+ * PRECISION OVER RECALL — for launch credibility it is better to drop an edge
+ * artwork than to admit a publishing diagram into the collection.
+ *
+ * The denylist is deliberately word-boundary matched and curated to avoid
+ * collisions with art vocabulary:
+ *   - NO bare 'graph'  (would match photoGRAPH / lithoGRAPH)
+ *   - NO 'icon'        (Orthodox / religious icons ARE art)
+ *   - NO 'table'/'plate' (vegeTABLE, art "plates")
+ * Each term below is a thing that is itself non-art, not a subject an artwork
+ * might depict.
+ */
+
+// Unambiguous non-art nouns/phrases. Matched case-insensitively on word
+// boundaries against titles + curatorial categories.
+export const NON_ART_TERMS = [
+  'diagram',
+  'diagrams',
+  'infographic',
+  'infographics',
+  'flowchart',
+  'flowcharts',
+  'flow chart',
+  'schematic',
+  'schematics',
+  'screenshot',
+  'screenshots',
+  'chart',
+  'charts',
+  'pie chart',
+  'bar chart',
+  'spreadsheet',
+  'spreadsheets',
+  'barcode',
+  'barcodes',
+  'qr code',
+  'clipart',
+  'clip art',
+  'logo',
+  'logos',
+  'map',
+  'maps',
+  'open access',
+  'open-access',
+  'publishing',
+  'coat of arms',
+  'coats of arms',
+  'title page',
+  'data visualization',
+  'data visualisation',
+] as const;
+
+// Build one alternation, longest-first so multi-word phrases win, each guarded
+// by word boundaries. Hyphens are treated as their own boundary so 'open-access'
+// matches in 'open-access publishing'.
+const NON_ART_RE = new RegExp(
+  `\\b(?:${[...NON_ART_TERMS]
+    .sort((a, b) => b.length - a.length)
+    .map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('|')})\\b`,
+  'i',
+);
+
+/** Return the matched non-art term (lowercased) if `text` contains one, else null. */
+export function matchesNonArtTerm(text: string): string | null {
+  const m = NON_ART_RE.exec(text ?? '');
+  return m ? m[0].toLowerCase() : null;
+}
+
+export interface WikimediaCurationInput {
+  /** imageinfo MIME (already image/* by the time the gate runs). */
+  mime: string;
+  /** Commons category titles (Category: prefix already stripped). */
+  categories: string[];
+  /** The record's display title / ObjectName. */
+  title: string;
+}
+
+/**
+ * Decide whether a Wikimedia Commons record is non-art. Returns a short reason
+ * when it should be rejected, else null.
+ *
+ * Two signals:
+ *  1. `image/svg+xml` — on Commons, SVG is overwhelmingly diagrams, logos,
+ *     charts, maps, flags and icons, essentially never a digitised artwork
+ *     (those are raster JPEG/PNG/TIFF). This is the single highest-precision rule
+ *     and it catches the bulk of the publishing-diagram class.
+ *  2. A category/title denylist hit — catches RASTER non-art that the SVG rule
+ *     misses (e.g. a PNG "Open Access Models Overview" categorised under
+ *     "Open access (publishing)").
+ */
+export function isNonArtWikimedia(input: WikimediaCurationInput): string | null {
+  if (/^image\/svg(\+xml)?$/i.test(input.mime.trim())) {
+    return 'svg vector graphic (diagram/logo/chart/map class)';
+  }
+  const hay = [input.title, ...input.categories].join(' | ');
+  const term = matchesNonArtTerm(hay);
+  return term ? `non-art signal "${term}" in title/category` : null;
+}
+
+// Europeana exposes a near-controlled type/medium signal (dcType / dctermsMedium
+// / dcFormat). When it explicitly names a non-art form we reject; when it is
+// absent we PASS (see the boundary note below). This list adds a few EDM/object
+// types beyond the shared denylist; it is matched ONLY against the type/medium
+// field, never the title, so documentary photographs are not mis-rejected.
+const EUROPEANA_NON_ART_TYPES = [
+  ...NON_ART_TERMS,
+  'text',
+  'sound',
+  'video',
+  'dataset',
+  'specimen',
+  'fossil',
+  'mineral',
+  'herbarium',
+  '3d',
+] as const;
+
+const EUROPEANA_NON_ART_RE = new RegExp(
+  `\\b(?:${[...EUROPEANA_NON_ART_TYPES]
+    .sort((a, b) => b.length - a.length)
+    .map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('|')})\\b`,
+  'i',
+);
+
+export interface EuropeanaCurationInput {
+  /** The joined dcType / dctermsMedium / dcFormat string the fetcher builds. */
+  medium: string;
+  /** Title — accepted for symmetry/diagnostics, NOT matched (precision). */
+  title: string;
+}
+
+/**
+ * Decide whether a Europeana record is non-art, on the TYPE/MEDIUM signal only.
+ *
+ * BOUNDARY (honest scope): most Europeana image records carry no type in the
+ * search profile. Europeana's documentary-photo keyword-noise (e.g. "access road
+ * to ..." matching the query word "access") is a RELEVANCE/RANKING problem — those
+ * are real photographs, indistinguishable from art photographs by type — and is
+ * addressed by search ranking (v1.2), NOT by this binary non-art gate. Matching
+ * such records by title would reject genuine art, so this gate deliberately does
+ * not. It only fires when an explicit non-art type is present.
+ */
+export function isNonArtEuropeana(input: EuropeanaCurationInput): string | null {
+  const m = EUROPEANA_NON_ART_RE.exec(input.medium ?? '');
+  return m ? m[0].toLowerCase() : null;
+}

--- a/src/fetchers/europeana.ts
+++ b/src/fetchers/europeana.ts
@@ -3,6 +3,7 @@ import { validateEuropeanaLicense } from '../licenseGate.js';
 import { cleanArtistName, detectAttributionType, normalizeRegion } from '../mappings.js';
 import { normalizeMedium } from '../medium.js';
 import type { Artwork, ValidationResult } from '../types.js';
+import { isNonArtEuropeana } from './curation.js';
 import { asOptionalString, asString, httpGet } from './helpers.js';
 import { sanitizeArtistName, sanitizeDescription, sanitizeTitle } from './sanitize.js';
 import type { Fetcher, SearchOptions } from './types.js';
@@ -207,6 +208,16 @@ export const europeanaFetcher: Fetcher = {
     }
     if (!parsed.id) {
       return reject(id, 'europeana: missing or non-string id', raw);
+    }
+
+    // Curation gate (rights already passed): Europeana federates many archives,
+    // so a non-art TYPE (Text, Sound, Map, specimen, ...) can slip through
+    // TYPE:IMAGE. Reject on the explicit type/medium signal only — never on the
+    // title, so genuine art photographs are not mis-rejected. (Documentary-photo
+    // keyword-noise is a ranking concern, not a non-art gate; see curation.ts.)
+    const nonArt = isNonArtEuropeana({ medium: parsed.medium, title: parsed.title });
+    if (nonArt) {
+      return reject(id, `europeana: non-art type "${nonArt}" (curation reject)`, raw);
     }
 
     const dateRange = parseDisplayDate(parsed.displayDate);

--- a/src/fetchers/wikimedia.ts
+++ b/src/fetchers/wikimedia.ts
@@ -3,6 +3,7 @@ import { validateWikimediaLicense } from '../licenseGate.js';
 import { cleanArtistName, detectAttributionType } from '../mappings.js';
 import { normalizeMedium } from '../medium.js';
 import type { Artwork, ValidationResult } from '../types.js';
+import { isNonArtWikimedia } from './curation.js';
 import { asFiniteNumber, asString, httpGet, isValidPositiveInt, rejectFor } from './helpers.js';
 import { ARTIST_NAME_MAX, DESCRIPTION_MAX, TITLE_MAX } from './sanitize.js';
 import type { Fetcher, SearchOptions } from './types.js';
@@ -292,6 +293,16 @@ export const wikimediaFetcher: Fetcher = {
     const cleanFileTitle = stripFileNumberSuffix(fileTitle);
     const rawTitle = (cleanObjectName || cleanFileTitle).trim();
     const title = (rawTitle || '(Untitled)').slice(0, TITLE_MAX);
+
+    // Curation gate: Commons is a federation, not a curated art museum — it
+    // carries diagrams, logos, charts, maps and publication pages alongside art,
+    // all correctly licensed. Reject non-art here (rights already passed). Uses
+    // the file's categories (Commons' curatorial taxonomy) + MIME + title.
+    const categories = categoryTitles(Array.isArray(page.categories) ? page.categories : []);
+    const nonArt = isNonArtWikimedia({ mime, categories, title });
+    if (nonArt) {
+      return reject(id, `wikimedia: ${nonArt} (curation reject)`, raw);
+    }
 
     const artistRaw = stripHtml(getExtField(ext, 'Artist')).slice(0, ARTIST_NAME_MAX);
     const attributionType = detectAttributionType(artistRaw);

--- a/tests/europeana.test.ts
+++ b/tests/europeana.test.ts
@@ -76,6 +76,19 @@ describe('Europeana adapter normalization', () => {
     expect(result.rejection.reason).toContain('rights field missing');
   });
 
+  it('curation-rejects an explicit non-art type (dcType "Text"), rights aside', () => {
+    const result = europeanaFetcher.normalize(fixture('europeana-rejected-nonart-text.json'));
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.reason).toMatch(/curation/i);
+    expect(result.rejection.reason).toMatch(/text/i);
+  });
+
+  it('still accepts genuine artworks after the curation gate (no false positive)', () => {
+    expect(europeanaFetcher.normalize(fixture('europeana-accepted-cc0.json')).status).toBe('accepted');
+    expect(europeanaFetcher.normalize(fixture('europeana-accepted-pdm.json')).status).toBe('accepted');
+  });
+
   it('rejects garbage input', () => {
     expect(europeanaFetcher.normalize(null).status).toBe('rejected');
     expect(europeanaFetcher.normalize('not an object').status).toBe('rejected');

--- a/tests/fetchers/curation.test.ts
+++ b/tests/fetchers/curation.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isNonArtEuropeana,
+  isNonArtWikimedia,
+  matchesNonArtTerm,
+} from '../../src/fetchers/curation.js';
+
+describe('matchesNonArtTerm — word-boundary non-art denylist (art-collision-free)', () => {
+  it('flags unambiguous non-art terms', () => {
+    expect(matchesNonArtTerm('Open-access and fake open-access publishing routes')).toBeTruthy();
+    expect(matchesNonArtTerm('Diagram of the human eye')).toBe('diagram');
+    expect(matchesNonArtTerm('Map of Venice')).toBe('map');
+    expect(matchesNonArtTerm('Company logo')).toBe('logo');
+    expect(matchesNonArtTerm('Bar chart of GDP')).toBeTruthy();
+  });
+
+  it('does NOT collide with art terms (the precision guarantee)', () => {
+    // 'graph' must not match photograph / lithograph
+    expect(matchesNonArtTerm('Photograph of a painting')).toBeNull();
+    expect(matchesNonArtTerm('Lithograph by Daumier')).toBeNull();
+    // 'icon' must not match — Orthodox/religious icons are ART
+    expect(matchesNonArtTerm('Icon of the Virgin and Child')).toBeNull();
+    // ordinary art titles survive
+    expect(matchesNonArtTerm('Sunflowers')).toBeNull();
+    expect(matchesNonArtTerm('Self-Portrait with a Straw Hat')).toBeNull();
+    expect(matchesNonArtTerm('The Great Wave off Kanagawa')).toBeNull();
+  });
+});
+
+describe('isNonArtWikimedia — SVG + category/title denylist (reuses the Smithsonian gate idea)', () => {
+  it('rejects SVG vector graphics (diagrams/logos/charts/maps/flags on Commons)', () => {
+    expect(isNonArtWikimedia({ mime: 'image/svg+xml', categories: [], title: 'Some Flag' })).toBeTruthy();
+  });
+
+  it('rejects the flagship junk: the OA-routes SVG diagram (wikimedia:157318642)', () => {
+    expect(
+      isNonArtWikimedia({
+        mime: 'image/svg+xml',
+        categories: ['Images of Open science for arts design music', 'Open access (publishing)'],
+        title: 'OS-ADM pag.88 Open-access and fake open-access publishing routes',
+      }),
+    ).toBeTruthy();
+  });
+
+  it('rejects the raster (PNG) junk via the topical category/title (wikimedia:175537332)', () => {
+    expect(
+      isNonArtWikimedia({
+        mime: 'image/png',
+        categories: ['Open access (publishing)'],
+        title: 'Open Access Models Overview',
+      }),
+    ).toBeTruthy();
+  });
+
+  it('KEEPS genuine artworks (raster, art-bearing or empty categories)', () => {
+    expect(
+      isNonArtWikimedia({
+        mime: 'image/jpeg',
+        categories: ['Still life: Vase with Twelve Sunflowers'],
+        title: 'Vincent Willem van Gogh 128',
+      }),
+    ).toBeNull();
+    expect(isNonArtWikimedia({ mime: 'image/jpeg', categories: [], title: 'Great Wave off Kanagawa2' })).toBeNull();
+    expect(
+      isNonArtWikimedia({
+        mime: 'image/jpeg',
+        categories: ['Colnaghi (art gallery)'],
+        title: 'Rembrandt van Rijn - Self-Portrait - Google Art Project',
+      }),
+    ).toBeNull();
+  });
+
+  it('KEEPS a raster religious icon (the icon-collision guard, end to end)', () => {
+    expect(
+      isNonArtWikimedia({ mime: 'image/jpeg', categories: ['Icons of Christ'], title: 'Icon of the Saviour' }),
+    ).toBeNull();
+  });
+});
+
+describe('isNonArtEuropeana — explicit non-art TYPE only (conservative; no title matching)', () => {
+  it('rejects records whose type/medium names a non-art form', () => {
+    expect(isNonArtEuropeana({ medium: 'Text', title: 'A letter' })).toBeTruthy();
+    expect(isNonArtEuropeana({ medium: 'image/jpeg Map', title: 'Map of Europe' })).toBe('map');
+    expect(isNonArtEuropeana({ medium: 'specimen', title: 'Beetle' })).toBeTruthy();
+  });
+
+  it('KEEPS art types', () => {
+    expect(isNonArtEuropeana({ medium: 'painting', title: 'Sunflowers' })).toBeNull();
+    expect(isNonArtEuropeana({ medium: 'Painting, Bildkonst', title: 'Persimoner' })).toBeNull();
+  });
+
+  it('does NOT reject typeless documentary photos by title (that is a v1.2 ranking concern, not a non-art gate)', () => {
+    // honest boundary: no type signal -> the gate passes it; ranking demotes it later
+    expect(isNonArtEuropeana({ medium: '', title: 'Hospital corridor with access site' })).toBeNull();
+    expect(isNonArtEuropeana({ medium: '', title: 'The access road to Säva Farm' })).toBeNull();
+  });
+});

--- a/tests/fixtures/europeana-rejected-nonart-text.json
+++ b/tests/fixtures/europeana-rejected-nonart-text.json
@@ -1,0 +1,16 @@
+{
+  "apikey": "test", "success": true, "itemsCount": 1, "totalResults": 1,
+  "items": [
+    {
+      "id": "/9200338/BibliographicResource_3000093834108",
+      "title": ["Municipal council meeting minutes, 1894"],
+      "dcCreator": ["Town clerk"],
+      "dcType": ["Text"],
+      "rights": ["http://creativecommons.org/publicdomain/zero/1.0/"],
+      "edmIsShownBy": ["https://example.org/scan/minutes_1894.jpg"],
+      "edmPreview": ["https://example.org/preview/minutes_1894.jpg"],
+      "dataProvider": ["Regional Archive"],
+      "country": ["Sweden"]
+    }
+  ]
+}

--- a/tests/fixtures/wikimedia-rejected-nonart-png.json
+++ b/tests/fixtures/wikimedia-rejected-nonart-png.json
@@ -1,0 +1,28 @@
+{
+  "query": {
+    "pages": [
+      {
+        "pageid": 175537332,
+        "title": "File:Open Access Models Overview.png",
+        "imageinfo": [
+          {
+            "url": "https://upload.wikimedia.org/wikipedia/commons/y/Open_Access_Models_Overview.png",
+            "descriptionurl": "https://commons.wikimedia.org/wiki/File:Open_Access_Models_Overview.png",
+            "mime": "image/png",
+            "width": 1000,
+            "height": 700,
+            "size": 54321,
+            "extmetadata": {
+              "ObjectName": { "value": "Open Access Models Overview" },
+              "License": { "value": "cc0" },
+              "LicenseShortName": { "value": "CC0" }
+            }
+          }
+        ],
+        "categories": [
+          { "title": "Category:Open access (publishing)" }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/wikimedia-rejected-nonart-svg.json
+++ b/tests/fixtures/wikimedia-rejected-nonart-svg.json
@@ -1,0 +1,29 @@
+{
+  "query": {
+    "pages": [
+      {
+        "pageid": 157318642,
+        "title": "File:OS-ADM pag.88 Open-access and fake open-access publishing routes.svg",
+        "imageinfo": [
+          {
+            "url": "https://upload.wikimedia.org/wikipedia/commons/x/OS-ADM_pag.88.svg",
+            "descriptionurl": "https://commons.wikimedia.org/wiki/File:OS-ADM_pag.88_Open-access_and_fake_open-access_publishing_routes.svg",
+            "mime": "image/svg+xml",
+            "width": 800,
+            "height": 600,
+            "size": 12345,
+            "extmetadata": {
+              "ObjectName": { "value": "OS-ADM pag.88 Open-access and fake open-access publishing routes" },
+              "License": { "value": "cc0" },
+              "LicenseShortName": { "value": "CC0" }
+            }
+          }
+        ],
+        "categories": [
+          { "title": "Category:Images of Open science for arts design music" },
+          { "title": "Category:Open access (publishing)" }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/wikimedia.test.ts
+++ b/tests/wikimedia.test.ts
@@ -63,6 +63,28 @@ describe('Wikimedia Commons adapter normalization', () => {
     expect(result.rejection.reason).toContain('missing');
   });
 
+  it('curation-rejects the flagship non-art SVG diagram (wikimedia:157318642), rights aside', () => {
+    const result = wikimediaFetcher.normalize(fixture('wikimedia-rejected-nonart-svg.json'));
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.reason).toMatch(/curation/i);
+    expect(result.rejection.reason).toMatch(/svg/i);
+  });
+
+  it('curation-rejects raster (PNG) non-art via the topical category (wikimedia:175537332)', () => {
+    const result = wikimediaFetcher.normalize(fixture('wikimedia-rejected-nonart-png.json'));
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.reason).toMatch(/curation/i);
+    expect(result.rejection.reason).toMatch(/open access|publishing/i);
+  });
+
+  it('still accepts a genuine artwork after the curation gate (no false positive)', () => {
+    // the existing CC0 photograph fixture is real art with no non-art signal
+    expect(wikimediaFetcher.normalize(fixture('wikimedia-accepted-cc0.json')).status).toBe('accepted');
+    expect(wikimediaFetcher.normalize(fixture('wikimedia-accepted-bruegel.json')).status).toBe('accepted');
+  });
+
   it('rejects garbage input gracefully', () => {
     expect(wikimediaFetcher.normalize(null).status).toBe('rejected');
     expect(wikimediaFetcher.normalize('not an object').status).toBe('rejected');


### PR DESCRIPTION
BASEL-URGENT. The federated sources are **not curated art museums** — Wikimedia Commons and Europeana carry diagrams, charts, logos, maps and publication pages alongside art, all correctly licensed. The rights gate passes that junk; this adds a **separate curation gate** (same idea as the Smithsonian `object_type` gate from #82): keep genuine artworks, reject non-art. **Precision over recall** for launch credibility.

## The fix (`src/fetchers/curation.ts`, wired into both fetchers' `normalize` after the rights gate)
- **`isNonArtWikimedia`** — two signals:
  1. reject `image/svg+xml` — on Commons, SVG is overwhelmingly diagrams/logos/charts/maps/flags, essentially never a digitised artwork (those are raster JPEG/PNG/TIFF). Highest-precision rule; catches the bulk of the diagram class.
  2. a **word-boundary category/title denylist** for raster non-art the SVG rule misses (e.g. a PNG categorised under "Open access (publishing)"). Curated to avoid art collisions: **no bare `graph`** (photoGRAPH/lithoGRAPH), **no `icon`** (Orthodox icons are art), **no `table`**.
- **`isNonArtEuropeana`** — rejects on the explicit `dcType`/medium signal only (Text, Sound, Map, specimen, ...), **never the title**. Europeana's documentary-photo keyword-noise ("access road to ...") is a **ranking problem (v1.2)**, not a non-art gate — those are real photographs, indistinguishable from art photos by type; matching them by title would reject genuine art, so the gate honestly does not. (Stated explicitly in the code.)

## Live before/after — `npm run smoke:curation`, real Commons/Europeana APIs
**`open access`** (the brand term people type at Basel, worst-hit):
```
wikimedia:157318642 -> reject: svg vector graphic (curation reject)     [the flagship example]
wikimedia:175537332 -> reject: non-art signal "open access" (curation)  [the raster PNG]
... whole SUPSI OS-ADM set rejected (6/12 curation; rest already rights-rejected)
-> 0 accepted, 6 CURATION-rejected (of 12). Before the gate the rights-valid diagrams were accepted.
```
**`sunflowers painting`** (genuine art must survive):
```
7 ACCEPT (Van Gogh sunflower paintings) — 0 curation false positives; the 5 rejects are CC-BY/SA rights only.
```
Europeana `sunflowers painting`: 7 real artworks accepted, 0 curation false positives.

## Recall tradeoff (documented)
The SVG rule drops rare legitimate vector/digital art; the denylist drops antique maps and any artwork whose title/category carries a denylisted term (e.g. a still-life titled with "map"). Acceptable for a curated art collection at launch; revisitable once ranking (v1.2) can demote rather than drop.

## Gates (real output)
- `vitest run` → **489/489** (33 files), exit 0 — **15 new** (curation unit tests incl. the icon/photograph collision guards + the honest Europeana boundary; fixture-based reject/accept for both fetchers)
- `tscq --noEmit` → 0 · build → 0

## Scope / safety
New `curation.ts` + gate calls in `wikimedia.ts`/`europeana.ts` + `scripts/smoke-curation.ts` + 3 fixtures. **Rights gate untouched** (strict default deny); curation is an *additional* reject layer, never a loosening. No `/core` shape change. Curated museums (Met/AIC/Cleveland/Smithsonian) are unaffected.

## OM-CR
Re-run gates + `npm run smoke:curation` against live APIs; confirm the flagship junk (`wikimedia:157318642`) is filtered and real art (`sunflowers`) is untouched; sanity-check the denylist for art collisions (probe e.g. religious icons, lithographs, maps-in-art).

Do not merge — Pramod merges.

Co-Authored by Pramod Prasanth <pramod@chainalign.com>