### PR TITLE
feat(coverage): IIIF client + commercial-POD rights gate + Rijksmuseum direct

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-sqlite vitest",
     "smoke:smithsonian": "NODE_OPTIONS=--experimental-sqlite tsx scripts/smoke-smithsonian.ts",
     "smoke:curation": "NODE_OPTIONS=--experimental-sqlite tsx scripts/smoke-curation.ts",
+    "smoke:rijksmuseum": "NODE_OPTIONS=--experimental-sqlite tsx scripts/smoke-rijksmuseum.ts",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [

--- a/scripts/smoke-rijksmuseum.ts
+++ b/scripts/smoke-rijksmuseum.ts
@@ -1,0 +1,43 @@
+// Live smoke for the Rijksmuseum DIRECT fetcher — hits the real keyless Data
+// Services (Linked-Art) + Micrio IIIF through the actual fetcher: search ->
+// getRaw (object -> VisualItem -> DigitalObject -> info.json) -> normalize, with
+// the commercial-POD rights gate + the >=3000px print floor applied live.
+//   npm run smoke:rijksmuseum
+import { rijksmuseumFetcher } from '../src/fetchers/rijksmuseum.js';
+
+async function sample(query: string, limit: number) {
+  console.log(`\n===== rijksmuseum · search "${query}" =====`);
+  const ids = await rijksmuseumFetcher.search(query, limit, { hasImage: true });
+  console.log(`search() -> ${ids.length} ids`);
+  let accepted = 0;
+  let rejected = 0;
+  for (const id of ids) {
+    try {
+      const res = rijksmuseumFetcher.normalize(await rijksmuseumFetcher.getRaw(id));
+      if (res.status === 'accepted') {
+        accepted++;
+        const a = res.artwork;
+        console.log(
+          `  ✓ ${id} "${a.title}" / ${a.artist.name} / ${a.displayDate} / ${a.license.type} / ${a.imageUrls.width}x${a.imageUrls.height}`,
+        );
+      } else {
+        rejected++;
+        console.log(`  ✗ ${id} — ${res.rejection.reason}`);
+      }
+    } catch (e) {
+      console.log(`  ERR ${id} — ${(e as Error).message}`);
+    }
+  }
+  console.log(`  -> ${accepted} accepted, ${rejected} rejected (of ${ids.length})`);
+}
+
+async function main() {
+  await sample('Vermeer', 4);
+  await sample('Rembrandt', 4);
+  await sample('The Night Watch', 3);
+}
+
+main().catch((e) => {
+  console.error('SMOKE FAILED:', e);
+  process.exit(1);
+});

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -103,3 +103,20 @@ export { aicFetcher } from '../fetchers/aic.js';
 export { wikimediaFetcher } from '../fetchers/wikimedia.js';
 export { europeanaFetcher } from '../fetchers/europeana.js';
 export { smithsonianFetcher } from '../fetchers/smithsonian.js';
+export { rijksmuseumFetcher } from '../fetchers/rijksmuseum.js';
+
+// Coverage foundation: the reusable IIIF client + the shared commercial-POD
+// rights gate (CC0/PDM/CC-BY/CC-BY-SA allow; NC/ND/unknown deny; >=3000px floor).
+export {
+  parseManifest,
+  parseInfoJson,
+  fullImageUrl,
+  meetsPrintResolution,
+  fetchManifest,
+  fetchInfoJson,
+  type IiifManifestParsed,
+  type IiifInfo,
+  type IiifImageRef,
+  type IiifApiVersion,
+} from '../iiif/client.js';
+export { validateCommercialRights } from '../rights/commercialRights.js';

--- a/src/fetchers/rijksmuseum.ts
+++ b/src/fetchers/rijksmuseum.ts
@@ -1,0 +1,293 @@
+/**
+ * Rijksmuseum DIRECT — the new keyless Data Services (Linked-Art JSON-LD) +
+ * Micrio IIIF 3.0. Replaces the Europeana-mediated Rijks path (direct = far
+ * richer metadata + authoritative per-object rights + true print pixels).
+ *
+ * The legacy key-based api.rijksmuseum.nl shut down 5 Jan 2026; this fetcher is
+ * keyless. Per-object rights are judged by the shared commercial-POD gate
+ * (CC0/PDM/CC-BY/CC-BY-SA only) and the image is gated to >=3000px long edge via
+ * the IIIF info.json — exactly the foundation this drive builds.
+ *
+ * Reaching the image is a deref chain (recorded live):
+ *   object (HumanMadeObject) -> shows[0] VisualItem -> digitally_shown_by[0]
+ *   DigitalObject -> access_point[0] = a ready IIIF /full/max URL on iiif.micr.io.
+ * The VisualItem carries the IMAGE rights (the asset we actually sell), so that
+ * is what the rights gate judges.
+ */
+import { cleanArtistName, detectAttributionType } from '../mappings.js';
+import { normalizeMedium } from '../medium.js';
+import { validateCommercialRights } from '../rights/commercialRights.js';
+import { fetchInfoJson, meetsPrintResolution } from '../iiif/client.js';
+import type { Artwork, ValidationResult } from '../types.js';
+import { httpGet, rejectFor } from './helpers.js';
+import { ARTIST_NAME_MAX, TITLE_MAX } from './sanitize.js';
+import type { Fetcher, SearchOptions } from './types.js';
+
+const ID_RESOLVER = 'https://id.rijksmuseum.nl';
+const SEARCH_API = 'https://data.rijksmuseum.nl/search/collection';
+const RIGHTS_SOURCE = 'rijksmuseum.linkedart.visualitem.subject_to';
+const PRINT_FLOOR_PX = 3000;
+
+// Getty AAT classifiers used by the Rijks Linked-Art records.
+const AAT_PRIMARY_TITLE = '300404670';
+const AAT_LANG_EN = '300388277';
+
+const reject = (id: string, reason: string, rawSnapshot: unknown): ValidationResult =>
+  rejectFor('rijksmuseum', id, reason, rawSnapshot);
+
+const isObj = (v: unknown): v is Record<string, unknown> => typeof v === 'object' && v !== null;
+const arr = (v: unknown): unknown[] => (Array.isArray(v) ? v : []);
+const str = (v: unknown): string => (typeof v === 'string' ? v : '');
+
+/** `https://id.rijksmuseum.nl/200108369` -> `rijksmuseum:200108369`. */
+function idFromUri(uri: string): string | null {
+  const m = uri.match(/\/(\d+)(?:\/)?$/);
+  return m ? `rijksmuseum:${m[1]}` : null;
+}
+
+function classifierIds(node: Record<string, unknown>): string[] {
+  return arr(node.classified_as)
+    .filter(isObj)
+    .map((c) => str(c.id))
+    .filter(Boolean);
+}
+
+/** Pick the primary title (AAT 300404670), preferring the English-language Name. */
+function pickTitle(object: Record<string, unknown>): string {
+  const names = arr(object.identified_by).filter(isObj);
+  const primaries = names.filter((n) => classifierIds(n).some((id) => id.includes(AAT_PRIMARY_TITLE)));
+  const pool = primaries.length ? primaries : names;
+  const english = pool.find((n) =>
+    arr(n.language)
+      .filter(isObj)
+      .some((l) => str(l.id).includes(AAT_LANG_EN)),
+  );
+  return str((english ?? pool[0])?.content);
+}
+
+/** Collect creator display names from produced_by(.part[]).carried_out_by[]. */
+function pickCreators(object: Record<string, unknown>): string[] {
+  const produced = isObj(object.produced_by) ? object.produced_by : undefined;
+  if (!produced) return [];
+  const actors: Record<string, unknown>[] = [];
+  for (const carrier of [produced, ...arr(produced.part).filter(isObj)]) {
+    for (const a of arr((carrier as Record<string, unknown>).carried_out_by).filter(isObj)) actors.push(a);
+  }
+  const names: string[] = [];
+  for (const actor of actors) {
+    const notations = arr(actor.notation).filter(isObj);
+    const en = notations.find((n) => str(n['@language']) === 'en');
+    const name = str((en ?? notations[0])?.['@value']);
+    if (name && !names.includes(name)) names.push(name);
+  }
+  return names;
+}
+
+/** Year bounds from produced_by.timespan ISO begin/end. */
+function pickYears(object: Record<string, unknown>): { yearStart: number | null; yearEnd: number | null; display: string } {
+  const produced = isObj(object.produced_by) ? object.produced_by : undefined;
+  const ts = produced && isObj(produced.timespan) ? produced.timespan : undefined;
+  const year = (iso: unknown): number | null => {
+    const m = str(iso).match(/^(-?\d{1,4})-/);
+    return m ? parseInt(m[1], 10) : null;
+  };
+  const yearStart = ts ? year(ts.begin_of_the_begin) : null;
+  const yearEnd = ts ? year(ts.end_of_the_end) : null;
+  // display string: prefer the English-language label, else any.
+  let display = '';
+  if (ts) {
+    const labels = arr(ts.identified_by).filter(isObj);
+    const en = labels.find((l) =>
+      arr(l.language)
+        .filter(isObj)
+        .some((x) => str(x.id).includes(AAT_LANG_EN)),
+    );
+    display = str((en ?? labels[0])?.content);
+  }
+  return { yearStart, yearEnd, display };
+}
+
+/** The image (VisualItem) rights URI: subject_to[] -> Right -> classified_as[] -> CC/RS URI. */
+function pickImageRights(visualItem: Record<string, unknown> | undefined): string | null {
+  if (!visualItem) return null;
+  for (const right of arr(visualItem.subject_to).filter(isObj)) {
+    for (const id of classifierIds(right)) {
+      if (id.includes('creativecommons.org') || id.includes('rightsstatements.org')) return id;
+    }
+  }
+  return null;
+}
+
+/** Object-type label -> medium category (e.g. "painting"). */
+function pickMedium(object: Record<string, unknown>): string {
+  return arr(object.classified_as)
+    .filter(isObj)
+    .map((c) => str(c._label))
+    .filter(Boolean)
+    .join(' ');
+}
+
+async function fetchLd(url: string): Promise<unknown> {
+  const res = await httpGet(url, { headers: { Accept: 'application/ld+json' } });
+  if (!res.ok) throw new Error(`Rijksmuseum fetch failed (${res.status}) for ${url}`);
+  return res.json();
+}
+
+export const rijksmuseumFetcher: Fetcher = {
+  code: 'rijksmuseum',
+  name: 'Rijksmuseum',
+
+  async search(query: string, limit: number, options: SearchOptions = {}): Promise<string[]> {
+    // The Data Services search is FACETED (no full-text `q`), and facets are
+    // ANDed within one request — so a single `title` query misses originals
+    // whose title doesn't contain the artist name (searching "Vermeer" on title
+    // returns reproductions OF Vermeer, not his paintings). Query `creator` and
+    // `title` independently and merge (creator first — artist-name queries are
+    // the common case and the more precise match), de-duped, sliced to `limit`.
+    const facetQuery = async (facet: 'creator' | 'title'): Promise<string[]> => {
+      const url = new URL(SEARCH_API);
+      url.searchParams.set(facet, query);
+      if (options.hasImage !== false) url.searchParams.set('imageAvailable', 'true');
+      const res = await httpGet(url, { headers: { Accept: 'application/ld+json' } });
+      if (!res.ok) throw new Error(`Rijksmuseum search failed (${facet}): ${res.status}`);
+      const json = (await res.json()) as { orderedItems?: Array<{ id?: unknown }> };
+      return arr(json.orderedItems)
+        .filter(isObj)
+        .map((it) => idFromUri(str(it.id)))
+        .filter((s): s is string => s !== null);
+    };
+
+    const [byCreator, byTitle] = await Promise.all([facetQuery('creator'), facetQuery('title')]);
+    const seen = new Set<string>();
+    const merged: string[] = [];
+    for (const id of [...byCreator, ...byTitle]) {
+      if (seen.has(id)) continue;
+      seen.add(id);
+      merged.push(id);
+      if (merged.length >= limit) break;
+    }
+    return merged;
+  },
+
+  async getRaw(id: string): Promise<unknown> {
+    const numeric = id.replace(/^rijksmuseum:/, '');
+    const object = await fetchLd(`${ID_RESOLVER}/${numeric}`);
+    let visualItem: Record<string, unknown> | undefined;
+    let image: { serviceBase: string; fullUrl: string; width?: number; height?: number } | undefined;
+
+    const visualRef = isObj(object) ? str((arr(object.shows).filter(isObj)[0])?.id) : '';
+    if (visualRef) {
+      const vi = await fetchLd(visualRef);
+      if (isObj(vi)) {
+        visualItem = vi;
+        const digitalRef = str((arr(vi.digitally_shown_by).filter(isObj)[0])?.id);
+        if (digitalRef) {
+          const digital = await fetchLd(digitalRef);
+          const accessPoint = isObj(digital) ? str((arr(digital.access_point).filter(isObj)[0])?.id) : '';
+          if (accessPoint) {
+            const serviceBase = accessPoint.replace(/\/full\/(?:max|full)\/0\/default\.\w+$/, '');
+            let width: number | undefined;
+            let height: number | undefined;
+            try {
+              const info = await fetchInfoJson(serviceBase);
+              width = info.width;
+              height = info.height;
+            } catch {
+              /* dims unavailable — normalize will reject on the resolution gate */
+            }
+            image = { serviceBase, fullUrl: accessPoint, width, height };
+          }
+        }
+      }
+    }
+    return { id, object, visualItem, image };
+  },
+
+  normalize(raw: unknown): ValidationResult {
+    if (!isObj(raw) || !isObj(raw.object)) {
+      return reject('rijksmuseum:unknown', 'rijksmuseum: bundle missing the Linked-Art object', raw);
+    }
+    const id = str(raw.id) || 'rijksmuseum:unknown';
+    const object = raw.object as Record<string, unknown>;
+    const visualItem = isObj(raw.visualItem) ? (raw.visualItem as Record<string, unknown>) : undefined;
+    const image = isObj(raw.image) ? (raw.image as Record<string, unknown>) : undefined;
+
+    // Rights gate first (strict default deny) — judges the IMAGE rights.
+    const rightsUri = pickImageRights(visualItem);
+    const decision = validateCommercialRights(rightsUri, RIGHTS_SOURCE);
+    if (!decision.accepted || !decision.license) {
+      return reject(id, decision.reason, raw);
+    }
+
+    // Print-resolution gate: must resolve an image >= 3000px on the long edge.
+    if (!image || !image.fullUrl) {
+      return reject(id, 'rijksmuseum: no print-resolution image resolved', raw);
+    }
+    const width = typeof image.width === 'number' ? image.width : 0;
+    const height = typeof image.height === 'number' ? image.height : 0;
+    if (!meetsPrintResolution(width, height, PRINT_FLOOR_PX)) {
+      return reject(
+        id,
+        `rijksmuseum: image ${width}x${height} below the print floor (${PRINT_FLOOR_PX}px long edge)`,
+        raw,
+      );
+    }
+
+    const title = (pickTitle(object) || '(Untitled)').slice(0, TITLE_MAX);
+    const creators = pickCreators(object);
+    const artistRaw = creators.join(', ').slice(0, ARTIST_NAME_MAX);
+    const { yearStart, yearEnd, display } = pickYears(object);
+    const displayDate = display || parseAndFormat(yearStart, yearEnd);
+
+    const artwork: Artwork = {
+      id,
+      museum: { code: 'rijksmuseum', name: 'Rijksmuseum', url: 'https://www.rijksmuseum.nl' },
+      title,
+      artist: {
+        name: cleanArtistName(artistRaw) || 'Unknown',
+        nationality: undefined,
+        lifespan: undefined,
+        attributionType: detectAttributionType(artistRaw),
+      },
+      displayDate,
+      yearStart,
+      yearEnd,
+      medium: '',
+      mediumCategory: normalizeMedium(pickMedium(object)),
+      region: null,
+      period: null,
+      imageUrls: {
+        full: str(image.fullUrl),
+        thumbnail: undefined,
+        width: width || undefined,
+        height: height || undefined,
+      },
+      imageOpenAccess: decision.imageOpenAccess,
+      metadataOpenAccess: decision.metadataOpenAccess,
+      license: decision.license,
+      source: {
+        apiUrl: `${ID_RESOLVER}/${id.replace(/^rijksmuseum:/, '')}`,
+        pageUrl: `https://www.rijksmuseum.nl/en/collection/${objectNumber(object)}`,
+      },
+    };
+    return { status: 'accepted', artwork };
+  },
+};
+
+/** Fallback display date when the timespan carries no label. */
+function parseAndFormat(start: number | null, end: number | null): string {
+  if (start === null && end === null) return '';
+  if (start === end) return String(start);
+  return `${start ?? ''}–${end ?? ''}`;
+}
+
+/** objectNumber (e.g. SK-A-2344) for the public page URL, when present. */
+function objectNumber(object: Record<string, unknown>): string {
+  for (const idn of arr(object.identified_by).filter(isObj)) {
+    if (str(idn.type) === 'Identifier' || classifierIds(idn).some((c) => c.includes('300404626'))) {
+      const c = str(idn.content);
+      if (/^[A-Z]/.test(c)) return c;
+    }
+  }
+  return '';
+}

--- a/src/fetchers/rijksmuseum.ts
+++ b/src/fetchers/rijksmuseum.ts
@@ -16,7 +16,7 @@
  */
 import { cleanArtistName, detectAttributionType } from '../mappings.js';
 import { normalizeMedium } from '../medium.js';
-import { validateCommercialRights } from '../rights/commercialRights.js';
+import { isRightsUri, validateCommercialRights } from '../rights/commercialRights.js';
 import { fetchInfoJson, meetsPrintResolution } from '../iiif/client.js';
 import type { Artwork, ValidationResult } from '../types.js';
 import { httpGet, rejectFor } from './helpers.js';
@@ -112,7 +112,8 @@ function pickImageRights(visualItem: Record<string, unknown> | undefined): strin
   if (!visualItem) return null;
   for (const right of arr(visualItem.subject_to).filter(isObj)) {
     for (const id of classifierIds(right)) {
-      if (id.includes('creativecommons.org') || id.includes('rightsstatements.org')) return id;
+      // Exact-hostname match (not substring) — the gate then judges the URI.
+      if (isRightsUri(id)) return id;
     }
   }
   return null;

--- a/src/iiif/client.ts
+++ b/src/iiif/client.ts
@@ -49,6 +49,13 @@ export interface IiifInfo {
 const isObj = (v: unknown): v is Record<string, unknown> => typeof v === 'object' && v !== null;
 const asNum = (v: unknown): number | undefined => (typeof v === 'number' && Number.isFinite(v) ? v : undefined);
 
+/** Linear trailing-slash strip (avoids a backtracking `/\/+$/` on attacker text). */
+function stripTrailingSlashes(s: string): string {
+  let end = s.length;
+  while (end > 0 && s.charCodeAt(end - 1) === 47 /* '/' */) end--;
+  return s.slice(0, end);
+}
+
 /** IIIF v3 labels are language maps ({en:[...]}); v2 are strings or arrays. */
 function firstLabel(label: unknown): string {
   if (typeof label === 'string') return label;
@@ -142,7 +149,7 @@ export function parseManifest(raw: unknown): IiifManifestParsed {
 
 /** Build the IIIF Image API full-resolution request for a service base. */
 export function fullImageUrl(serviceId: string, apiVersion: IiifApiVersion): string {
-  const base = serviceId.replace(/\/+$/, '');
+  const base = stripTrailingSlashes(serviceId);
   // v3 deprecates `full/full`; the canonical "largest" size is `full/max`.
   return apiVersion === 3 ? `${base}/full/max/0/default.jpg` : `${base}/full/full/0/default.jpg`;
 }
@@ -181,7 +188,7 @@ export async function fetchManifest(url: string): Promise<IiifManifestParsed> {
 
 /** Fetch + parse an Image API info.json for a service base. */
 export async function fetchInfoJson(serviceId: string): Promise<IiifInfo> {
-  const url = `${serviceId.replace(/\/+$/, '')}/info.json`;
+  const url = `${stripTrailingSlashes(serviceId)}/info.json`;
   const res = await httpGet(url, { headers: { Accept: 'application/ld+json,application/json' } });
   if (!res.ok) throw new Error(`iiif: info.json fetch failed (${res.status}) for ${url}`);
   return parseInfoJson(await res.json());

--- a/src/iiif/client.ts
+++ b/src/iiif/client.ts
@@ -1,0 +1,188 @@
+/**
+ * Reusable IIIF client — the shared foundation for every IIIF-backed source
+ * (Rijksmuseum, NGA, SMK, Yale, Belvedere, Basel, Wellcome, ...).
+ *
+ * Handles BOTH IIIF Presentation/Image API 2.x and 3.x, because the sources mix
+ * versions. It does three things:
+ *  - parse a Presentation manifest -> label, the per-object `rights` URI, and the
+ *    Image API service(s);
+ *  - parse an Image API `info.json` -> real pixel width/height (authoritative for
+ *    the print-resolution floor);
+ *  - build a `/full/max|full/0/default.jpg` request and check the >=3000px bar.
+ *
+ * IIIF is NOT a guarantee of print resolution — always read info.json (per the
+ * integration research). This module never decides RIGHTS; it only surfaces the
+ * rights URI for the shared commercial gate to judge.
+ */
+import { httpGet } from '../fetchers/helpers.js';
+
+export type IiifApiVersion = 2 | 3;
+
+export interface IiifImageRef {
+  /** IIIF Image API service base (no /full/... suffix). */
+  serviceId: string;
+  /** A ready-to-use full-resolution request built from the service base. */
+  fullUrl: string;
+  /** Pixel dimensions from the canvas/body, when the manifest carries them. */
+  width?: number;
+  height?: number;
+}
+
+export interface IiifManifestParsed {
+  apiVersion: IiifApiVersion;
+  label: string;
+  /** The `rights` (v3) / `license` (v2) URI, or null when absent (never guessed). */
+  rights: string | null;
+  /** Image services, primary canvas first. */
+  images: IiifImageRef[];
+}
+
+export interface IiifInfo {
+  apiVersion: IiifApiVersion;
+  width: number;
+  height: number;
+  maxWidth?: number;
+  maxHeight?: number;
+  maxArea?: number;
+}
+
+const isObj = (v: unknown): v is Record<string, unknown> => typeof v === 'object' && v !== null;
+const asNum = (v: unknown): number | undefined => (typeof v === 'number' && Number.isFinite(v) ? v : undefined);
+
+/** IIIF v3 labels are language maps ({en:[...]}); v2 are strings or arrays. */
+function firstLabel(label: unknown): string {
+  if (typeof label === 'string') return label;
+  if (Array.isArray(label)) {
+    const s = label.find((x) => typeof x === 'string');
+    if (typeof s === 'string') return s;
+  }
+  if (isObj(label)) {
+    const en = label.en ?? label.none ?? Object.values(label)[0];
+    if (Array.isArray(en) && typeof en[0] === 'string') return en[0];
+    if (typeof en === 'string') return en;
+  }
+  return '';
+}
+
+function detectPresentationVersion(raw: Record<string, unknown>): IiifApiVersion {
+  const ctx = JSON.stringify(raw['@context'] ?? '');
+  if (ctx.includes('presentation/2')) return 2;
+  if (ctx.includes('presentation/3')) return 3;
+  // Structural fallback: v2 uses `sequences`, v3 uses `items`.
+  return Array.isArray(raw.sequences) ? 2 : 3;
+}
+
+function v3Images(raw: Record<string, unknown>): IiifImageRef[] {
+  const out: IiifImageRef[] = [];
+  const canvases = Array.isArray(raw.items) ? raw.items : [];
+  for (const canvas of canvases) {
+    if (!isObj(canvas)) continue;
+    const cw = asNum(canvas.width);
+    const ch = asNum(canvas.height);
+    const pages = Array.isArray(canvas.items) ? canvas.items : [];
+    for (const page of pages) {
+      if (!isObj(page)) continue;
+      const annos = Array.isArray(page.items) ? page.items : [];
+      for (const anno of annos) {
+        if (!isObj(anno)) continue;
+        const body = anno.body;
+        if (!isObj(body)) continue;
+        const services = Array.isArray(body.service) ? body.service : body.service ? [body.service] : [];
+        const svc = services.find(isObj);
+        const serviceId = svc ? (typeof svc.id === 'string' ? svc.id : typeof svc['@id'] === 'string' ? (svc['@id'] as string) : '') : '';
+        if (!serviceId) continue;
+        out.push({
+          serviceId,
+          fullUrl: fullImageUrl(serviceId, 3),
+          width: asNum(body.width) ?? cw,
+          height: asNum(body.height) ?? ch,
+        });
+      }
+    }
+  }
+  return out;
+}
+
+function v2Images(raw: Record<string, unknown>): IiifImageRef[] {
+  const out: IiifImageRef[] = [];
+  const sequences = Array.isArray(raw.sequences) ? raw.sequences : [];
+  for (const seq of sequences) {
+    if (!isObj(seq)) continue;
+    const canvases = Array.isArray(seq.canvases) ? seq.canvases : [];
+    for (const canvas of canvases) {
+      if (!isObj(canvas)) continue;
+      const cw = asNum(canvas.width);
+      const ch = asNum(canvas.height);
+      const images = Array.isArray(canvas.images) ? canvas.images : [];
+      for (const image of images) {
+        if (!isObj(image)) continue;
+        const resource = isObj(image.resource) ? image.resource : undefined;
+        const service = resource && isObj(resource.service) ? resource.service : undefined;
+        const serviceId = service ? (typeof service['@id'] === 'string' ? (service['@id'] as string) : typeof service.id === 'string' ? (service.id as string) : '') : '';
+        if (!serviceId) continue;
+        out.push({ serviceId, fullUrl: fullImageUrl(serviceId, 2), width: cw, height: ch });
+      }
+    }
+  }
+  return out;
+}
+
+/** Parse an IIIF Presentation manifest (v2 or v3). Tolerant: absent fields -> null/empty. */
+export function parseManifest(raw: unknown): IiifManifestParsed {
+  if (!isObj(raw)) {
+    return { apiVersion: 3, label: '', rights: null, images: [] };
+  }
+  const apiVersion = detectPresentationVersion(raw);
+  const label = firstLabel(raw.label);
+  const rightsField = apiVersion === 3 ? raw.rights : (raw.rights ?? raw.license);
+  const rights = typeof rightsField === 'string' ? rightsField : null;
+  const images = apiVersion === 3 ? v3Images(raw) : v2Images(raw);
+  return { apiVersion, label, rights, images };
+}
+
+/** Build the IIIF Image API full-resolution request for a service base. */
+export function fullImageUrl(serviceId: string, apiVersion: IiifApiVersion): string {
+  const base = serviceId.replace(/\/+$/, '');
+  // v3 deprecates `full/full`; the canonical "largest" size is `full/max`.
+  return apiVersion === 3 ? `${base}/full/max/0/default.jpg` : `${base}/full/full/0/default.jpg`;
+}
+
+/** Parse an Image API info.json. Throws if no usable width/height are present. */
+export function parseInfoJson(raw: unknown): IiifInfo {
+  if (!isObj(raw)) throw new Error('iiif: info.json is not an object');
+  const width = asNum(raw.width);
+  const height = asNum(raw.height);
+  if (width === undefined || height === undefined) {
+    throw new Error('iiif: info.json has no usable width/height');
+  }
+  const ctx = JSON.stringify(raw['@context'] ?? '');
+  const apiVersion: IiifApiVersion = ctx.includes('image/2') || raw.type === 'ImageService2' ? 2 : 3;
+  return {
+    apiVersion,
+    width,
+    height,
+    maxWidth: asNum(raw.maxWidth),
+    maxHeight: asNum(raw.maxHeight),
+    maxArea: asNum(raw.maxArea),
+  };
+}
+
+/** True when the long edge meets the print/POD floor (default 3000px ≈ 300dpi @ A3). */
+export function meetsPrintResolution(width: number, height: number, floorPx = 3000): boolean {
+  return Math.max(width, height) >= floorPx;
+}
+
+/** Fetch + parse a Presentation manifest. */
+export async function fetchManifest(url: string): Promise<IiifManifestParsed> {
+  const res = await httpGet(url, { headers: { Accept: 'application/ld+json,application/json' } });
+  if (!res.ok) throw new Error(`iiif: manifest fetch failed (${res.status}) for ${url}`);
+  return parseManifest(await res.json());
+}
+
+/** Fetch + parse an Image API info.json for a service base. */
+export async function fetchInfoJson(serviceId: string): Promise<IiifInfo> {
+  const url = `${serviceId.replace(/\/+$/, '')}/info.json`;
+  const res = await httpGet(url, { headers: { Accept: 'application/ld+json,application/json' } });
+  if (!res.ok) throw new Error(`iiif: info.json fetch failed (${res.status}) for ${url}`);
+  return parseInfoJson(await res.json());
+}

--- a/src/rights/commercialRights.ts
+++ b/src/rights/commercialRights.ts
@@ -42,22 +42,41 @@ function accept(
   return { accepted: true, license, imageOpenAccess: true, metadataOpenAccess: true, reason: `accepted ${type}` };
 }
 
+/** True when `host` is exactly `domain` or a subdomain of it (NOT a substring). */
+function hostIs(host: string, domain: string): boolean {
+  return host === domain || host.endsWith(`.${domain}`);
+}
+
 /**
- * Normalize a rights URI for matching: lowercase, drop the scheme + `www.`,
- * collapse whitespace, strip a trailing slash. Keeps the path so license codes
- * (`by-nc-sa`) remain matchable.
+ * Parse a rights URI into its exact hostname + lowercased, non-empty path
+ * segments. Returns null when the value is not a parseable absolute URL. This is
+ * the security boundary: matching the HOSTNAME (not a substring of the whole
+ * string) is what stops `creativecommons.org.evil.com` / `evil.com/?x=creativecommons.org`
+ * from spoofing the gate.
  */
-function normalize(uri: string): string {
-  return uri
-    .trim()
+function parseRights(uri: string): { host: string; segments: string[] } | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(uri.trim());
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+  const host = parsed.hostname.toLowerCase();
+  if (!host) return null;
+  const segments = parsed.pathname
     .toLowerCase()
-    .replace(/^https?:\/\//, '')
-    .replace(/^www\./, '')
-    .replace(/\/+$/, '');
+    .split('/')
+    .filter((s) => s.length > 0);
+  return { host, segments };
 }
 
 /**
  * Validate a rights URI for commercial-POD eligibility.
+ *
+ * Hostname is matched EXACTLY (creativecommons.org / rightsstatements.org, or a
+ * subdomain), never as a substring — the licence path is only trusted once the
+ * host is proven, so a forged host cannot smuggle an allowlisted path through.
  *
  * @param rightsUri the per-object rights statement URI (CC or RightsStatements)
  * @param verificationSource provenance label recorded on the license, e.g.
@@ -71,40 +90,57 @@ export function validateCommercialRights(
     return reject('rights URI missing — strict default deny');
   }
   const raw = rightsUri.trim();
-  const u = normalize(raw);
+  const parsed = parseRights(raw);
+  if (!parsed) {
+    return reject(`rights=${raw}: not a parseable rights URL — strict default deny`);
+  }
+  const { host, segments } = parsed;
 
   // RightsStatements.org is a curatorial assertion vocabulary, NOT a licence
   // grant. "No Copyright"/"No Known Copyright" shifts liability to the reuser;
   // "In Copyright" is closed. None are auto-approvable for commercial sale.
-  if (u.includes('rightsstatements.org')) {
+  if (hostIs(host, 'rightsstatements.org')) {
     return reject(
       `rights=${raw}: rightsstatements.org assertion is a disclaimer, not a licence grant — review required`,
     );
   }
 
-  if (u.includes('publicdomain/zero')) return accept('CC0', raw, verificationSource);
-  if (u.includes('publicdomain/mark')) return accept('PD', raw, verificationSource);
-
-  // For CC licences the code is the path segment after "licenses/", e.g.
-  // "licenses/by-nc-sa/4.0" -> "by-nc-sa". Parse the code from the segments so
-  // the NC/ND substring checks are exact (and beat the bare-"by" match, since
-  // "by-nc" contains "by").
-  const segs = u.split('/');
-  const li = segs.indexOf('licenses');
-  const code = li >= 0 && segs[li + 1] ? segs[li + 1] : '';
-  const parts = code.split('-'); // ["by","nc","sa"]
-
-  if (parts.includes('nc')) {
-    return reject(`rights=${raw}: NonCommercial (NC) — cannot be sold as a reproduction`);
-  }
-  if (parts.includes('nd')) {
-    return reject(`rights=${raw}: NoDerivatives (ND) — a print crop/scale is a derivative`);
+  // Only Creative Commons URIs can be accepted (CC0/PDM/BY/BY-SA all live here).
+  if (!hostIs(host, 'creativecommons.org')) {
+    return reject(`rights=${raw}: unrecognized rights host '${host}' — strict default deny`);
   }
 
-  if (u.includes('creativecommons.org') && parts[0] === 'by') {
-    if (parts.includes('sa')) return accept('CC-BY-SA', raw, verificationSource);
-    if (parts.length === 1) return accept('CC-BY', raw, verificationSource);
+  // Path segments are now trusted (host proven). publicdomain/{zero,mark}.
+  if (segments[0] === 'publicdomain') {
+    if (segments[1] === 'zero') return accept('CC0', raw, verificationSource);
+    if (segments[1] === 'mark') return accept('PD', raw, verificationSource);
+    return reject(`rights=${raw}: unrecognized public-domain tool — strict default deny`);
+  }
+
+  // licenses/<code>/<version>, code e.g. "by", "by-sa", "by-nc-sa".
+  if (segments[0] === 'licenses') {
+    const parts = (segments[1] ?? '').split('-'); // ["by","nc","sa"]
+    if (parts.includes('nc')) {
+      return reject(`rights=${raw}: NonCommercial (NC) — cannot be sold as a reproduction`);
+    }
+    if (parts.includes('nd')) {
+      return reject(`rights=${raw}: NoDerivatives (ND) — a print crop/scale is a derivative`);
+    }
+    if (parts[0] === 'by') {
+      if (parts.includes('sa')) return accept('CC-BY-SA', raw, verificationSource);
+      if (parts.length === 1) return accept('CC-BY', raw, verificationSource);
+    }
   }
 
   return reject(`rights=${raw}: unrecognized or non-open licence — strict default deny`);
+}
+
+/**
+ * True when a URI's HOSTNAME is a recognized rights vocabulary host
+ * (creativecommons.org / rightsstatements.org or a subdomain). Used to pick the
+ * rights classifier out of a record's metadata without substring spoofing.
+ */
+export function isRightsUri(uri: string): boolean {
+  const parsed = parseRights(uri);
+  return parsed !== null && (hostIs(parsed.host, 'creativecommons.org') || hostIs(parsed.host, 'rightsstatements.org'));
 }

--- a/src/rights/commercialRights.ts
+++ b/src/rights/commercialRights.ts
@@ -1,0 +1,110 @@
+/**
+ * Shared per-record COMMERCIAL-POD rights gate, keyed on a rights URI.
+ *
+ * open-museum.art sells print-on-demand reproductions, so the rights bar is:
+ * the image must be openly licensed for COMMERCIAL use. This gate is reused by
+ * every IIIF / Linked-Art source (Rijksmuseum, NGA, SMK, Yale, Belvedere, ...)
+ * whose per-object rights are expressed as a Creative Commons / RightsStatements
+ * URI.
+ *
+ * Two non-negotiable rules from the integration research:
+ *  1. **Hard-exclude all NonCommercial (NC) and NoDerivatives (ND).** NC forbids
+ *     sale; ND forbids the crop/scale a print requires.
+ *  2. **"No known copyright" (rightsstatements.org NoC and NKC vocab) is a
+ *     liability DISCLAIMER, not a licence grant** — review-required, never auto.
+ *
+ * Auto-safe allowlist: CC0, Public Domain Mark (PD-Art), CC-BY, CC-BY-SA.
+ * Everything else — in-copyright, unknown, empty — is strict default deny.
+ */
+import type { ArtworkLicense, LicenseType } from '../types.js';
+import type { LicenseDecision } from '../licenseGate.js';
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function reject(reason: string): LicenseDecision {
+  return { accepted: false, license: null, imageOpenAccess: false, metadataOpenAccess: false, reason };
+}
+
+function accept(
+  type: LicenseType,
+  rawValue: string,
+  verificationSource: string,
+): LicenseDecision {
+  const license: ArtworkLicense = {
+    type,
+    rawValue,
+    verificationSource,
+    verifiedAt: nowIso(),
+    confidence: 'high',
+  };
+  return { accepted: true, license, imageOpenAccess: true, metadataOpenAccess: true, reason: `accepted ${type}` };
+}
+
+/**
+ * Normalize a rights URI for matching: lowercase, drop the scheme + `www.`,
+ * collapse whitespace, strip a trailing slash. Keeps the path so license codes
+ * (`by-nc-sa`) remain matchable.
+ */
+function normalize(uri: string): string {
+  return uri
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, '')
+    .replace(/^www\./, '')
+    .replace(/\/+$/, '');
+}
+
+/**
+ * Validate a rights URI for commercial-POD eligibility.
+ *
+ * @param rightsUri the per-object rights statement URI (CC or RightsStatements)
+ * @param verificationSource provenance label recorded on the license, e.g.
+ *        `"rijksmuseum.iiif.rights"`
+ */
+export function validateCommercialRights(
+  rightsUri: string | null | undefined,
+  verificationSource: string,
+): LicenseDecision {
+  if (typeof rightsUri !== 'string' || rightsUri.trim() === '') {
+    return reject('rights URI missing — strict default deny');
+  }
+  const raw = rightsUri.trim();
+  const u = normalize(raw);
+
+  // RightsStatements.org is a curatorial assertion vocabulary, NOT a licence
+  // grant. "No Copyright"/"No Known Copyright" shifts liability to the reuser;
+  // "In Copyright" is closed. None are auto-approvable for commercial sale.
+  if (u.includes('rightsstatements.org')) {
+    return reject(
+      `rights=${raw}: rightsstatements.org assertion is a disclaimer, not a licence grant — review required`,
+    );
+  }
+
+  if (u.includes('publicdomain/zero')) return accept('CC0', raw, verificationSource);
+  if (u.includes('publicdomain/mark')) return accept('PD', raw, verificationSource);
+
+  // For CC licences the code is the path segment after "licenses/", e.g.
+  // "licenses/by-nc-sa/4.0" -> "by-nc-sa". Parse the code from the segments so
+  // the NC/ND substring checks are exact (and beat the bare-"by" match, since
+  // "by-nc" contains "by").
+  const segs = u.split('/');
+  const li = segs.indexOf('licenses');
+  const code = li >= 0 && segs[li + 1] ? segs[li + 1] : '';
+  const parts = code.split('-'); // ["by","nc","sa"]
+
+  if (parts.includes('nc')) {
+    return reject(`rights=${raw}: NonCommercial (NC) — cannot be sold as a reproduction`);
+  }
+  if (parts.includes('nd')) {
+    return reject(`rights=${raw}: NoDerivatives (ND) — a print crop/scale is a derivative`);
+  }
+
+  if (u.includes('creativecommons.org') && parts[0] === 'by') {
+    if (parts.includes('sa')) return accept('CC-BY-SA', raw, verificationSource);
+    if (parts.length === 1) return accept('CC-BY', raw, verificationSource);
+  }
+
+  return reject(`rights=${raw}: unrecognized or non-open licence — strict default deny`);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,6 +28,7 @@ import { aicFetcher } from './fetchers/aic.js';
 import { clevelandFetcher } from './fetchers/cleveland.js';
 import { europeanaFetcher } from './fetchers/europeana.js';
 import { metFetcher } from './fetchers/met.js';
+import { rijksmuseumFetcher } from './fetchers/rijksmuseum.js';
 import { smithsonianFetcher, smithsonianApiKey } from './fetchers/smithsonian.js';
 import { wikimediaFetcher } from './fetchers/wikimedia.js';
 import type { Fetcher } from './fetchers/types.js';
@@ -47,6 +48,9 @@ const FETCHERS: Record<string, Fetcher> = {
   [clevelandFetcher.code]: clevelandFetcher,
   [aicFetcher.code]: aicFetcher,
   [wikimediaFetcher.code]: wikimediaFetcher,
+  // Rijksmuseum DIRECT (keyless Data Services + Micrio IIIF) — supersedes the
+  // Europeana-mediated Rijks path with richer metadata + true print pixels.
+  [rijksmuseumFetcher.code]: rijksmuseumFetcher,
 };
 
 // Europeana requires a per-user API key (free tier, 10K req/day). Only

--- a/tests/fixtures/rijksmuseum-accepted-milkmaid.json
+++ b/tests/fixtures/rijksmuseum-accepted-milkmaid.json
@@ -1,0 +1,547 @@
+{
+  "id": "rijksmuseum:200108369",
+  "object": {
+    "id": "https://id.rijksmuseum.nl/200108369",
+    "type": "HumanMadeObject",
+    "identified_by": [
+      {
+        "id": "_:b39",
+        "type": "Name",
+        "content": "The Milkmaid",
+        "classified_as": [
+          {
+            "id": "http://vocab.getty.edu/aat/300404670",
+            "type": "Type",
+            "classified_as": [
+              {
+                "id": "http://vocab.getty.edu/aat/300418049",
+                "type": "Type",
+                "_label": "brief text"
+              }
+            ]
+          },
+          {
+            "id": "http://vocab.getty.edu/aat/300417207",
+            "type": "Type"
+          }
+        ],
+        "language": [
+          {
+            "id": "http://vocab.getty.edu/aat/300388277",
+            "type": "Language"
+          }
+        ]
+      },
+      {
+        "type": "Name",
+        "content": "De melkmeid",
+        "identified_by": [
+          {
+            "type": "Identifier",
+            "content": "2",
+            "classified_as": [
+              {
+                "id": "http://vocab.getty.edu/aat/300456575",
+                "type": "Type"
+              }
+            ]
+          }
+        ],
+        "classified_as": [
+          {
+            "id": "https://id.rijksmuseum.nl/22015528",
+            "type": "Type",
+            "notation": [
+              {
+                "@language": "nl",
+                "@value": "voormalige titel"
+              },
+              {
+                "@language": "en",
+                "@value": "former title"
+              }
+            ]
+          }
+        ],
+        "language": [
+          {
+            "id": "http://vocab.getty.edu/aat/300388256",
+            "type": "Language"
+          }
+        ]
+      },
+      {
+        "id": "_:b41",
+        "type": "Name",
+        "content": "Het melkmeisje",
+        "identified_by": [
+          {
+            "id": "_:b152",
+            "type": "Identifier",
+            "content": "1",
+            "classified_as": [
+              {
+                "id": "http://vocab.getty.edu/aat/300456575",
+                "type": "Type"
+              }
+            ]
+          }
+        ],
+        "classified_as": [
+          {
+            "id": "http://vocab.getty.edu/aat/300417200",
+            "type": "Type"
+          }
+        ],
+        "language": [
+          {
+            "id": "http://vocab.getty.edu/aat/300388256",
+            "type": "Language"
+          }
+        ]
+      },
+      {
+        "type": "Name",
+        "content": "De keukenmeid",
+        "identified_by": [
+          {
+            "type": "Identifier",
+            "content": "3",
+            "classified_as": [
+              {
+                "id": "http://vocab.getty.edu/aat/300456575",
+                "type": "Type"
+              }
+            ]
+          }
+        ],
+        "classified_as": [
+          {
+            "id": "https://id.rijksmuseum.nl/22015528",
+            "type": "Type",
+            "notation": [
+              {
+                "@language": "nl",
+                "@value": "voormalige titel"
+              },
+              {
+                "@language": "en",
+                "@value": "former title"
+              }
+            ]
+          }
+        ],
+        "language": [
+          {
+            "id": "http://vocab.getty.edu/aat/300388256",
+            "type": "Language"
+          }
+        ]
+      },
+      {
+        "type": "Name",
+        "content": "The Milkmaid",
+        "identified_by": [
+          {
+            "type": "Identifier",
+            "content": "1",
+            "classified_as": [
+              {
+                "id": "http://vocab.getty.edu/aat/300456575",
+                "type": "Type"
+              }
+            ]
+          }
+        ],
+        "classified_as": [
+          {
+            "id": "http://vocab.getty.edu/aat/300417200",
+            "type": "Type"
+          }
+        ],
+        "language": [
+          {
+            "id": "http://vocab.getty.edu/aat/300388277",
+            "type": "Language"
+          }
+        ],
+        "translation_of": [
+          {
+            "id": "_:b41",
+            "type": "Name",
+            "content": "Het melkmeisje",
+            "identified_by": [
+              {
+                "id": "_:b152",
+                "type": "Identifier",
+                "content": "1",
+                "classified_as": [
+                  {
+                    "id": "http://vocab.getty.edu/aat/300456575",
+                    "type": "Type"
+                  }
+                ]
+              }
+            ],
+            "classified_as": [
+              {
+                "id": "http://vocab.getty.edu/aat/300417200",
+                "type": "Type"
+              }
+            ],
+            "language": [
+              {
+                "id": "http://vocab.getty.edu/aat/300388256",
+                "type": "Language"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "_:b44",
+        "type": "Name",
+        "content": "Het melkmeisje",
+        "classified_as": [
+          {
+            "id": "http://vocab.getty.edu/aat/300404670",
+            "type": "Type",
+            "classified_as": [
+              {
+                "id": "http://vocab.getty.edu/aat/300418049",
+                "type": "Type",
+                "_label": "brief text"
+              }
+            ]
+          },
+          {
+            "id": "http://vocab.getty.edu/aat/300417207",
+            "type": "Type"
+          }
+        ],
+        "language": [
+          {
+            "id": "http://vocab.getty.edu/aat/300388256",
+            "type": "Language"
+          }
+        ]
+      },
+      {
+        "type": "Identifier",
+        "content": "SK-A-2344",
+        "classified_as": [
+          {
+            "id": "https://id.rijksmuseum.nl/22015218",
+            "type": "Type",
+            "notation": [
+              {
+                "@language": "nl",
+                "@value": "objectnummer"
+              },
+              {
+                "@language": "en",
+                "@value": "object number"
+              }
+            ]
+          },
+          {
+            "id": "http://vocab.getty.edu/aat/300312355",
+            "type": "Type"
+          }
+        ]
+      }
+    ],
+    "produced_by": {
+      "type": "Production",
+      "timespan": {
+        "type": "TimeSpan",
+        "identified_by": [
+          {
+            "type": "Name",
+            "content": "ca. 1660",
+            "language": [
+              {
+                "id": "http://vocab.getty.edu/aat/300388256",
+                "type": "Language"
+              }
+            ]
+          },
+          {
+            "type": "Name",
+            "content": "c. 1660",
+            "language": [
+              {
+                "id": "http://vocab.getty.edu/aat/300388277",
+                "type": "Language"
+              }
+            ]
+          }
+        ],
+        "begin_of_the_begin": "1660-01-01T00:00:00Z",
+        "end_of_the_end": "1660-12-31T23:59:59Z"
+      },
+      "referred_to_by": [
+        {
+          "type": "LinguisticObject",
+          "content": "Johannes Vermeer",
+          "classified_as": [
+            {
+              "id": "http://vocab.getty.edu/aat/300435416",
+              "type": "Type"
+            }
+          ],
+          "language": [
+            {
+              "id": "http://vocab.getty.edu/aat/300388256",
+              "type": "Language"
+            }
+          ]
+        },
+        {
+          "type": "LinguisticObject",
+          "content": "Johannes Vermeer",
+          "classified_as": [
+            {
+              "id": "http://vocab.getty.edu/aat/300435416",
+              "type": "Type"
+            }
+          ],
+          "language": [
+            {
+              "id": "http://vocab.getty.edu/aat/300388277",
+              "type": "Language"
+            }
+          ]
+        }
+      ],
+      "part": [
+        {
+          "type": "Production",
+          "carried_out_by": [
+            {
+              "id": "https://id.rijksmuseum.nl/2101778",
+              "type": "Person",
+              "notation": [
+                {
+                  "@language": "en",
+                  "@value": "Johannes Vermeer"
+                },
+                {
+                  "@language": "nl",
+                  "@value": "Johannes Vermeer"
+                }
+              ],
+              "equivalent": [
+                {
+                  "id": "http://vocab.getty.edu/ulan/500032927",
+                  "type": "Person"
+                },
+                {
+                  "id": "http://www.wikidata.org/entity/Q41264",
+                  "type": "Person"
+                },
+                {
+                  "id": "http://viaf.org/viaf/51961439",
+                  "type": "Person"
+                },
+                {
+                  "id": "https://rkd.nl/artists/80476",
+                  "type": "Person"
+                },
+                {
+                  "id": "http://data.cerl.org/thesaurus/cnp01437165",
+                  "type": "Person"
+                }
+              ]
+            }
+          ],
+          "identified_by": [
+            {
+              "type": "Identifier",
+              "content": "1",
+              "classified_as": [
+                {
+                  "id": "http://vocab.getty.edu/aat/300456575",
+                  "type": "Type"
+                }
+              ]
+            }
+          ],
+          "classified_as": [
+            {
+              "id": "http://vocab.getty.edu/aat/300404450",
+              "type": "Type"
+            }
+          ],
+          "technique": [
+            {
+              "id": "https://id.rijksmuseum.nl/2202217",
+              "type": "Type",
+              "notation": [
+                {
+                  "@language": "en",
+                  "@value": "painter"
+                },
+                {
+                  "@language": "nl",
+                  "@value": "schilder"
+                }
+              ],
+              "equivalent": [
+                {
+                  "id": "http://vocab.getty.edu/aat/300025136",
+                  "type": "Type"
+                }
+              ]
+            }
+          ],
+          "referred_to_by": [
+            {
+              "type": "LinguisticObject",
+              "content": "schilder: Johannes Vermeer",
+              "classified_as": [
+                {
+                  "id": "http://vocab.getty.edu/aat/300435416",
+                  "type": "Type"
+                }
+              ],
+              "language": [
+                {
+                  "id": "http://vocab.getty.edu/aat/300388256",
+                  "type": "Language"
+                }
+              ]
+            },
+            {
+              "type": "LinguisticObject",
+              "content": "Johannes Vermeer",
+              "classified_as": [
+                {
+                  "id": "http://vocab.getty.edu/aat/300435417",
+                  "type": "Type"
+                }
+              ],
+              "language": [
+                {
+                  "id": "http://vocab.getty.edu/aat/300388277",
+                  "type": "Language"
+                }
+              ]
+            },
+            {
+              "type": "LinguisticObject",
+              "content": "Johannes Vermeer",
+              "classified_as": [
+                {
+                  "id": "http://vocab.getty.edu/aat/300435417",
+                  "type": "Type"
+                }
+              ],
+              "language": [
+                {
+                  "id": "http://vocab.getty.edu/aat/300388256",
+                  "type": "Language"
+                }
+              ]
+            },
+            {
+              "type": "LinguisticObject",
+              "content": "painter: Johannes Vermeer",
+              "classified_as": [
+                {
+                  "id": "http://vocab.getty.edu/aat/300435416",
+                  "type": "Type"
+                }
+              ],
+              "language": [
+                {
+                  "id": "http://vocab.getty.edu/aat/300388277",
+                  "type": "Language"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "classified_as": [
+      {
+        "id": "https://id.rijksmuseum.nl/2208",
+        "type": "Type",
+        "classified_as": [
+          {
+            "id": "http://vocab.getty.edu/aat/300435443",
+            "type": "Type",
+            "_label": "Type of Work"
+          }
+        ],
+        "notation": [
+          {
+            "@language": "nl",
+            "@value": "schilderij"
+          },
+          {
+            "@language": "en",
+            "@value": "painting"
+          }
+        ],
+        "equivalent": [
+          {
+            "id": "http://vocab.getty.edu/aat/300033618",
+            "type": "Type"
+          },
+          {
+            "id": "http://www.wikidata.org/entity/Q3305213",
+            "type": "Type"
+          }
+        ]
+      }
+    ]
+  },
+  "visualItem": {
+    "id": "https://id.rijksmuseum.nl/202108369",
+    "type": "VisualItem",
+    "subject_to": [
+      {
+        "type": "Right",
+        "identified_by": [
+          {
+            "type": "Name",
+            "content": "Publieke domein",
+            "language": [
+              {
+                "id": "http://vocab.getty.edu/aat/300388256",
+                "type": "Language",
+                "_label": "Dutch"
+              }
+            ]
+          },
+          {
+            "type": "Name",
+            "content": "Public Domain",
+            "language": [
+              {
+                "id": "http://vocab.getty.edu/aat/300388277",
+                "type": "Language",
+                "_label": "English"
+              }
+            ]
+          }
+        ],
+        "classified_as": [
+          {
+            "id": "https://creativecommons.org/publicdomain/mark/1.0/",
+            "type": "Type",
+            "_label": "Public Domain"
+          }
+        ]
+      }
+    ]
+  },
+  "image": {
+    "serviceBase": "https://iiif.micr.io/QkOGy",
+    "fullUrl": "https://iiif.micr.io/QkOGy/full/max/0/default.jpg",
+    "width": 4649,
+    "height": 5177
+  }
+}

--- a/tests/iiif/client.test.ts
+++ b/tests/iiif/client.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import {
+  fullImageUrl,
+  meetsPrintResolution,
+  parseInfoJson,
+  parseManifest,
+} from '../../src/iiif/client.js';
+
+const v3Manifest = {
+  '@context': 'http://iiif.io/api/presentation/3/context.json',
+  id: 'https://example.org/iiif/manifest/1',
+  type: 'Manifest',
+  label: { en: ['Sunflowers'], nl: ['Zonnebloemen'] },
+  rights: 'http://creativecommons.org/publicdomain/zero/1.0/',
+  items: [
+    {
+      type: 'Canvas',
+      width: 4000,
+      height: 5000,
+      items: [
+        {
+          type: 'AnnotationPage',
+          items: [
+            {
+              type: 'Annotation',
+              body: {
+                type: 'Image',
+                format: 'image/jpeg',
+                width: 4000,
+                height: 5000,
+                service: [{ id: 'https://img.example.org/iiif/abc', type: 'ImageService3', profile: 'level2' }],
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const v2Manifest = {
+  '@context': 'http://iiif.io/api/presentation/2/context.json',
+  '@id': 'https://example.org/iiif/manifest/2',
+  '@type': 'sc:Manifest',
+  label: 'Old Master',
+  license: 'https://creativecommons.org/licenses/by/4.0/',
+  sequences: [
+    {
+      '@type': 'sc:Sequence',
+      canvases: [
+        {
+          '@type': 'sc:Canvas',
+          width: 3200,
+          height: 2400,
+          images: [
+            {
+              '@type': 'oa:Annotation',
+              resource: {
+                '@id': 'https://img.example.org/full.jpg',
+                service: { '@id': 'https://img.example.org/iiif/xyz', '@context': 'http://iiif.io/api/image/2/context.json' },
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+describe('parseManifest — IIIF Presentation 2 + 3', () => {
+  it('extracts label, rights, image service and canvas size from a v3 manifest', () => {
+    const m = parseManifest(v3Manifest);
+    expect(m.apiVersion).toBe(3);
+    expect(m.label).toBe('Sunflowers');
+    expect(m.rights).toBe('http://creativecommons.org/publicdomain/zero/1.0/');
+    expect(m.images[0].serviceId).toBe('https://img.example.org/iiif/abc');
+    expect(m.images[0].width).toBe(4000);
+    expect(m.images[0].height).toBe(5000);
+  });
+
+  it('extracts from a v2 manifest (license field, @id service)', () => {
+    const m = parseManifest(v2Manifest);
+    expect(m.apiVersion).toBe(2);
+    expect(m.label).toBe('Old Master');
+    expect(m.rights).toBe('https://creativecommons.org/licenses/by/4.0/');
+    expect(m.images[0].serviceId).toBe('https://img.example.org/iiif/xyz');
+    expect(m.images[0].width).toBe(3200);
+  });
+
+  it('returns null rights and empty images when absent (no guessing)', () => {
+    const m = parseManifest({ '@context': 'http://iiif.io/api/presentation/3/context.json', type: 'Manifest', items: [] });
+    expect(m.rights).toBeNull();
+    expect(m.images).toEqual([]);
+  });
+});
+
+describe('fullImageUrl — IIIF Image API full-resolution request', () => {
+  it('uses /full/max for v3 and /full/full for v2', () => {
+    expect(fullImageUrl('https://img/iiif/a', 3)).toBe('https://img/iiif/a/full/max/0/default.jpg');
+    expect(fullImageUrl('https://img/iiif/a/', 3)).toBe('https://img/iiif/a/full/max/0/default.jpg');
+    expect(fullImageUrl('https://img/iiif/a', 2)).toBe('https://img/iiif/a/full/full/0/default.jpg');
+  });
+});
+
+describe('parseInfoJson — IIIF Image API info.json', () => {
+  it('reads width/height/maxWidth and api version from v3', () => {
+    const info = parseInfoJson({
+      '@context': 'http://iiif.io/api/image/3/context.json',
+      id: 'https://img/iiif/abc',
+      type: 'ImageService3',
+      width: 6000,
+      height: 7500,
+      maxWidth: 6000,
+    });
+    expect(info.width).toBe(6000);
+    expect(info.height).toBe(7500);
+    expect(info.maxWidth).toBe(6000);
+    expect(info.apiVersion).toBe(3);
+  });
+
+  it('reads v2 info.json (@context image/2)', () => {
+    const info = parseInfoJson({
+      '@context': 'http://iiif.io/api/image/2/context.json',
+      '@id': 'https://img/iiif/xyz',
+      width: 2000,
+      height: 1500,
+    });
+    expect(info.width).toBe(2000);
+    expect(info.height).toBe(1500);
+    expect(info.apiVersion).toBe(2);
+  });
+
+  it('throws on a malformed info.json (no usable dimensions)', () => {
+    expect(() => parseInfoJson({ foo: 'bar' })).toThrow();
+  });
+});
+
+describe('meetsPrintResolution — >=3000px long edge floor (print/POD bar)', () => {
+  it('passes when the long edge is at/above the floor', () => {
+    expect(meetsPrintResolution(4000, 2000)).toBe(true); // long edge 4000
+    expect(meetsPrintResolution(2000, 3000)).toBe(true); // portrait, long edge 3000
+    expect(meetsPrintResolution(3000, 1)).toBe(true); // exactly the floor
+  });
+
+  it('fails below the floor', () => {
+    expect(meetsPrintResolution(2999, 2999)).toBe(false);
+    expect(meetsPrintResolution(1800, 1200)).toBe(false);
+  });
+
+  it('honors a custom floor', () => {
+    expect(meetsPrintResolution(2500, 100, 2000)).toBe(true);
+    expect(meetsPrintResolution(2500, 100, 4000)).toBe(false);
+  });
+});

--- a/tests/rights/commercialRights.test.ts
+++ b/tests/rights/commercialRights.test.ts
@@ -85,13 +85,43 @@ describe('validateCommercialRights — commercial-POD rights gate (CC0/PDM/CC-BY
     }
   });
 
-  it('normalizes scheme/host/case/whitespace and trailing slash', () => {
+  it('tolerates surrounding whitespace, uppercase scheme/host and a trailing slash', () => {
     expect(validateCommercialRights('  HTTPS://CreativeCommons.ORG/licenses/BY/4.0  ', SRC).accepted).toBe(true);
-    expect(validateCommercialRights('creativecommons.org/publicdomain/zero/1.0', SRC).license?.type).toBe('CC0');
+    expect(validateCommercialRights('https://creativecommons.org/publicdomain/zero/1.0', SRC).license?.type).toBe('CC0');
+  });
+
+  it('rejects scheme-less rights values (an absolute http(s) URL is required for a safe hostname check)', () => {
+    expect(validateCommercialRights('creativecommons.org/publicdomain/zero/1.0', SRC).accepted).toBe(false);
   });
 
   it('does not misclassify by-nc as by (NC check precedes the bare-BY match)', () => {
     // "by-nc" contains "by" — the NC guard must win.
     expect(validateCommercialRights('https://creativecommons.org/licenses/by-nc/4.0/', SRC).accepted).toBe(false);
+  });
+
+  it('REJECTS host-spoofed licence URLs (exact hostname, not substring — CodeQL incomplete-URL-sanitization)', () => {
+    for (const u of [
+      'https://creativecommons.org.evil.com/publicdomain/zero/1.0/',
+      'https://creativecommons.org.evil.com/licenses/by/4.0/',
+      'https://evil.com/?x=creativecommons.org/licenses/by/4.0',
+      'https://evil.com/creativecommons.org/licenses/by/4.0/',
+      'https://creativecommons.org.attacker.io/licenses/by-sa/4.0/',
+      'https://notcreativecommons.org/licenses/by/4.0/',
+      'https://creativecommons.org@evil.com/licenses/by/4.0/',
+    ]) {
+      expect(validateCommercialRights(u, SRC).accepted, u).toBe(false);
+    }
+  });
+
+  it('accepts the genuine host with a path-only subdomain still rejected unless the path is a real licence', () => {
+    // wiki.creativecommons.org is a real subdomain but /faq is not a licence path
+    expect(validateCommercialRights('https://wiki.creativecommons.org/faq', SRC).accepted).toBe(false);
+    // the canonical host + path still works
+    expect(validateCommercialRights('https://creativecommons.org/licenses/by/4.0/', SRC).accepted).toBe(true);
+  });
+
+  it('rejects unparseable rights values without throwing', () => {
+    expect(validateCommercialRights('not a url', SRC).accepted).toBe(false);
+    expect(validateCommercialRights('http://', SRC).accepted).toBe(false);
   });
 });

--- a/tests/rights/commercialRights.test.ts
+++ b/tests/rights/commercialRights.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { validateCommercialRights } from '../../src/rights/commercialRights.js';
+
+const SRC = 'rijksmuseum.iiif.rights';
+
+describe('validateCommercialRights — commercial-POD rights gate (CC0/PDM/CC-BY/CC-BY-SA allow; NC/ND/unknown deny)', () => {
+  it('accepts CC0 with high confidence', () => {
+    const d = validateCommercialRights('https://creativecommons.org/publicdomain/zero/1.0/', SRC);
+    expect(d.accepted).toBe(true);
+    expect(d.license?.type).toBe('CC0');
+    expect(d.license?.confidence).toBe('high');
+    expect(d.imageOpenAccess).toBe(true);
+    expect(d.metadataOpenAccess).toBe(true);
+    expect(d.license?.verificationSource).toBe(SRC);
+  });
+
+  it('accepts the Public Domain Mark (PD-Art) as PD', () => {
+    const d = validateCommercialRights('http://creativecommons.org/publicdomain/mark/1.0/', SRC);
+    expect(d.accepted).toBe(true);
+    expect(d.license?.type).toBe('PD');
+  });
+
+  it('accepts CC-BY (any version)', () => {
+    for (const u of [
+      'https://creativecommons.org/licenses/by/4.0/',
+      'https://creativecommons.org/licenses/by/3.0/',
+      'https://creativecommons.org/licenses/by/2.0/',
+    ]) {
+      const d = validateCommercialRights(u, SRC);
+      expect(d.accepted, u).toBe(true);
+      expect(d.license?.type, u).toBe('CC-BY');
+    }
+  });
+
+  it('accepts CC-BY-SA (ShareAlike does not block commercial sale)', () => {
+    const d = validateCommercialRights('https://creativecommons.org/licenses/by-sa/4.0/', SRC);
+    expect(d.accepted).toBe(true);
+    expect(d.license?.type).toBe('CC-BY-SA');
+  });
+
+  it('REJECTS every NonCommercial variant', () => {
+    for (const u of [
+      'https://creativecommons.org/licenses/by-nc/4.0/',
+      'https://creativecommons.org/licenses/by-nc-sa/4.0/',
+      'https://creativecommons.org/licenses/by-nc-nd/4.0/',
+    ]) {
+      const d = validateCommercialRights(u, SRC);
+      expect(d.accepted, u).toBe(false);
+      expect(d.reason, u).toMatch(/non-?commercial|nc/i);
+    }
+  });
+
+  it('REJECTS every NoDerivatives variant', () => {
+    for (const u of [
+      'https://creativecommons.org/licenses/by-nd/4.0/',
+      'https://creativecommons.org/licenses/by-nc-nd/4.0/',
+    ]) {
+      const d = validateCommercialRights(u, SRC);
+      expect(d.accepted, u).toBe(false);
+      expect(d.reason, u).toMatch(/no.?deriv|nd|nc/i);
+    }
+  });
+
+  it('REJECTS rightsstatements.org "No Copyright"/"No Known Copyright" (disclaimer, not a grant — review required)', () => {
+    for (const u of [
+      'http://rightsstatements.org/vocab/NoC-US/1.0/',
+      'http://rightsstatements.org/vocab/NoC-NC/1.0/',
+      'http://rightsstatements.org/vocab/NKC/1.0/',
+    ]) {
+      const d = validateCommercialRights(u, SRC);
+      expect(d.accepted, u).toBe(false);
+      expect(d.reason, u).toMatch(/review|known copyright|disclaimer|not a grant/i);
+    }
+  });
+
+  it('REJECTS in-copyright rights statements', () => {
+    const d = validateCommercialRights('http://rightsstatements.org/vocab/InC/1.0/', SRC);
+    expect(d.accepted).toBe(false);
+  });
+
+  it('REJECTS missing/empty/unrecognized rights (strict default deny)', () => {
+    for (const u of [null, undefined, '', '   ', 'all rights reserved', 'https://example.org/license']) {
+      const d = validateCommercialRights(u as string, SRC);
+      expect(d.accepted, String(u)).toBe(false);
+    }
+  });
+
+  it('normalizes scheme/host/case/whitespace and trailing slash', () => {
+    expect(validateCommercialRights('  HTTPS://CreativeCommons.ORG/licenses/BY/4.0  ', SRC).accepted).toBe(true);
+    expect(validateCommercialRights('creativecommons.org/publicdomain/zero/1.0', SRC).license?.type).toBe('CC0');
+  });
+
+  it('does not misclassify by-nc as by (NC check precedes the bare-BY match)', () => {
+    // "by-nc" contains "by" — the NC guard must win.
+    expect(validateCommercialRights('https://creativecommons.org/licenses/by-nc/4.0/', SRC).accepted).toBe(false);
+  });
+});

--- a/tests/rijksmuseum.test.ts
+++ b/tests/rijksmuseum.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { rijksmuseumFetcher } from '../src/fetchers/rijksmuseum.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+function fixture(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(here, 'fixtures', 'rijksmuseum-accepted-milkmaid.json'), 'utf-8'));
+}
+/** deep-clone so per-test mutations don't bleed. */
+const clone = (o: unknown) => JSON.parse(JSON.stringify(o));
+
+describe('Rijksmuseum direct (Linked-Art + Micrio IIIF) normalization', () => {
+  it('normalizes The Milkmaid (Vermeer) into the Artwork shape', () => {
+    const result = rijksmuseumFetcher.normalize(fixture());
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    const a = result.artwork;
+    expect(a.id).toBe('rijksmuseum:200108369');
+    expect(a.museum.code).toBe('rijksmuseum');
+    expect(a.title).toBe('The Milkmaid');
+    expect(a.artist.name).toBe('Johannes Vermeer');
+    expect(a.artist.attributionType).toBe('named');
+    expect(a.yearStart).toBe(1660);
+    expect(a.yearEnd).toBe(1660);
+    // image rights is the PD Mark on the VisualItem
+    expect(a.license.type).toBe('PD');
+    expect(a.imageOpenAccess).toBe(true);
+    expect(a.imageUrls.full).toBe('https://iiif.micr.io/QkOGy/full/max/0/default.jpg');
+    expect(a.imageUrls.width).toBe(4649);
+    expect(a.imageUrls.height).toBe(5177);
+  });
+
+  it('REJECTS when image rights are NonCommercial (commercial-POD gate)', () => {
+    const b = clone(fixture());
+    b.visualItem.subject_to[0].classified_as[0].id = 'https://creativecommons.org/licenses/by-nc/4.0/';
+    const result = rijksmuseumFetcher.normalize(b);
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.reason).toMatch(/non-?commercial|nc/i);
+  });
+
+  it('REJECTS sub-print-resolution images (<3000px long edge)', () => {
+    const b = clone(fixture());
+    b.image.width = 1800;
+    b.image.height = 1400;
+    const result = rijksmuseumFetcher.normalize(b);
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.reason).toMatch(/resolution|3000|print/i);
+  });
+
+  it('REJECTS when no image was resolved', () => {
+    const b = clone(fixture());
+    delete b.image;
+    expect(rijksmuseumFetcher.normalize(b).status).toBe('rejected');
+  });
+
+  it('REJECTS when rights are missing entirely (strict default deny)', () => {
+    const b = clone(fixture());
+    b.visualItem.subject_to = [];
+    expect(rijksmuseumFetcher.normalize(b).status).toBe('rejected');
+  });
+
+  it('rejects garbage input gracefully', () => {
+    expect(rijksmuseumFetcher.normalize(null).status).toBe('rejected');
+    expect(rijksmuseumFetcher.normalize('nope').status).toBe('rejected');
+    expect(rijksmuseumFetcher.normalize({}).status).toBe('rejected');
+  });
+});


### PR DESCRIPTION
The **foundation** for the museum-coverage expansion (ranked catalog `om-m-museum-api-catalog-2026-06-21`), plus the first source built on it. Keyless, OSS, zero-infra (source keys via env, like Europeana).

## (1) Shared commercial-POD rights gate — `src/rights/commercialRights.ts`
The POD business model means the bar is **commercial** reuse. Reusable per-record gate keyed on a rights URI:
- **Allow:** CC0, PD-Mark (PD-Art), CC-BY, CC-BY-SA.
- **Hard-exclude:** every **NC** and **ND** variant; every `rightsstatements.org` assertion — *"No known copyright" is a liability disclaimer, not a grant* → review-required; in-copyright; unknown/missing → strict default deny.
- The NC/ND guard parses the licence **code segment** (`by-nc-sa` → `["by","nc","sa"]`) so `by-nc` can't slip through the bare-`by` match.

## (2) Reusable IIIF client — `src/iiif/client.ts`
Handles IIIF Presentation + Image API **2.x and 3.x**: parse manifest → label / rights URI / image service; parse `info.json` → real pixel dimensions; build `/full/max|full/0/default.jpg`; `meetsPrintResolution()` enforces the **≥3000px long-edge** print floor. IIIF ≠ guaranteed print size — dimensions always come from `info.json`. Unlocks the rest of the IIIF shortlist (NGA, SMK, Yale, Belvedere, Basel, Wellcome).

## (3) Rijksmuseum DIRECT — `src/fetchers/rijksmuseum.ts`
The legacy key API shut down **5 Jan 2026**; this is the new keyless **Data Services (Linked-Art JSON-LD) + Micrio IIIF 3.0**, replacing the Europeana-mediated Rijks path (richer metadata + authoritative per-object rights + true print pixels).
- `getRaw` derefs the image chain: object → `shows` VisualItem → `digitally_shown_by` DigitalObject → `access_point` Micrio URL → `info.json` for pixels.
- `normalize` judges the **image** rights (the VisualItem `subject_to` — the asset actually sold) via the commercial gate, and enforces the 3000px floor.
- **Search quality:** queries the `creator` AND `title` facets and merges — so "Vermeer" returns his paintings (The Milkmaid, The Love Letter, The Little Street) rather than reproductions *of* them.
- Registered in the federation; exported from `/core`.

## Live-verified — `npm run smoke:rijksmuseum` (real API)
```
The Night Watch / Rembrandt van Rijn / 1642 / PD / 14645x12158
The Milkmaid    / Johannes Vermeer   / c.1660 / PD / 4649x5177
The Love Letter / Johannes Vermeer   / c.1669 / PD / 5268x6064
```
All ≥3000px, rights gated per record.

## Gates (real output)
- `vitest run` → **516/516** (36 files), exit 0 — **27 new**: rights gate (accept CC0/PDM/BY/BY-SA; reject every NC/ND/NoC/InC + unknown; by-nc-not-by guard), IIIF client (v2+v3 manifest/info.json, URL building, print floor), Rijks normalize off a **real Milkmaid fixture** (accept + NC-reject + sub-print-reject + missing-image/rights + garbage).
- `tscq --noEmit` → 0 · build → 0

## Scope / safety
New `rights/`, `iiif/`, `fetchers/rijksmuseum.ts` + registration + `/core` exports + a live smoke. Existing per-museum validators and the strict rights discipline are untouched. This PR is **foundation + Rijks only**; the rest of the shortlist (MNK, NGA, SMK, Paris Musées, ...) are follow-up PRs on this foundation.

**Known follow-up (not in scope):** de-dup of Rijks records still arriving via Europeana is a ranking concern (v1.2).

## OM-CR
Re-run gates + `npm run smoke:rijksmuseum`; adversarially probe the rights gate (NC/ND/NoC bypasses, the `by-nc` vs `by` precedence); confirm the IIIF client against both v2 and v3 shapes; confirm the 3000px floor rejects sub-print images live.

Do not merge — Pramod merges.

Co-Authored by Pramod Prasanth <pramod@chainalign.com>