### PR TITLE
feat(regions): facet non-Western cultures that fell to region=null

### DIFF
--- a/src/data/regions.json
+++ b/src/data/regions.json
@@ -1,10 +1,12 @@
 {
   "japan": ["japan", "japanese", "edo", "kyoto", "tokyo", "osaka"],
-  "china": ["china", "chinese", "tang", "song", "ming", "qing", "tibet", "tibetan"],
+  "china": ["china", "chinese", "tang", "song", "ming", "qing"],
   "korea": ["korea", "korean", "joseon", "goryeo"],
   "iran": ["iran", "iranian", "persian", "persia", "safavid", "qajar"],
-  "india": ["india", "indian", "mughal", "rajasthani", "punjabi"],
-  "islamic": ["islamic art", "ottoman", "mamluk", "fatimid"],
+  "india": ["india", "indian", "mughal", "rajasthani", "punjabi", "south asia", "south asian", "deccan", "deccani", "pahari", "gandhara", "bengal", "bengali", "gujarat", "tamil", "sri lanka", "sri lankan", "sinhalese"],
+  "southeast asia": ["southeast asia", "southeast asian", "indonesia", "indonesian", "java", "javanese", "bali", "balinese", "sumatra", "sumatran", "cambodia", "cambodian", "khmer", "angkor", "burma", "burmese", "myanmar", "thailand", "thai", "siam", "siamese", "vietnam", "vietnamese", "laos", "lao", "laotian", "malaysia", "malay", "philippines", "filipino"],
+  "himalaya": ["himalaya", "himalayan", "nepal", "nepalese", "nepali", "tibet", "tibetan", "bhutan", "bhutanese", "gurkha", "sherpa", "newari", "kathmandu", "lhasa"],
+  "islamic": ["islamic", "islamic art", "islamic world", "muslim", "ottoman", "mamluk", "fatimid", "seljuk", "timurid", "turkey", "turkish", "iznik", "near east"],
   "egypt": ["egypt", "egyptian", "ptolemaic"],
   "greece": ["greece", "greek", "hellenistic", "attic"],
   "rome": ["rome", "roman", "roman empire"],
@@ -16,6 +18,6 @@
   "spain": ["spain", "spanish", "andalusian", "catalan"],
   "england": ["england", "english", "british", "great britain"],
   "americas": ["united states", "american", "mexican", "peruvian"],
-  "africa": ["africa", "african", "yoruba", "kongo", "asante"],
+  "africa": ["africa", "african", "yoruba", "kongo", "asante", "ashanti", "nigeria", "nigerian", "benin", "benin city", "igbo", "togo", "ilorin", "lome", "ghana", "ghanaian", "mali", "malian", "senegal", "senegalese", "ethiopia", "ethiopian"],
   "oceania": ["oceania", "polynesian", "maori", "papua"]
 }

--- a/src/mappings.ts
+++ b/src/mappings.ts
@@ -3,7 +3,7 @@ import regionsData from './data/regions.json' with { type: 'json' };
 const regionMap = regionsData as Record<string, string[]>;
 
 // Flatten every (canonical, alias) pair into a word-boundary regex, longest
-// alias first. Two reasons, mirroring the dynasty matcher in dateParser.ts:
+// alias first. Three reasons, mirroring the dynasty matcher in dateParser.ts:
 //   1. Word boundaries (`\b`) stop an alias matching a substring of an unrelated
 //      word. The old `includes()` mapped "Toledo"/"Macedonian" → japan (both
 //      contain "edo") and "Mustang" → china (contains "tang").
@@ -11,12 +11,18 @@ const regionMap = regionsData as Record<string, string[]>;
 //      specific one it is contained in: "roman renaissance" (→ italy) must be
 //      tested before "roman" (→ rome), or every Roman-Renaissance string would
 //      resolve to rome.
