### PR TITLE
chore(release): 0.12.0 — coverage foundation + Rijks direct + Micrio colour fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] — 2026-06-21
+
+### Added
+
+- **Reusable IIIF client (`src/iiif/`).** Parses IIIF Presentation + Image API 2.x and 3.x: manifest → label / `rights` URI / image service; `info.json` → real pixel dimensions; builds `/full/max|full/0/default.jpg`; and `meetsPrintResolution()` enforces a ≥3000px long-edge print floor. IIIF is not a guarantee of print size, so dimensions always come from `info.json`. The shared foundation for the museum-coverage expansion. (#87)
+- **Shared commercial-POD rights gate (`src/rights/commercialRights.ts`).** `validateCommercialRights` judges a per-record rights URI for commercial print-on-demand eligibility: allow CC0, Public Domain Mark, CC-BY, CC-BY-SA; hard-exclude every NonCommercial (NC) and NoDerivatives (ND) variant; reject all `rightsstatements.org` assertions ("no known copyright" is a liability disclaimer, not a grant); strict default deny on unknown/missing. Matching uses URL parsing + exact hostname (no substring spoofing — a host like `creativecommons.org.evil.com` is rejected). (#87)
+- **Rijksmuseum direct source.** Keyless integration of the new Rijksmuseum Data Services (Linked-Art JSON-LD) + Micrio IIIF 3.0, replacing the Europeana-mediated Rijks path (richer metadata, authoritative per-object rights, true print pixels). The legacy key-based API shut down 5 Jan 2026. Per-object rights are judged by the commercial gate; images are gated to ≥3000px via `info.json`. (#87)
+- **Non-art curation gate for Wikimedia Commons + Europeana (`src/fetchers/curation.ts`).** These federations are not curated art museums — they carry diagrams, logos, charts, maps and publication pages alongside art, all correctly licensed. The gate rejects non-art (Commons: `image/svg+xml` + a word-boundary category/title denylist; Europeana: explicit non-art `dcType`) while keeping genuine artworks, with precision over recall. The rights gate is unchanged; this is an additional curation layer. (#86)
+
+### Fixed
+
+- **Colour extraction now allowlists the Rijksmuseum Micrio IIIF host (`iiif.micr.io`).** The colour facet previously failed closed for Rijksmuseum images because the host was absent from the CDN allowlist; it is now allowlisted (exact-hostname match, so look-alike hosts are still rejected).
+
+## [0.11.0] — 2026-06-18
+
+### Added
+
+- **Keyless Tier-1 delegated-attestor library (`open-museum-mcp/core`).** `prepareTier1(payloadString, imageBytes)` builds a keyless Tier-1 signing request — byte-exact payload carriage, tier-stable SHA-256 integrity (identical to Tier-0), image hard-binding, and a deterministic C2PA claim (`claimToBeSigned`) — without ever holding a key. `verifyTier1` is the public-key-only, fail-closed verifier (`ATTESTED_DELEGATE` only when integrity, signature, signer-resolves-to-`attestor.did`, `attestor.did != actor`, and bound-asset all hold; otherwise `REJECTED`, never silently downgraded). Exports the pinned COSE primitives (`coseSigStructure`, `assembleCoseSign1`, `COSE_PROTECTED_EDDSA`) so the OMA signing service signs identical bytes verbatim. (#84)
+- **Smithsonian Open Access (EDAN) source.** Federated as an additional source with strict CC0 validation and a non-art `object_type` curation gate (rejects Library books and Natural History specimens). Enabled when `SMITHSONIAN_API_KEY` (or the `SI_API_KEY` alias) is set. (#79, #82)
+
 ## [0.10.2] — 2026-06-10
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-museum-mcp",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-museum-mcp",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-museum-mcp",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "MCP server for license-verified search across open-access museum collections (The Met, Cleveland, AIC, Wikimedia Commons, Europeana).",
   "type": "module",
   "main": "dist/server.js",

--- a/src/color/extract.ts
+++ b/src/color/extract.ts
@@ -114,6 +114,7 @@ const CDN_ALLOWLIST = new Set([
   'commons.wikimedia.org',           // Wikimedia Commons (some thumb paths)
   'api.europeana.eu',                // Europeana thumbnail proxy
   'ids.si.edu',                      // Smithsonian IDS image server (deliveryService + IIIF)
+  'iiif.micr.io',                    // Rijksmuseum images via Micrio IIIF (data.rijksmuseum.nl)
   // Europeana edmIsShownBy (full images) comes from arbitrary per-provider
   // CDNs — those are intentionally NOT listed here and will fail open.
 ]);

--- a/tests/color/extract.test.ts
+++ b/tests/color/extract.test.ts
@@ -1,6 +1,20 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createColorExtractor, type SharpLike } from '../../src/color/extract.js';
+import { createColorExtractor, isAllowlistedImageHost, type SharpLike } from '../../src/color/extract.js';
 import type { Artwork } from '../../src/types.js';
+
+describe('isAllowlistedImageHost — CDN allowlist (exact hostname)', () => {
+  it('allows the Rijksmuseum Micrio IIIF host (OM-CR N1: colour facet no longer fails closed)', () => {
+    expect(isAllowlistedImageHost('https://iiif.micr.io/QkOGy/full/max/0/default.jpg')).toBe(true);
+  });
+  it('still rejects a look-alike host (no substring spoofing)', () => {
+    expect(isAllowlistedImageHost('https://iiif.micr.io.evil.com/x.jpg')).toBe(false);
+    expect(isAllowlistedImageHost('https://evil.com/?x=iiif.micr.io')).toBe(false);
+  });
+  it('keeps the existing hosts allowed', () => {
+    expect(isAllowlistedImageHost('https://ids.si.edu/ids/deliveryService?id=x')).toBe(true);
+    expect(isAllowlistedImageHost('https://images.metmuseum.org/full.jpg')).toBe(true);
+  });
+});
 
 function artwork(over: Partial<Artwork['imageUrls']> = {}): Artwork {
   return {


### PR DESCRIPTION
**DRAFT release** for **open-museum-mcp@0.12.0**. Bumps `0.11.0 → 0.12.0` (minor — additive coverage foundation + a new source). Opened as a draft per the standing review gate.

## What this release ships
Already merged to main:
- Reusable **IIIF client** + shared **commercial-POD rights gate** + **Rijksmuseum direct** source (#87).
- **Non-art curation gate** for Wikimedia + Europeana (#86).

New in this PR:
- **`color`: add `iiif.micr.io` to `CDN_ALLOWLIST`** so the colour facet no longer fails closed for Rijksmuseum (Micrio IIIF) images. Exact-hostname match, so look-alike hosts are still rejected. *(OM-CR non-blocking finding N1.)*
- **CHANGELOG**: adds the 0.12.0 entry and **backfills the previously-missing 0.11.0 entry** (keyless Tier-1 attestor library + Smithsonian source).

## Gates (real output)
- `vitest run` → **523/523** (36 files), exit 0 — +3 colour-allowlist tests (`iiif.micr.io` allowed; look-alike + query-string spoof rejected; existing hosts intact).
- `tscq --noEmit` → 0 · build → 0

## Publish flow (Pramod, after merge)
```
git checkout main && git pull
npm run build
npm publish
```
After publish, OMA bumps its pin to `open-museum-mcp@^0.12.0` (OM-OR dispatches OM-A separately).

**Do not merge, do not publish — Pramod merges + publishes.**

Co-Authored by Pramod Prasanth <pramod@chainalign.com>