### PR TITLE
chore(release): 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] — 2026-06-24
+
+### Added
+
+- **Walters Art Museum (`walters`) — the engine's first INGEST source.** The Walters v1 REST API closed in 2023; the collection is published only as static CSVs under a blanket CC0 license. A build-time script (`scripts/build-walters-index.ts`) fetches the CSVs, applies the rights gate, and writes a committed bundle (`src/data/walters.json`, 20,483 records) that ships in the package — so it works offline with no API key. Rights: the dataset is declared CC0, and the gate defensively keeps only pre-1928, image-bearing records (the 1928+/loaned/copyright tail is excluded). Deep Islamic/Persian manuscripts, Mamluk Qur'ans, and Ethiopian material — one of the cleanest non-Western open sources. (#111)
+- **SMK — National Gallery of Denmark (`smk`).** Keyless REST API (`api.smk.dk`) over ~39k public-domain, image-bearing works served as IIIF JP2 masters + a full-resolution `image_native` JPEG (print-grade; dimensions surfaced via `maxResolution`). Rights: a per-object `public_domain` boolean + a `rights` URI that tiers CC0 vs the Public Domain Mark — parsed by exact hostname (never a substring), reusing the audited shared rights parser. (#114)
+- **Rijksmuseum region + period faceting.** Rijksmuseum-direct records previously returned `region: null` and `period: null`, making them invisible to faceting. Period is now derived from the parsed year bounds (single-century spans → a tradition tag), and region from the dereferenced production-place reference via `normalizeRegion` + a compact place gazetteer (Rijks records cities like Jingdezhen/Java/Amsterdam) — so Chinese/Japanese/Indonesian Rijks works become facetable. (#115)
+
+### Fixed
+
+- **Walters bundle loads via `readFileSync` instead of a dynamic JSON import.** The lazy `import()` of the 5MB bundle was pathologically slow under the bundler transform (a test warm-up hook timed out at 30s and starved the worker pool). Loading with native `readFileSync` + `JSON.parse` is ~100ms; a post-build step (`scripts/copy-data-assets.mjs`) copies the bundle into `dist/data` so it still ships. (#116)
+
 ## [0.13.0] — 2026-06-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ This is what "rights-verified" means here: validated against published museum me
 | Art Institute of Chicago | `aic` | none | ✅ v0.2 |
 | Wikimedia Commons | `wikimedia` | none | ✅ v0.3 |
 | Europeana | `europeana` | API key (free, per-user) | ✅ v0.4 |
-| Walters Art Museum | `walters` | none (bundled CC0 dataset) | ✅ v0.13 |
+| Walters Art Museum | `walters` | none (bundled CC0 dataset) | ✅ v0.14 |
 | SMK (National Gallery of Denmark) | `smk` | none | ✅ v0.14 |
 | Smithsonian Open Access | `si` | API key (free) | 📋 v2 |
 | Rijksmuseum | `rijks` | API key (free) | 📋 v2 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-museum-mcp",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-museum-mcp",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-museum-mcp",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "MCP server for license-verified search across open-access museum collections (The Met, Cleveland, AIC, Wikimedia Commons, Europeana).",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
Publishes the work merged since 0.13.0 — **Walters + SMK + Rijks faceting** are on `main` but not yet on npm (npm still serves 0.13.0). Version + CHANGELOG only, no code changes.

## Version
`0.13.0 → 0.14.0` in `package.json` + `package-lock.json`. `dist/version.js` auto-reads it (verified `0.14.0`).

## CHANGELOG [0.14.0]
- **#111** Walters Art Museum — first INGEST source (bundled CC0, ~20.5k records, offline, no key).
- **#114** SMK / National Gallery of Denmark — keyless CC0/PD FEDERATE (~39k PD works, print-grade).
- **#115** Rijksmuseum region + period faceting (was always null → invisible to facets).
- **#116** Walters bundle loads via `readFileSync` (fixed the flaky 30s test timeout).

Also corrects the README Walters status to v0.14 (it ships here, not the already-published 0.13.0).

## Gates
- `tscq --noEmit` → 0
- `vitest run` → **572/572**
- `npm run build` → 0 (bundle copied to `dist/data`)

**OM-CR: fast confirm (version + changelog).** Then Pramod merges + `npm publish` 0.14.0 → Walters + SMK become available via `npx open-museum-mcp`.

Co-Authored by Pramod Prasanth <pramod@chainalign.com>