+//   3. An optional `(?:s|es)` plural suffix before the closing boundary, so a
+//      demonym alias also matches its plural — museum culture fields say
+//      "Iranians", "Koreans", "Thais", "Khmers", "Muslims" (the bare `\b` after
+//      "iranian" fails on the trailing "s"). The `-ese`/`-i`/`-ian` forms that a
+//      plural rule can't reach (Burmese, Nepali, Cambodian) are listed as
+//      explicit aliases instead.
 const REGION_MATCHERS: Array<{ canonical: string; re: RegExp }> = Object.entries(regionMap)
   .flatMap(([canonical, aliases]) => aliases.map((alias) => ({ canonical, alias })))
   .sort((a, b) => b.alias.length - a.alias.length)
   .map(({ canonical, alias }) => ({
     canonical,
-    re: new RegExp(`\\b${alias.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i'),
+    re: new RegExp(`\\b${alias.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:s|es)?\\b`, 'i'),
   }));
 
 export function normalizeRegion(input: string | null | undefined): string | null {

--- a/tests/mappings.test.ts
+++ b/tests/mappings.test.ts
@@ -15,7 +15,43 @@ describe('normalizeRegion', () => {
   it('matches an alias as a whole word inside a longer culture string', () => {
     expect(normalizeRegion('Tang dynasty')).toBe('china');
     expect(normalizeRegion('Edo period, Kyoto')).toBe('japan');
-    expect(normalizeRegion('Tibetan thangka')).toBe('china');
+    // Tibetan art is Himalayan, not Chinese — it has its own canonical now.
+    expect(normalizeRegion('Tibetan thangka')).toBe('himalaya');
+  });
+
+  it('facets non-Western cultures that previously fell to null (world-museum coverage)', () => {
+    // African nations/cities beyond the original yoruba/kongo/asante.
+    expect(normalizeRegion('Nigeria')).toBe('africa');
+    expect(normalizeRegion('Benin City')).toBe('africa');
+    expect(normalizeRegion('Togo')).toBe('africa');
+    // Southeast Asia — a new canonical (Indonesia, Cambodia, Burma, Thailand…).
+    expect(normalizeRegion('Javanese Batiks')).toBe('southeast asia');
+    expect(normalizeRegion('Khmer')).toBe('southeast asia');
+    expect(normalizeRegion('Burma (Myanmar)')).toBe('southeast asia');
+    expect(normalizeRegion('Thailand')).toBe('southeast asia');
+    // Himalaya — a new canonical (Nepal, Tibet, Bhutan).
+    expect(normalizeRegion('Nepalese')).toBe('himalaya');
+    expect(normalizeRegion('Himalayan peoples')).toBe('himalaya');
+    // Strengthened existing canonicals.
+    expect(normalizeRegion('Arts of the Islamic World')).toBe('islamic');
+    expect(normalizeRegion('South Asians')).toBe('india');
+  });
+
+  it('matches plural demonyms (the trailing -s that the bare \\b boundary dropped)', () => {
+    // Museum culture fields routinely pluralise: "Iranians", "Koreans",
+    // "Thais", "Khmers", "Muslims". The optional (?:s|es) suffix recovers them.
+    expect(normalizeRegion('Iranians')).toBe('iran');
+    expect(normalizeRegion('Koreans')).toBe('korea');
+    expect(normalizeRegion('Muslims')).toBe('islamic');
+    expect(normalizeRegion('Khmers')).toBe('southeast asia');
+  });
+
+  it('does not let the plural suffix create false matches', () => {
+    // "Somalis" must NOT match "mali" (africa) — the leading \\b still guards it.
+    expect(normalizeRegion('Somalis')).toBe(null);
+    // Topic/material words that look regional stay null.
+    expect(normalizeRegion('Anthropology')).toBe(null);
+    expect(normalizeRegion('Coins')).toBe(null);
   });
 
   it('does not match an alias that is only a substring of another word', () => {


### PR DESCRIPTION
Coverage deepening for the wired CC0 sources (complements the Smithsonian recall widen #107).

## Diagnosis (live)
Ran real non-Western queries through the wired Met + Smithsonian fetchers: **~25% of accepted non-Western works carried `region=null`** (Met 28%, SI 23%) — surfaced but not facetable by tradition. Harvested the actual unmapped `culture`/`place` strings to drive the fix (not guessed).

Two root causes:
1. **Western-leaning region map** — no Southeast-Asia/Himalaya canonical; `africa` missing Nigeria/Benin City/Togo/Ghana/Mali; `islamic` only matched the literal `"islamic art"` (bare "Islamic"/"Muslim"/Turkey all missed).
2. **Plural demonyms dropped** — the matcher's bare `\b` fails on `Iranians`/`Koreans`/`Khmers`/`Muslims` (the trailing `s` breaks the boundary after `iranian`/`korean`/…).

## Fix
- **New canonicals**: `southeast asia` (Indonesia/Java, Cambodia/Khmer, Burma/Myanmar, Thailand, Vietnam…) and `himalaya` (Nepal, Tibet, Bhutan). **Tibet/Tibetan move `china`→`himalaya`** — Tibetan art is Himalayan, not Chinese.
- **Strengthened**: `africa` (Nigeria, Benin City, Togo, Ghana, Mali, Igbo, Ethiopia…), `islamic` (bare `islamic`, `muslim`, `islamic world`, Turkey, Seljuk, Timurid, Iznik), `india` (south asia/asian, Deccan, Pahari, Gandhara, Bengal, Sri Lanka).
- **Matcher**: optional `(?:s|es)` before the closing `\b` so plural demonyms resolve. Leading `\b` still guards collisions — `Somalis`↛`mali`, `Mustang`↛`china`, `Toledo`↛`japan`.

`region` is a free-form string (no enum) → **additive, zero consumer ripple**.

## Verification
- Live-verified against the harvested unmapped strings: **39/39** resolve correctly, all collision/precision guards hold.
- vitest **523/523** (+4 new tests: new canonicals, plural demonyms, collision guards; 1 existing test updated for the intended Tibet→himalaya reclassification). tscq 0, build 0.

Closes the region-faceting issue. Independent of #105/#107 (off `main`). Do not merge (Pramod).

Co-Authored by Pramod Prasanth <pramod@chainalign.com>