### PR TITLE
fix(walters): load bundle via readFileSync (fixes flaky 30s test timeout on main)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/cfpramod/open-museum-mcp#readme",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/copy-data-assets.mjs",
     "build:mcpb": "node scripts/build-mcpb.mjs",
     "dev": "NODE_OPTIONS=--experimental-sqlite tsx src/server.ts",
     "prepare": "npm run build",

--- a/scripts/copy-data-assets.mjs
+++ b/scripts/copy-data-assets.mjs
@@ -1,0 +1,17 @@
+// Post-build asset copy. tsc copies JSON data files that are `import`ed (regions,
+// dynasties), but the Walters bundle is read at runtime via fs.readFileSync (a
+// 5MB bundler-transformed JSON import is pathologically slow), so tsc never sees
+// it. Copy it explicitly into dist/data so it ships in the published package.
+import { copyFileSync, mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const root = new URL('..', import.meta.url);
+const ASSETS = ['walters.json'];
+
+mkdirSync(fileURLToPath(new URL('dist/data/', root)), { recursive: true });
+for (const name of ASSETS) {
+  const from = fileURLToPath(new URL(`src/data/${name}`, root));
+  const to = fileURLToPath(new URL(`dist/data/${name}`, root));
+  copyFileSync(from, to);
+  console.error(`copied ${name} -> dist/data/${name}`);
+}

--- a/src/fetchers/walters.ts
+++ b/src/fetchers/walters.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { parseDisplayDate } from '../dateParser.js';
 import { validateWaltersLicense } from '../licenseGate.js';
 import { cleanArtistName, detectAttributionType, normalizeRegion } from '../mappings.js';
@@ -62,15 +64,19 @@ function normalizeText(s: string): string {
     .trim();
 }
 
-/** Lazily load + index the bundle. The 5MB JSON is parsed only on first Walters
- *  use (dynamic import), so processes that never query Walters pay nothing. */
+// Bundle path resolved relative to this module (dist/fetchers -> dist/data after
+// build; the build step copies src/data/walters.json into dist/data).
+const BUNDLE_PATH = fileURLToPath(new URL('../data/walters.json', import.meta.url));
+
+/** Lazily load + index the bundle. The ~5MB JSON is read + parsed only on first
+ *  Walters use (native readFileSync + JSON.parse — NOT a bundler-transformed JSON
+ *  import, which is pathologically slow on a file this size), so processes that
+ *  never query Walters pay nothing. */
 async function loadIndex(): Promise<LoadedIndex> {
   if (!indexPromise) {
     indexPromise = (async () => {
-      const mod = (await import('../data/walters.json', { with: { type: 'json' } })) as {
-        default: WaltersBundle;
-      };
-      const objects = mod.default.objects ?? [];
+      const bundle = JSON.parse(readFileSync(BUNDLE_PATH, 'utf-8')) as WaltersBundle;
+      const objects = bundle.objects ?? [];
       const byId = new Map<string, WaltersRecord>();
       const blobs: string[] = [];
       for (const r of objects) {


### PR DESCRIPTION
**Follow-up to the merged #111.** When I rebased to prep #111, it had already merged — and the rebase surfaced that main's Walters loader **flakes the test suite**: the lazy `import('../data/walters.json', { with: { type: 'json' } })` is pathologically slow under the bundler transform on a 5MB file. The `beforeAll` warm-up hook times out at 30s (reproduced in isolation) and starves the vitest worker pool, failing unrelated files (medium/cite).

## Fix
- Load the bundle with native `readFileSync` + `JSON.parse` (~100ms, bypasses the transform) instead of a dynamic JSON import.
- Since tsc no longer sees a JSON import, a post-build step (`scripts/copy-data-assets.mjs`) copies `src/data/walters.json` → `dist/data/` so it still ships in the package. `build` is now `tsc && node scripts/copy-data-assets.mjs`.

No behavior change — same bundle, same rights gate, same search. Just a fast, deterministic load.

## Verification
- `vitest run` → **562/562** (Walters 12/12 in 7.3s, was timing out at 30s).
- tscq 0, build 0; `dist/data/walters.json` (5.3MB) confirmed shipped post-build.

Off `main` (one commit). Do not merge (Pramod).

Co-Authored by Pramod Prasanth <pramod@chainalign.com>