### PR TITLE
feat(smithsonian): deepen non-Western recall via unit-aware curation

### DIFF
--- a/src/fetchers/smithsonian.ts
+++ b/src/fetchers/smithsonian.ts
@@ -35,14 +35,37 @@ const reject = (id: string, reason: string, rawSnapshot: unknown): ValidationRes
 // Smithsonian Open Access spans ALL units — including Libraries (bibliographic
 // "Books" records) and Natural History (specimens) — not just art museums. An
 // `online_media_type:"Images"` search still surfaces book covers and specimen
-// photos. `indexedStructured.object_type` (controlled vocabulary) is the direct
-// art/non-art signal: art records carry "Drawings"/"Paintings"/"Decorative
-// arts" etc.; books carry "Books"; specimens carry no object_type at all. We
-// gate on an art-type ALLOWLIST (precision over recall — better to drop an edge
-// artwork than admit a book or a beetle). Matched as a substring of the
-// lowercased controlled value, so "Decorative Arts-Jewelry" and "Drawings" both
-// hit. A record with no recognized art object_type is rejected as non-art.
+// photos. Curation runs in TWO complementary passes (a record is art if EITHER
+// fires):
+//
+// 1. UNIT pass — the record's `unitCode` names a dedicated art/design museum.
+//    Everything those units image is art by definition, so this recovers forms
+//    the keyword list can't (an FSG handscroll, an NMAfA reliquary). It is the
+//    bigger non-Western win: the Asian-Art (NMAA/FSG), African-Art (NMAfA),
+//    American-Art (SAAM), Portrait (NPG), Hirshhorn (HMSG) and Cooper Hewitt
+//    (CHNDM) units carry the Islamic/Indian/Chinese/African/Korean depth.
+//    Deliberately EXCLUDES the natural-history specimen depts (NMNHENTO beetles,
+//    NMNHMINSCI minerals, NMNHBOTANY/PALEO) and the mixed-history units (NMAH,
+//    NMAAHC) and anthropology (NMNHANTHRO, NMAI) — those fall to pass 2 so a
+//    trophy / machine / ecofact / human-remains record is NOT swept in on unit
+//    alone.
+//
+// 2. OBJECT-TYPE pass — `indexedStructured.object_type` (controlled vocabulary)
+//    names an art form on the allowlist. This is how the mixed-history and
+//    anthropology units contribute (a netsuke / mask / celadon bowl from
+//    NMNHANTHRO) without admitting the non-art around it. Matched as a substring
+//    of the lowercased value, so "Decorative Arts-Jewelry" and "Bowls (vessels)"
+//    both hit. A record with no recognized art object_type AND a non-art unit is
+//    rejected (precision over recall — better to drop an edge object than admit a
+//    book or a beetle).
+
+// Dedicated art/design museum unit codes — pass 1. (FSG = legacy Freer–Sackler
+// code; NMAA = its current "National Museum of Asian Art" code. Both kept so
+// older and newer records resolve.)
+const ART_UNIT_CODES = new Set(['NMAA', 'FSG', 'NMAfA', 'SAAM', 'NPG', 'HMSG', 'CHNDM']);
+
 const ART_OBJECT_TYPE_KEYWORDS = [
+  // Western fine + decorative art (original list).
   'painting',
   'drawing',
   'print',
@@ -69,13 +92,80 @@ const ART_OBJECT_TYPE_KEYWORDS = [
   'metalwork',
   'works on paper',
   'work on paper',
+  // Non-Western art forms that EDAN records as the object's FORM, not a Western
+  // classification — these were the bulk of the dropped non-Western art (netsuke,
+  // masks, celadon vessels, Japanese lacquerware, Islamic/Mughal manuscripts).
+  'mask',
+  'netsuke',
+  'carving',
+  'manuscript',
+  'koran',
+  'quran',
+  'calligraphy',
+  'scroll',
+  'woodblock',
+  'woodcut',
+  'inro',
+  'okimono',
+  'kimono',
+  'robe',
+  'lacquer',
+  'amulet',
+  'pendant',
+  'figurine',
+  'statuette',
+  'relief',
+  'censer',
+  'incense',
+  'carpet',
+  'embroidery',
+  // Decorative-arts vessel/container forms (ceramics, metalwork, lacquer) whose
+  // object_type is the form, not the material — Korean celadon, Chinese bronze,
+  // Japanese tea wares. (Collision-prone short forms — bowl/urn/rug/icon/screen —
+  // live in ART_OBJECT_TYPE_PATTERNS instead, word-anchored.)
+  'vessel',
+  'vase',
+  'jar',
+  'bottle',
+  'ewer',
+  'flask',
+  'dish',
+  'plate',
+  'cup',
+  'teapot',
+  'basket',
 ];
 
-/** True when any object_type value names an art form on the allowlist. */
+// Word-anchored art forms. These collide badly as bare substrings — `box` is
+// inside "boxing gloves", `rug` inside "Drugs"/"crude drug" (NMAH materia
+// medica), `bowl` inside "Bowling", `urn` inside "Return", `icon` inside
+// "Silicon", `screen` inside "Touchscreen", `fan` inside "infant" — so they're
+// matched on WORD BOUNDARIES instead. Recovers Japanese lacquer boxes, hand fans,
+// Korean celadon bowls, funerary urns, religious icons, folding screens and rugs
+// without admitting NMAH sports/electronics/pharmaceutical objects. Patterns are
+// anchored + linear (no backtracking) and run only over short controlled-vocab
+// values.
+const ART_OBJECT_TYPE_PATTERNS = [
+  /\bbox(es)?\b/i,
+  /\bfan(s)?\b/i,
+  /\brug(s)?\b/i,
+  /\bbowl(s)?\b/i,
+  /\burn(s)?\b/i,
+  /\bicon(s)?\b/i,
+  /\bscreen(s)?\b/i,
+];
+
+/** True when the record's unit is a dedicated art/design museum (curation pass 1). */
+function isArtUnit(unitCode: string): boolean {
+  return ART_UNIT_CODES.has(unitCode);
+}
+
+/** True when any object_type value names an art form on the allowlist (curation pass 2). */
 function isArtObjectType(objectTypes: string[]): boolean {
   for (const t of objectTypes) {
     const lower = t.toLowerCase();
     if (ART_OBJECT_TYPE_KEYWORDS.some((k) => lower.includes(k))) return true;
+    if (ART_OBJECT_TYPE_PATTERNS.some((re) => re.test(t))) return true;
   }
   return false;
 }
@@ -354,11 +444,14 @@ export const smithsonianFetcher: Fetcher = {
     // Non-art curation gate (runs AFTER the rights gate — rights is the hard
     // boundary; this is a relevance gate that keeps the federated ART result set
     // free of Smithsonian Libraries book records and Natural History specimens).
+    // A record is art if EITHER its unit is a dedicated art museum (pass 1) OR an
+    // object_type names an art form (pass 2). See the constants block above.
+    const unitCode = asString(record.unitCode);
     const objectTypes = objectTypeSignals(content);
-    if (!isArtObjectType(objectTypes)) {
+    if (!isArtUnit(unitCode) && !isArtObjectType(objectTypes)) {
       return reject(
         id,
-        `smithsonian: non-art object_type=${objectTypes.length ? objectTypes.join('/') : 'none'} (curation reject)`,
+        `smithsonian: non-art unit=${unitCode || 'none'} object_type=${objectTypes.length ? objectTypes.join('/') : 'none'} (curation reject)`,
         raw,
       );
     }

--- a/tests/smithsonian.test.ts
+++ b/tests/smithsonian.test.ts
@@ -139,8 +139,12 @@ describe('Smithsonian adapter normalization', () => {
   it('rejects a CC0 Libraries "Books" record as non-art (curation gate)', () => {
     const raw = clone('smithsonian-accepted.json');
     const response = raw.response as {
+      unitCode?: string;
       content: { indexedStructured: Record<string, unknown>; freetext: Record<string, unknown> };
     };
+    // A real Libraries record carries the Libraries unit (SIL), not an art unit —
+    // set it so the curation gate exercises the object_type pass, not unit pass.
+    response.unitCode = 'SIL';
     response.content.indexedStructured.object_type = ['Books'];
     response.content.freetext.objectType = [{ label: 'Type', content: 'Books' }];
     const result = smithsonianFetcher.normalize(raw);
@@ -153,8 +157,12 @@ describe('Smithsonian adapter normalization', () => {
   it('rejects a CC0 Natural History specimen (no object_type) as non-art', () => {
     const raw = clone('smithsonian-accepted.json');
     const response = raw.response as {
+      unitCode?: string;
       content: { indexedStructured: Record<string, unknown>; freetext: Record<string, unknown> };
     };
+    // Entomology specimen: a specimen dept unit + no object_type → rejected by
+    // BOTH passes.
+    response.unitCode = 'NMNHENTO';
     delete response.content.indexedStructured.object_type;
     delete response.content.freetext.objectType;
     const result = smithsonianFetcher.normalize(raw);
@@ -352,5 +360,98 @@ describe('Smithsonian adapter image resolution (hi-res resource over capped deli
     const iu = result.artwork.imageUrls;
     expect(iu.full).toContain('deliveryService');
     expect(iu.maxResolution).toBeUndefined(); // no published dims → honest absence
+  });
+});
+
+describe('Smithsonian non-Western curation deepening (unit pass + expanded art forms)', () => {
+  // Helper: clone the accepted fixture and force a unit + object_type so each
+  // case isolates exactly one curation path.
+  function withUnitAndType(unitCode: string, objectType: string[]) {
+    const raw = clone('smithsonian-accepted.json');
+    const response = raw.response as {
+      unitCode?: string;
+      content: { indexedStructured: Record<string, unknown>; freetext: Record<string, unknown> };
+    };
+    response.unitCode = unitCode;
+    response.content.indexedStructured.object_type = objectType;
+    response.content.freetext.objectType = objectType.map((t) => ({ label: 'Type', content: t }));
+    return raw;
+  }
+
+  // PASS 1 — dedicated art/design museum units accept regardless of form.
+  it('accepts an art-museum-unit record even when the object_type is not on the form list', () => {
+    // A Freer–Sackler (NMAA) handscroll whose form "Handscrolls" is not a keyword
+    // — the unit pass must still accept it.
+    for (const unit of ['NMAA', 'FSG', 'NMAfA', 'SAAM', 'NPG', 'HMSG', 'CHNDM']) {
+      const result = smithsonianFetcher.normalize(withUnitAndType(unit, ['Handscrolls']));
+      expect(result.status, unit).toBe('accepted');
+    }
+  });
+
+  // PASS 2 — non-Western art FORMS now accepted from non-art units (anthropology).
+  it('accepts non-Western art forms from a non-art unit (anthropology) via the form list', () => {
+    const forms = [
+      ['Netsukes'],
+      ['Masks'],
+      ['Carvings (visual works)'],
+      ['Manuscripts'],
+      ['Korans'],
+      ['Lacquer'],
+      ['Vessels (containers)'],
+      ['Vases'],
+      ['Bottles'],
+      ['Dishes (vessels)'],
+    ];
+    for (const ot of forms) {
+      const result = smithsonianFetcher.normalize(withUnitAndType('NMNHANTHRO', ot));
+      expect(result.status, ot.join()).toBe('accepted');
+    }
+  });
+
+  // Word-anchored forms: recover the real art, reject the substring collisions.
+  it('accepts word-anchored art forms (Boxes, Bowls, Urns, Icons, Screens, Fans, Rugs)', () => {
+    for (const ot of [
+      ['Boxes (containers)'],
+      ['Picnic Box'],
+      ['Scarf-Box'],
+      ['Bowls (vessels)'],
+      ['Urns'],
+      ['Icons'],
+      ['Screens'],
+      ['Fans'],
+      ['Rugs'],
+    ]) {
+      const result = smithsonianFetcher.normalize(withUnitAndType('NMNHANTHRO', ot));
+      expect(result.status, ot.join()).toBe('accepted');
+    }
+  });
+
+  it('does NOT let word-anchored forms admit their substring collisions', () => {
+    // box⊄boxing, rug⊄Drugs, bowl⊄Bowling, urn⊄Return, icon⊄Silicon, screen⊄Touchscreen
+    for (const ot of [
+      ['Boxing gloves'],
+      ['Drugs'],
+      ['crude drug'],
+      ['Bowling balls'],
+      ['Returns'],
+      ['Silicon wafers'],
+      ['Touchscreens'],
+    ]) {
+      const result = smithsonianFetcher.normalize(withUnitAndType('NMAH', ot));
+      expect(result.status, ot.join()).toBe('rejected');
+    }
+  });
+
+  // Specimen depts (distinct unit codes) stay rejected — no beetles/minerals.
+  it('keeps natural-history specimen departments out (unit not art + form not art)', () => {
+    for (const [unit, ot] of [
+      ['NMNHENTO', ['Insects']],
+      ['NMNHMINSCI', ['Minerals']],
+      ['NMNHBOTANY', ['Plants']],
+      ['NMNHPALEO', ['Fossils']],
+    ] as Array<[string, string[]]>) {
+      const result = smithsonianFetcher.normalize(withUnitAndType(unit, ot));
+      expect(result.status, unit).toBe('rejected');
+    }
   });
 });


### PR DESCRIPTION
Closes #106. Coverage drive Tier-1 #1 (`glam-coverage-backlog-2026-06-23`) — widen the existing Smithsonian pull, **zero new connector code**.

## Diagnosis (live)
The curation gate's allowlist matched Western *classifications* (painting/print/ceramic), but EDAN records non-Western works by **form** (Netsuke, Mask, Bowl, Vase, Manuscript, Koran, Lacquered Box). Measured across 10 non-Western queries: **34 accepted / 84 curation-dropped (71%)**, with **zero rights rejections** — purely a relevance miss.

## Fix
Two complementary passes (art if EITHER fires):

| Pass | What | Recovers |
|---|---|---|
| **1. Unit** | dedicated art/design units `NMAA·FSG·NMAfA·SAAM·NPG·HMSG·CHNDM` accept regardless of form | Asian/African/American art whose form isn't a keyword (handscrolls, reliquaries) |
| **2. Object-type** | expanded form list (mask, netsuke, carving, manuscript, koran, calligraphy, scroll, lacquer, vessel/bowl/vase/jar/bottle…) | netsuke/masks/celadon/lacquer from NMNH-Anthropology |

**Precision guards:**
- Unit pass deliberately **excludes** specimen depts (`NMNHENTO/MINSCI/BOTANY/PALEO`), mixed-history (`NMAH/NMAAHC`), and anthropology (`NMNHANTHRO/NMAI`) — so a trophy / machine / ecofact / human-remains record is never accepted on unit alone.
- Collision-prone short forms (box, fan, rug, bowl, urn, icon, screen) are **word-anchored regexes**, not substrings: `box`⊄`boxing gloves`, `rug`⊄`Drugs` (NMAH materia medica), `bowl`⊄`Bowling`, `urn`⊄`Return`, `icon`⊄`Silicon`, `screen`⊄`Touchscreen`. Anchored + linear (no ReDoS).
- **NMAI is NOT unit-accepted** — consent/TK-label screening (backlog §2.6) is a separate gate.

## Result (live, same queries)
**34 → 112 accepted (+229%)**, **zero new false positives**, specimen depts still fully excluded.

## Verification
- vitest **525/525** (520 baseline + 5 new: unit pass, form pass, word-anchor accept, collision reject, specimen reject). Two existing curation tests updated to a realistic non-art unit.
- tscq 0, build 0. Diagnosed + result-verified live through the real fetcher.

## Known residual (documented, not silently capped)
- **Pre-existing** (not this PR): SIA archival photos / SIL library plates get in via the long-standing `photograph`/`print` keywords — a unit-aware SIA/SIL tightening is a separate follow-up (noted in #106).
- A few NMNHANTHRO long-tail forms ("Coin Case", "Water Sprinkler") remain dropped — acceptable precision tradeoff.

Independent of #105 (off `main`). Do not merge (Pramod).

Co-Authored by Pramod Prasanth <pramod@chainalign.com>