### PR TITLE
fix(images): serve true-max image URLs + expose maxResolution/master

### DIFF
--- a/src/fetchers/aic.ts
+++ b/src/fetchers/aic.ts
@@ -152,9 +152,15 @@ export const aicFetcher: Fetcher = {
     const region = normalizeRegion(asString(r.place_of_origin));
 
     const imageId = asString(r.image_id);
-    // AIC publishes through IIIF Image API 2.0. 843px-wide is AIC's
-    // standard public-display size; 200px-wide is the thumbnail tier.
-    const fullImage = imageId ? `${AIC_IIIF}/${imageId}/full/843,/0/default.jpg` : '';
+    // AIC publishes through IIIF Image API 2.x. `/full/843,/` is AIC's standard
+    // public-DISPLAY size — but the source holds the full scan at 3.5–4× that
+    // (e.g. a Tokaido plate is 843px wide via this size and ~3500px via `max`).
+    // `/full/max/` returns the largest the IIIF server will produce (AIC's level-2
+    // profile supports it; `max` was added in Image API 2.1 and AIC honors it),
+    // so we ask for the true maximum here and keep 200px as the thumbnail tier.
+    // AIC's data API publishes no PIXEL dimensions (only physical cm), so
+    // `width`/`height`/`maxResolution` stay unset rather than carrying a guess.
+    const fullImage = imageId ? `${AIC_IIIF}/${imageId}/full/max/0/default.jpg` : '';
     const thumbnail = imageId ? `${AIC_IIIF}/${imageId}/full/200,/0/default.jpg` : undefined;
 
     const artwork: Artwork = {

--- a/src/fetchers/cleveland.ts
+++ b/src/fetchers/cleveland.ts
@@ -7,8 +7,10 @@ import {
   asFiniteNumber,
   asOptionalString,
   asString,
+  coerceFiniteNumber,
   httpGet,
   isValidPositiveInt,
+  pickMaxResolution,
   rejectFor,
 } from './helpers.js';
 import { sanitizeArtistName, sanitizeTitle } from './sanitize.js';
@@ -128,11 +130,38 @@ export const clevelandFetcher: Fetcher = {
     const images = (r.images && typeof r.images === 'object' ? r.images : {}) as Record<string, unknown>;
     const printVariant = images.print as Record<string, unknown> | undefined;
     const webVariant = images.web as Record<string, unknown> | undefined;
-    // Prefer the higher-resolution `print` URL when both are available; fall
-    // back to `web` (smaller display image). The full TIFF is too large for
-    // most consumer use cases, so we don't surface it.
-    const fullImage = asString(printVariant?.url) || asString(webVariant?.url);
+    const fullVariant = images.full as Record<string, unknown> | undefined;
+    // Displayable image: prefer the `print` JPEG (~3400px, renders in <img>),
+    // fall back to `web`. We deliberately do NOT put the `full` asset here —
+    // it's a multi-hundred-MB TIFF that no browser renders.
+    const displayVariant = asString(printVariant?.url) ? printVariant : webVariant;
+    const fullImage = asString(displayVariant?.url);
     const thumbnail = asOptionalString(webVariant?.url);
+    const displayWidth = coerceFiniteNumber(displayVariant?.width) ?? undefined;
+    const displayHeight = coerceFiniteNumber(displayVariant?.height) ?? undefined;
+    const displayBytes = coerceFiniteNumber(displayVariant?.filesize) ?? undefined;
+
+    // Archival master: the `_full.tif` (e.g. 11966×7990, orders of magnitude
+    // larger than `print`). Surfaced as `master` so print/POD consumers can reach
+    // the true maximum, while `full` stays browser-safe. TIFF is flagged via
+    // `format` so consumers know it needs conversion before an <img>.
+    const masterUrl = asString(fullVariant?.url);
+    const masterWidth = coerceFiniteNumber(fullVariant?.width) ?? undefined;
+    const masterHeight = coerceFiniteNumber(fullVariant?.height) ?? undefined;
+    const master = masterUrl
+      ? {
+          url: masterUrl,
+          width: masterWidth,
+          height: masterHeight,
+          format: /\.tif{1,2}$/i.test(masterUrl) ? 'image/tiff' : undefined,
+          byteSize: coerceFiniteNumber(fullVariant?.filesize) ?? undefined,
+        }
+      : undefined;
+
+    const maxResolution = pickMaxResolution(
+      { width: masterWidth, height: masterHeight },
+      { width: displayWidth, height: displayHeight },
+    );
 
     const artwork: Artwork = {
       id,
@@ -158,6 +187,11 @@ export const clevelandFetcher: Fetcher = {
       imageUrls: {
         full: fullImage,
         thumbnail,
+        width: displayWidth,
+        height: displayHeight,
+        byteSize: displayBytes,
+        master,
+        maxResolution,
       },
       imageOpenAccess: decision.imageOpenAccess,
       metadataOpenAccess: decision.metadataOpenAccess,

--- a/src/fetchers/helpers.ts
+++ b/src/fetchers/helpers.ts
@@ -54,6 +54,46 @@ export function asFiniteNumber(v: unknown): number | null {
 }
 
 /**
+ * Coerce a number OR a numeric string to a finite number, else null. Cleveland
+ * publishes image `width`/`height`/`filesize` as strings ("11966"); this accepts
+ * both shapes without the caller string-juggling at every field.
+ */
+export function coerceFiniteNumber(v: unknown): number | null {
+  if (typeof v === 'number') return Number.isFinite(v) ? v : null;
+  if (typeof v === 'string' && v.trim() !== '') {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+/**
+ * Pick the TRUE-maximum pixel dimensions from a set of candidate image variants
+ * (displayable derivative, archival master, mirror impressions). Ranks by pixel
+ * AREA so a portrait master out-scores a wider-but-shorter derivative. Candidates
+ * missing either dimension are ignored; returns `undefined` when none qualify, so
+ * `imageUrls.maxResolution` stays absent rather than carrying a half-known size.
+ */
+export function pickMaxResolution(
+  ...candidates: Array<{ width?: number; height?: number } | undefined>
+): { width: number; height: number } | undefined {
+  let best: { width: number; height: number } | undefined;
+  let bestArea = 0;
+  for (const c of candidates) {
+    if (!c) continue;
+    const w = asFiniteNumber(c.width);
+    const h = asFiniteNumber(c.height);
+    if (w === null || h === null || w <= 0 || h <= 0) continue;
+    const area = w * h;
+    if (area > bestArea) {
+      bestArea = area;
+      best = { width: w, height: h };
+    }
+  }
+  return best;
+}
+
+/**
  * True when `v` is a valid museum-side artwork ID: a positive integer.
  * Every adapter's `normalize()` makes this exact check before assembling
  * an `<museum>:<id>` string, so it lives here once.

--- a/src/fetchers/rijksmuseum.ts
+++ b/src/fetchers/rijksmuseum.ts
@@ -19,7 +19,7 @@ import { normalizeMedium } from '../medium.js';
 import { isRightsUri, validateCommercialRights } from '../rights/commercialRights.js';
 import { fetchInfoJson, meetsPrintResolution } from '../iiif/client.js';
 import type { Artwork, ValidationResult } from '../types.js';
-import { httpGet, rejectFor } from './helpers.js';
+import { httpGet, pickMaxResolution, rejectFor } from './helpers.js';
 import { ARTIST_NAME_MAX, TITLE_MAX } from './sanitize.js';
 import type { Fetcher, SearchOptions } from './types.js';
 
@@ -262,6 +262,9 @@ export const rijksmuseumFetcher: Fetcher = {
         thumbnail: undefined,
         width: width || undefined,
         height: height || undefined,
+        // The IIIF `/full/max/` request already serves the source maximum, and
+        // `width`/`height` come straight from info.json — so they ARE the true max.
+        maxResolution: pickMaxResolution({ width: width || undefined, height: height || undefined }),
       },
       imageOpenAccess: decision.imageOpenAccess,
       metadataOpenAccess: decision.metadataOpenAccess,

--- a/src/fetchers/smithsonian.ts
+++ b/src/fetchers/smithsonian.ts
@@ -2,8 +2,15 @@ import { parseDisplayDate } from '../dateParser.js';
 import { validateSmithsonianLicense } from '../licenseGate.js';
 import { cleanArtistName, detectAttributionType, normalizeRegion } from '../mappings.js';
 import { normalizeMedium } from '../medium.js';
-import type { Artwork, ValidationResult } from '../types.js';
-import { asFiniteNumber, asOptionalString, asString, httpGet, rejectFor } from './helpers.js';
+import type { Artwork, ArtworkMaster, ValidationResult } from '../types.js';
+import {
+  asFiniteNumber,
+  asOptionalString,
+  asString,
+  httpGet,
+  pickMaxResolution,
+  rejectFor,
+} from './helpers.js';
 import { sanitizeArtistName, sanitizeTitle } from './sanitize.js';
 import type { Fetcher, SearchOptions } from './types.js';
 
@@ -165,16 +172,42 @@ interface SiMedia {
   resources?: unknown;
 }
 
+interface PickedImage {
+  full: string;
+  thumbnail?: string;
+  width?: number;
+  height?: number;
+  master?: ArtworkMaster;
+  maxResolution?: { width: number; height: number };
+}
+
+/** Pixel dims of a resource entry, or undefined when not both published. */
+function resourceDims(r: Record<string, unknown> | undefined): { width?: number; height?: number } {
+  if (!r) return {};
+  const w = asFiniteNumber(r.width);
+  const h = asFiniteNumber(r.height);
+  return { width: w !== null && w > 0 ? w : undefined, height: h !== null && h > 0 ? h : undefined };
+}
+
 /**
  * Select the primary image media from `online_media.media[]`. Returns the
- * delivery URL + thumbnail + (when published) pixel dimensions, but ONLY when
+ * displayable URL + thumbnail + (when published) pixel dimensions, but ONLY when
  * the chosen media's own `usage.access` is CC0 — a metadata-CC0 record whose
  * image carries usage conditions surfaces no image (imageOpenAccess=false).
+ *
+ * IMAGE-RESOLUTION FIX: `media.content` points at `ids.si.edu/.../deliveryService`,
+ * which caps the long edge at ~2000px (verified live: a 2900×4362 master serves as
+ * 1330×2000 from deliveryService). The `resources[]` array already carries a
+ * "High-resolution JPEG" entry with the FULL pixels and a direct `download?id=…jpg`
+ * URL (the same image, browser-displayable). Prefer that resource URL + its dims;
+ * fall back to deliveryService only when no hi-res resource is published. (SI's
+ * IIIF endpoint 400s on `/full/max/` for these ids, so we use the published
+ * resource rather than an info.json round-trip — no extra request, true max.)
  */
 function pickImage(
   content: Record<string, unknown>,
   imageOpenAccess: boolean,
-): { full: string; thumbnail?: string; width?: number; height?: number } {
+): PickedImage {
   if (!imageOpenAccess) return { full: '' };
   const dnr = content.descriptiveNonRepeating;
   const om =
@@ -191,27 +224,36 @@ function pickImage(
   const media = mediaArr.find((m) => asString(m.type).toLowerCase() === 'images') ?? mediaArr[0];
   if (!media) return { full: '' };
 
-  const full = asString(media.content);
   const thumbnail = asOptionalString(media.thumbnail);
-
-  // Mine published pixel dimensions from the high-res rendition for the
-  // additive imageUrls.width/height fields (DX). Prefer JPEG over TIFF.
-  let width: number | undefined;
-  let height: number | undefined;
   const resources = Array.isArray(media.resources)
     ? (media.resources as Array<Record<string, unknown>>)
     : [];
   const jpeg = resources.find((r) => /jpeg|jpg/i.test(asString(r.label)));
   const tiff = resources.find((r) => /tiff|tif/i.test(asString(r.label)));
-  const dims = jpeg ?? tiff;
-  if (dims) {
-    const w = asFiniteNumber(dims.width);
-    const h = asFiniteNumber(dims.height);
-    if (w !== null && w > 0) width = w;
-    if (h !== null && h > 0) height = h;
-  }
+  const jpegDims = resourceDims(jpeg);
+  const tiffDims = resourceDims(tiff);
 
-  return { full, thumbnail, width, height };
+  // Displayable `full`: the hi-res JPEG resource (true max, renders in <img>),
+  // falling back to the capped deliveryService URL only when no hi-res JPEG URL.
+  const jpegUrl = asString(jpeg?.url);
+  const full = jpegUrl || asString(media.content);
+  const usingHiRes = Boolean(jpegUrl);
+  const width = usingHiRes ? jpegDims.width : undefined;
+  const height = usingHiRes ? jpegDims.height : undefined;
+
+  // Archival master: a TIFF resource, when published and strictly larger than the
+  // displayable JPEG. Non-<img>-renderable, so flagged with `format`.
+  const tiffUrl = asString(tiff?.url);
+  const tiffArea = (tiffDims.width ?? 0) * (tiffDims.height ?? 0);
+  const jpegArea = (jpegDims.width ?? 0) * (jpegDims.height ?? 0);
+  const master: ArtworkMaster | undefined =
+    tiffUrl && tiffArea > jpegArea
+      ? { url: tiffUrl, width: tiffDims.width, height: tiffDims.height, format: 'image/tiff' }
+      : undefined;
+
+  const maxResolution = pickMaxResolution(jpegDims, tiffDims);
+
+  return { full, thumbnail, width, height, master, maxResolution };
 }
 
 // Canonical env var is SMITHSONIAN_API_KEY (matches the EUROPEANA_API_KEY
@@ -388,6 +430,8 @@ export const smithsonianFetcher: Fetcher = {
         thumbnail: image.thumbnail,
         width: image.width,
         height: image.height,
+        master: image.master,
+        maxResolution: image.maxResolution,
       },
       imageOpenAccess: decision.imageOpenAccess,
       metadataOpenAccess: decision.metadataOpenAccess,

--- a/src/fetchers/wikimedia.ts
+++ b/src/fetchers/wikimedia.ts
@@ -2,7 +2,7 @@ import { parseDisplayDate } from '../dateParser.js';
 import { validateWikimediaLicense } from '../licenseGate.js';
 import { cleanArtistName, detectAttributionType } from '../mappings.js';
 import { normalizeMedium } from '../medium.js';
-import type { Artwork, ValidationResult } from '../types.js';
+import type { Artwork, ArtworkMaster, ValidationResult } from '../types.js';
 import { isNonArtWikimedia } from './curation.js';
 import {
   asFiniteNumber,
@@ -22,6 +22,32 @@ const COMMONS_PAGE = 'https://commons.wikimedia.org/wiki';
 // videos, audio and other media too; v0.3 surfaces only static images so the
 // `imageUrls.full` contract holds.
 const IMAGE_MIME_PREFIX = 'image/';
+
+// MIME types a browser renders directly in an `<img>`. Commons ALSO hosts art
+// scans whose original is a TIFF/DjVu/XCF — those pass the `image/` prefix and
+// can survive the curation gate (a raster TIFF is a legitimate artwork), but a
+// browser won't render them. Per the `full = always displayable` contract (PR
+// #105), a non-displayable original is routed to `master` and `full` is set to a
+// Commons-rendered JPEG derivative. Positive allowlist: anything NOT in this set
+// is treated as non-displayable.
+const DISPLAYABLE_IMAGE_MIMES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
+
+// Width of the rendered displayable derivative requested for non-`<img>` originals
+// (via `iiurlwidth`, with `Special:FilePath?width=` as the no-extra-data fallback).
+// MediaWiki never upscales past the original, so this is an upper bound, not a force.
+const WIKIMEDIA_DISPLAY_WIDTH = 2048;
+
+/**
+ * Stable Commons render URL for a file at a given width. `Special:FilePath` 302s
+ * to the rendered thumbnail; for a non-web original (TIFF/DjVu) that thumbnail is
+ * a JPEG/PNG, so this yields a browser-displayable `full` without the upload-path
+ * hash. Used as the fallback when imageinfo's `thumburl` is absent.
+ */
+function commonsRenderUrl(pageTitle: string, width: number): string {
+  const file = pageTitle.replace(/^File:/i, '').trim();
+  if (!file) return '';
+  return `${COMMONS_PAGE}/Special:FilePath/${encodeURIComponent(file)}?width=${width}`;
+}
 
 const reject = (id: string, reason: string, rawSnapshot: unknown): ValidationResult =>
   rejectFor('wikimedia', id, reason, rawSnapshot);
@@ -231,6 +257,10 @@ export const wikimediaFetcher: Fetcher = {
     // creation dates ("1910s paintings by Claude Monet" etc).
     url.searchParams.set('prop', 'imageinfo|categories');
     url.searchParams.set('iiprop', 'url|size|mime|extmetadata');
+    // Ask for a rendered-thumbnail URL too. For browser-displayable originals
+    // (JPEG/PNG/…) we ignore it and serve the full original; for a non-`<img>`
+    // original (TIFF/DjVu) `thumburl` is the Commons-rendered JPEG we put in `full`.
+    url.searchParams.set('iiurlwidth', String(WIKIMEDIA_DISPLAY_WIDTH));
     url.searchParams.set(
       'iiextmetadatafilter',
       'License|LicenseShortName|LicenseUrl|UsageTerms|Artist|ObjectName|DateTime|Credit|ImageDescription',
@@ -341,11 +371,50 @@ export const wikimediaFetcher: Fetcher = {
       if (fromCats) dateRange = fromCats;
     }
 
-    const fullImage = asString(info.url);
     const pageUrl = asString(info.descriptionurl) || `${COMMONS_PAGE}/?curid=${pageId}`;
-    const width = asFiniteNumber(info.width) ?? undefined;
-    const height = asFiniteNumber(info.height) ?? undefined;
-    const byteSize = asFiniteNumber(info.size) ?? undefined;
+    const originalImageUrl = asString(info.url);
+    const originalWidth = asFiniteNumber(info.width) ?? undefined;
+    const originalHeight = asFiniteNumber(info.height) ?? undefined;
+    const originalBytes = asFiniteNumber(info.size) ?? undefined;
+
+    // `full` must be browser-`<img>`-renderable (PR #105 contract). When the
+    // Commons original already is (JPEG/PNG/…), it's also the maximum — serve it
+    // directly. When it isn't (e.g. a TIFF art scan), route the original to
+    // `master` and serve a Commons-rendered JPEG as `full`; `maxResolution` still
+    // reports the original (master) pixels — the true max.
+    let fullImage: string;
+    let width: number | undefined;
+    let height: number | undefined;
+    let byteSize: number | undefined;
+    let master: ArtworkMaster | undefined;
+    const maxResolution = pickMaxResolution({ width: originalWidth, height: originalHeight });
+
+    if (DISPLAYABLE_IMAGE_MIMES.has(mime)) {
+      fullImage = originalImageUrl;
+      width = originalWidth;
+      height = originalHeight;
+      byteSize = originalBytes;
+    } else {
+      const rendered = asString(info.thumburl) || commonsRenderUrl(asString(page.title), WIKIMEDIA_DISPLAY_WIDTH);
+      if (!rendered) {
+        // No displayable rendition obtainable — we can't honor the `full`
+        // contract, so reject rather than emit a non-renderable TIFF as `full`.
+        return reject(id, `wikimedia: ${mime} original has no browser-displayable rendition`, raw);
+      }
+      fullImage = rendered;
+      width = asFiniteNumber(info.thumbwidth) ?? undefined;
+      height = asFiniteNumber(info.thumbheight) ?? undefined;
+      // The original is strictly larger than the 2048px-capped derivative, so
+      // `maxResolution` (initialised from the original dims above) already reports
+      // the master's pixels — the true max.
+      master = {
+        url: originalImageUrl,
+        width: originalWidth,
+        height: originalHeight,
+        format: mime,
+        byteSize: originalBytes,
+      };
+    }
     // Credit field is HTML; pull out the first http(s) href as the upstream
     // pointer. Important: don't strip HTML before extracting — stripHtml
     // would discard the `<a href>` we need.
@@ -393,10 +462,8 @@ export const wikimediaFetcher: Fetcher = {
         width,
         height,
         byteSize,
-        // Commons serves the original upload as `full`, so it already IS the
-        // maximum — surface it as maxResolution so consumers rank Commons works
-        // on the same true-max field as every other source.
-        maxResolution: pickMaxResolution({ width, height }),
+        master,
+        maxResolution,
       },
       imageOpenAccess: decision.imageOpenAccess,
       metadataOpenAccess: decision.metadataOpenAccess,

--- a/src/fetchers/wikimedia.ts
+++ b/src/fetchers/wikimedia.ts
@@ -4,7 +4,14 @@ import { cleanArtistName, detectAttributionType } from '../mappings.js';
 import { normalizeMedium } from '../medium.js';
 import type { Artwork, ValidationResult } from '../types.js';
 import { isNonArtWikimedia } from './curation.js';
-import { asFiniteNumber, asString, httpGet, isValidPositiveInt, rejectFor } from './helpers.js';
+import {
+  asFiniteNumber,
+  asString,
+  httpGet,
+  isValidPositiveInt,
+  pickMaxResolution,
+  rejectFor,
+} from './helpers.js';
 import { ARTIST_NAME_MAX, DESCRIPTION_MAX, TITLE_MAX } from './sanitize.js';
 import type { Fetcher, SearchOptions } from './types.js';
 
@@ -386,6 +393,10 @@ export const wikimediaFetcher: Fetcher = {
         width,
         height,
         byteSize,
+        // Commons serves the original upload as `full`, so it already IS the
+        // maximum — surface it as maxResolution so consumers rank Commons works
+        // on the same true-max field as every other source.
+        maxResolution: pickMaxResolution({ width, height }),
       },
       imageOpenAccess: decision.imageOpenAccess,
       metadataOpenAccess: decision.metadataOpenAccess,

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,16 +31,47 @@ export interface ArtworkLicense {
   confidence: RightsConfidence;
 }
 
+/**
+ * Print/archival master image — the largest asset the museum publishes, which
+ * may be NON-DISPLAYABLE in a browser `<img>` (e.g. a multi-hundred-MB TIFF) or
+ * simply too large for screen use. Distinct from `ArtworkImages.full`, which is
+ * always a browser-renderable derivative. Present only when a master exists that
+ * is genuinely larger than `full`; absent when `full` already is the maximum the
+ * source offers (then `maxResolution` mirrors the `full` dims).
+ */
+export interface ArtworkMaster {
+  url: string;
+  width?: number;
+  height?: number;
+  /** MIME type, e.g. `image/tiff` or `image/jpeg`. Flags non-`<img>` masters. */
+  format?: string;
+  byteSize?: number;
+}
+
 export interface ArtworkImages {
+  /** Browser-displayable image (safe for `<img>`). Always a renderable derivative. */
   full: string;
   large?: string;
   thumbnail?: string;
-  /** Pixel width of the `full` asset, when the museum publishes it. */
+  /** Pixel width of the `full` (displayable) asset, when the museum publishes it. */
   width?: number;
-  /** Pixel height of the `full` asset, when the museum publishes it. */
+  /** Pixel height of the `full` (displayable) asset, when the museum publishes it. */
   height?: number;
   /** Byte size of the `full` asset, when the museum publishes it. */
   byteSize?: number;
+  /**
+   * Print/archival master when it is strictly larger than `full` (e.g. Cleveland's
+   * `_full.tif`). Absent when `full` already is the source maximum. See {@link ArtworkMaster}.
+   */
+  master?: ArtworkMaster;
+  /**
+   * TRUE maximum pixel dimensions available for this work, across `full` AND
+   * `master`. The single field the OMA image-quality filter and calendar plate
+   * selection should rank on — so consumers never under-rate a work by reading a
+   * default-size derivative's dims. Absent only when the source publishes no
+   * pixel dimensions at all (e.g. AIC's data API). Additive v0.13 field.
+   */
+  maxResolution?: { width: number; height: number };
 }
 
 export interface ArtworkSource {

--- a/tests/aic.test.ts
+++ b/tests/aic.test.ts
@@ -36,9 +36,12 @@ describe('AIC adapter normalization', () => {
     expect(a.license.rawValue).toBe('true');
     expect(a.imageOpenAccess).toBe(true);
     expect(a.metadataOpenAccess).toBe(true);
+    // `full` requests the IIIF source maximum (`/full/max/`), not the 843px
+    // public-display size — AIC holds the scan at 3.5–4× that. Thumbnail stays 200px.
     expect(a.imageUrls.full).toBe(
-      'https://www.artic.edu/iiif/2/3c27b499-af56-f0d5-93b5-a7f2f1ad5813/full/843,/0/default.jpg',
+      'https://www.artic.edu/iiif/2/3c27b499-af56-f0d5-93b5-a7f2f1ad5813/full/max/0/default.jpg',
     );
+    expect(a.imageUrls.full).not.toContain('/full/843,/');
     expect(a.imageUrls.thumbnail).toContain('/full/200,/');
     expect(a.source.pageUrl).toBe('https://www.artic.edu/artworks/16568');
     expect(a.source.apiUrl).toContain('api.artic.edu');

--- a/tests/cleveland.test.ts
+++ b/tests/cleveland.test.ts
@@ -127,3 +127,46 @@ describe('Cleveland adapter mediumCategory', () => {
     expect(result.artwork.mediumCategory).toBe('other');
   });
 });
+
+describe('Cleveland adapter image resolution (master/displayable split + maxResolution)', () => {
+  // Regression guard for the image-resolution miss: Cleveland's `_full.tif`
+  // master (11512×11476) was previously discarded; `full` served the 3400px
+  // `_print.jpg` and no true-max signal was exposed.
+  it('serves the print JPEG as the displayable `full`, with its dims', () => {
+    const result = clevelandFetcher.normalize(fixture('cleveland-accepted.json'));
+    if (result.status !== 'accepted') throw new Error('expected accepted');
+    const iu = result.artwork.imageUrls;
+    expect(iu.full).toContain('_print.jpg');
+    expect(iu.full).not.toContain('.tif'); // never a non-displayable TIFF in `full`
+    expect(iu.width).toBe(3400);
+    expect(iu.height).toBe(3389);
+  });
+
+  it('surfaces the `_full.tif` archival master with dims and an image/tiff format flag', () => {
+    const result = clevelandFetcher.normalize(fixture('cleveland-accepted.json'));
+    if (result.status !== 'accepted') throw new Error('expected accepted');
+    const m = result.artwork.imageUrls.master;
+    expect(m?.url).toContain('_full.tif');
+    expect(m?.width).toBe(11512);
+    expect(m?.height).toBe(11476);
+    expect(m?.format).toBe('image/tiff');
+  });
+
+  it('reports the TRUE maximum dimensions (the TIFF master, not the print derivative)', () => {
+    const result = clevelandFetcher.normalize(fixture('cleveland-accepted.json'));
+    if (result.status !== 'accepted') throw new Error('expected accepted');
+    expect(result.artwork.imageUrls.maxResolution).toEqual({ width: 11512, height: 11476 });
+  });
+
+  it('omits the master (and maxResolution falls back to print) when no `_full.tif` is published', () => {
+    const raw = structuredClone(fixture('cleveland-accepted.json')) as {
+      data: { images: Record<string, unknown> };
+    };
+    delete raw.data.images.full;
+    const result = clevelandFetcher.normalize(raw);
+    if (result.status !== 'accepted') throw new Error('expected accepted');
+    const iu = result.artwork.imageUrls;
+    expect(iu.master).toBeUndefined();
+    expect(iu.maxResolution).toEqual({ width: 3400, height: 3389 });
+  });
+});

--- a/tests/fetchers/helpers.test.ts
+++ b/tests/fetchers/helpers.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { coerceFiniteNumber, pickMaxResolution } from '../../src/fetchers/helpers.js';
+
+describe('coerceFiniteNumber', () => {
+  it('passes finite numbers through', () => {
+    expect(coerceFiniteNumber(11966)).toBe(11966);
+    expect(coerceFiniteNumber(0)).toBe(0);
+    expect(coerceFiniteNumber(-5)).toBe(-5);
+  });
+
+  it('parses numeric strings (Cleveland publishes dims as strings)', () => {
+    expect(coerceFiniteNumber('11966')).toBe(11966);
+    expect(coerceFiniteNumber('  7990  ')).toBe(7990);
+  });
+
+  it('returns null for non-finite, empty, or non-numeric values', () => {
+    expect(coerceFiniteNumber('')).toBeNull();
+    expect(coerceFiniteNumber('   ')).toBeNull();
+    expect(coerceFiniteNumber('abc')).toBeNull();
+    expect(coerceFiniteNumber(NaN)).toBeNull();
+    expect(coerceFiniteNumber(Infinity)).toBeNull();
+    expect(coerceFiniteNumber(null)).toBeNull();
+    expect(coerceFiniteNumber(undefined)).toBeNull();
+    expect(coerceFiniteNumber({})).toBeNull();
+  });
+});
+
+describe('pickMaxResolution', () => {
+  it('picks the candidate with the largest pixel AREA (portrait master beats wide derivative)', () => {
+    // A 3400×2270 wide derivative vs an 11966×7990 master — master wins by area.
+    expect(
+      pickMaxResolution({ width: 3400, height: 2270 }, { width: 11966, height: 7990 }),
+    ).toEqual({ width: 11966, height: 7990 });
+  });
+
+  it('ignores candidates missing either dimension', () => {
+    expect(
+      pickMaxResolution({ width: 2900 }, { width: 2900, height: 4362 }),
+    ).toEqual({ width: 2900, height: 4362 });
+  });
+
+  it('ignores zero/negative/undefined candidates and returns undefined when none qualify', () => {
+    expect(pickMaxResolution(undefined, { width: 0, height: 100 }, { width: -1, height: -1 })).toBeUndefined();
+    expect(pickMaxResolution()).toBeUndefined();
+    expect(pickMaxResolution(undefined)).toBeUndefined();
+  });
+
+  it('handles a single valid candidate (the common max-already case)', () => {
+    expect(pickMaxResolution({ width: 4649, height: 5177 })).toEqual({ width: 4649, height: 5177 });
+  });
+});

--- a/tests/smithsonian.test.ts
+++ b/tests/smithsonian.test.ts
@@ -45,10 +45,15 @@ describe('Smithsonian adapter normalization', () => {
     expect(a.license.rawValue).toBe('CC0');
     expect(a.imageOpenAccess).toBe(true);
     expect(a.metadataOpenAccess).toBe(true);
-    expect(a.imageUrls.full).toContain('ids.si.edu');
+    // `full` is the hi-res JPEG resource (true max), NOT the ~2000px-capped
+    // deliveryService URL the record's `media.content` points at.
+    expect(a.imageUrls.full).toContain('ids.si.edu/ids/download');
+    expect(a.imageUrls.full).toContain('.jpg');
+    expect(a.imageUrls.full).not.toContain('deliveryService');
     expect(a.imageUrls.thumbnail).toContain('ids.si.edu');
     expect(a.imageUrls.width).toBe(2200);
     expect(a.imageUrls.height).toBe(3000);
+    expect(a.imageUrls.maxResolution).toEqual({ width: 2200, height: 3000 });
     expect(a.source.apiUrl).toContain('api.si.edu/openaccess');
     expect(a.source.pageUrl).toContain('americanart.si.edu');
     expect(a.description).toBe('Decorative Arts-Jewelry');
@@ -281,5 +286,71 @@ describe('Smithsonian adapter search', () => {
     }) as unknown as typeof fetch;
     await smithsonianFetcher.search('q', 5);
     expect(capturedUrl).toContain('api_key=canonical-key');
+  });
+});
+
+describe('Smithsonian adapter image resolution (hi-res resource over capped deliveryService)', () => {
+  // Regression guard: `media.content` is a `deliveryService` URL that caps the
+  // long edge at ~2000px; the `resources[]` array already carries the full-pixel
+  // "High-resolution JPEG" with a direct download URL + true dims. `full` must use
+  // the resource URL so works aren't under-rated on understated resolution.
+  it('uses the hi-res JPEG resource URL + dims, not the deliveryService default', () => {
+    const result = smithsonianFetcher.normalize(fixture('smithsonian-accepted.json'));
+    if (result.status !== 'accepted') throw new Error('expected accepted');
+    const iu = result.artwork.imageUrls;
+    expect(iu.full).toBe('https://ids.si.edu/ids/download?id=SAAM-1929.8.175.19_1.jpg');
+    expect(iu.maxResolution).toEqual({ width: 2200, height: 3000 });
+  });
+
+  it('does not surface a same-size TIFF as a master (master means MORE pixels than `full`)', () => {
+    // The fixture's TIFF and JPEG are both 2200×3000 — a same-resolution TIFF adds
+    // no max-resolution signal, so no `master` is emitted.
+    const result = smithsonianFetcher.normalize(fixture('smithsonian-accepted.json'));
+    if (result.status !== 'accepted') throw new Error('expected accepted');
+    expect(result.artwork.imageUrls.master).toBeUndefined();
+  });
+
+  it('surfaces a TIFF master when it is strictly larger than the displayable JPEG', () => {
+    const raw = structuredClone(fixture('smithsonian-accepted.json')) as {
+      response: {
+        content: {
+          descriptiveNonRepeating: {
+            online_media: { media: Array<{ resources: Array<Record<string, unknown>> }> };
+          };
+        };
+      };
+    };
+    const resources = raw.response.content.descriptiveNonRepeating.online_media.media[0].resources;
+    // Bump the TIFF resource to a true archival size larger than the 2200×3000 JPEG.
+    const tiff = resources.find((r) => /tiff|tif/i.test(String(r.label)));
+    if (!tiff) throw new Error('fixture has no TIFF resource');
+    tiff.width = 6000;
+    tiff.height = 8000;
+    const result = smithsonianFetcher.normalize(raw);
+    if (result.status !== 'accepted') throw new Error('expected accepted');
+    const iu = result.artwork.imageUrls;
+    expect(iu.full).toContain('.jpg'); // displayable stays the JPEG
+    expect(iu.master?.url).toContain('.tif');
+    expect(iu.master?.format).toBe('image/tiff');
+    expect(iu.master?.width).toBe(6000);
+    expect(iu.maxResolution).toEqual({ width: 6000, height: 8000 });
+  });
+
+  it('falls back to the deliveryService URL when no hi-res resource is published', () => {
+    const raw = structuredClone(fixture('smithsonian-accepted.json')) as {
+      response: {
+        content: {
+          descriptiveNonRepeating: {
+            online_media: { media: Array<Record<string, unknown>> };
+          };
+        };
+      };
+    };
+    raw.response.content.descriptiveNonRepeating.online_media.media[0].resources = [];
+    const result = smithsonianFetcher.normalize(raw);
+    if (result.status !== 'accepted') throw new Error('expected accepted');
+    const iu = result.artwork.imageUrls;
+    expect(iu.full).toContain('deliveryService');
+    expect(iu.maxResolution).toBeUndefined(); // no published dims → honest absence
   });
 });

--- a/tests/wikimedia.test.ts
+++ b/tests/wikimedia.test.ts
@@ -925,3 +925,89 @@ describe('Wikimedia Commons adapter mediumCategory', () => {
     expect(result.artwork.mediumCategory).toBe('other');
   });
 });
+
+describe('Wikimedia non-displayable originals (image/tiff → displayable full + master) [W1]', () => {
+  // PR #105 made `full` contractually browser-displayable. Commons hosts raster
+  // TIFF art scans that pass the image/ MIME prefix AND survive the curation gate
+  // (a TIFF painting is legitimate art) but DON'T render in an <img>. They must be
+  // routed to `master`, with `full` set to a Commons-rendered JPEG — or rejected.
+  function tiffPage(opts: { thumburl?: string; title?: string }) {
+    const imageinfo: Record<string, unknown> = {
+      url: 'https://upload.wikimedia.org/wikipedia/commons/a/ab/Great_Painting.tif',
+      descriptionurl: 'https://commons.wikimedia.org/wiki/File:Great_Painting.tif',
+      mime: 'image/tiff',
+      width: 9000,
+      height: 7000,
+      size: 350_000_000,
+      extmetadata: { License: { value: 'pd' }, ObjectName: { value: 'Great Painting' } },
+    };
+    if (opts.thumburl) {
+      imageinfo.thumburl = opts.thumburl;
+      imageinfo.thumbwidth = 2048;
+      imageinfo.thumbheight = 1593;
+    }
+    return {
+      query: {
+        pages: [
+          { pageid: 77000001, title: opts.title ?? 'File:Great_Painting.tif', imageinfo: [imageinfo] },
+        ],
+      },
+    };
+  }
+
+  it('uses the imageinfo thumburl (rendered JPEG) as `full`, routes the TIFF to `master`', () => {
+    const result = wikimediaFetcher.normalize(
+      tiffPage({
+        thumburl:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/a/ab/Great_Painting.tif/2048px-Great_Painting.tif.jpg',
+      }),
+    );
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    const iu = result.artwork.imageUrls;
+    // `full` is a rendered JPEG — never the raw .tif.
+    expect(iu.full).toContain('.jpg');
+    expect(iu.full).not.toMatch(/\.tif$/);
+    expect(iu.width).toBe(2048);
+    expect(iu.height).toBe(1593);
+    // master carries the full-resolution TIFF original, flagged as image/tiff.
+    expect(iu.master?.url).toMatch(/\.tif$/);
+    expect(iu.master?.format).toBe('image/tiff');
+    expect(iu.master?.width).toBe(9000);
+    expect(iu.master?.height).toBe(7000);
+    expect(iu.master?.byteSize).toBe(350_000_000);
+    // maxResolution reports the TRUE max (the master), not the 2048px derivative.
+    expect(iu.maxResolution).toEqual({ width: 9000, height: 7000 });
+  });
+
+  it('falls back to Special:FilePath?width= when no thumburl is published', () => {
+    const result = wikimediaFetcher.normalize(tiffPage({}));
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    const iu = result.artwork.imageUrls;
+    expect(iu.full).toContain('Special:FilePath');
+    expect(iu.full).toContain('width=2048');
+    expect(iu.full).not.toMatch(/\.tif$/);
+    expect(iu.master?.format).toBe('image/tiff');
+    expect(iu.maxResolution).toEqual({ width: 9000, height: 7000 });
+  });
+
+  it('rejects a non-displayable original when no rendition can be produced (no thumburl, no title)', () => {
+    const result = wikimediaFetcher.normalize(tiffPage({ title: '' }));
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.rejection.reason).toMatch(/no browser-displayable rendition/);
+    expect(result.rejection.reason).toContain('image/tiff');
+  });
+
+  it('leaves a normal JPEG untouched: original is `full`, no master', () => {
+    const result = wikimediaFetcher.normalize(fixture('wikimedia-accepted-bruegel.json'));
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    const iu = result.artwork.imageUrls;
+    expect(iu.full).toContain('upload.wikimedia.org');
+    expect(iu.full).toMatch(/\.jpg$/i);
+    expect(iu.master).toBeUndefined();
+    expect(iu.maxResolution).toEqual({ width: 1246, height: 800 });
+  });
+});


### PR DESCRIPTION
## Why
The MCP served **non-max image URLs** for several sources when a higher-res asset existed at the **same source**. The OMA image-quality filter and OM-D's calendar plate selection therefore ranked works on **understated resolution** — good works got under-rated, down-ranked, or handed a soft image. Surfaced by OM-D's Ed.001 calendar audit (dogfooded 14 Hiroshige works); re-verified live here through the real fetchers.

## Diagnosis (live-verified)
| Source | Before | True max | Fix |
|---|---|---|---|
| **AIC** | `/full/843,/` (843px ≈ 23%) | `/full/max/` 3.5–4× (e.g. 843→3591) | URL rewrite |
| **Cleveland** | `_print.jpg` (3400px); `_full.tif` discarded | `_full.tif` 11966×7990 | master/displayable split |
| **Smithsonian** | `deliveryService` URL capped 1330×2000 | hi-res JPEG resource 2900×4362 | use in-payload resource URL |

Met (`/original/`) and Wikimedia (Commons original) were already serving the max — Wikimedia now also reports it via `maxResolution`.

## Contract change (additive, non-breaking) — pending OM-OR ratification
`ArtworkImages` gains:
- **`master?`** `{url,width,height,format,byteSize}` — print/archival master, surfaced **only when strictly larger** than `full`; may be non-`<img>`-renderable (TIFF, flagged via `format`).
- **`maxResolution?`** `{width,height}` — the **true maximum** across `full` + `master`. The single field OM-A (quality filter) + OM-D (calendar) should rank on. Absent only where the source publishes no pixel dims (AIC data API) — honest absence over a guess.

`full` is now contractually the **browser-displayable** image; the master is where the extra pixels live.

Populated for Cleveland, Smithsonian, Wikimedia, Rijksmuseum.

## Scope note (no silent cap)
Cross-mirror impression selection (picking the largest scan of the **same** work across **federated** sources) is a ranking-layer concern (ranking v1.2). It is **enabled by** this `maxResolution` field, not implemented here. Within a single record, each fetcher now picks its largest variant.

## Verification
- `NODE_OPTIONS=--experimental-sqlite vitest run` → **535 passed** (520 baseline + 15 new: per-source regression locks + `pickMaxResolution`/`coerceFiniteNumber` units).
- `tscq --noEmit` → clean. `npm run build` → clean.
- Live-verified through the real fetchers (Cleveland 1948.306/1940.982, SI Hiroshige, AIC).

## Coordination
Field shape posted to OM-OR as `[DECISION-NEEDED]` so OM-A + OM-D consume **one** field, not three. Do not merge until OM-CR (code gate) + the field shape is ratified. Pramod merges + publishes.

Co-Authored by Pramod Prasanth <pramod@chainalign.com>

---

## Addendum — OM-CR W1 fix (Wikimedia non-displayable originals)

OM-CR flagged W1: `wikimedia.ts` could put a Commons **TIFF** into the now-displayable `full` (the only guard was `mime.startsWith('image/')`, and the #86 curation gate keeps raster-TIFF art). Closed in this PR:
- Positive allowlist of `<img>`-renderable MIMEs (jpeg/png/gif/webp). Any other `image/*` original (TIFF/DjVu/…) → original routed to **`master`**, `full` set to a Commons-rendered JPEG (imageinfo `thumburl` via new `iiurlwidth`, fallback `Special:FilePath?width=N`), or **rejected** when no rendition is producible.
- `maxResolution` still reports the original (master) pixels.
- **Live-smoked** on a real Commons `image/tiff` painting: `full` → rendered `.tif.jpg` (2048px), `master` → `.tif` (4141×3543), `maxResolution` 4141×3543.
- +4 regression tests (thumburl, Special:FilePath fallback, reject path, JPEG-untouched). **vitest 539/539**, tscq 0.