### PR TITLE
chore(release): 0.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-museum-mcp",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-museum-mcp",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-museum-mcp",
-  "version": "0.14.0",
-  "description": "MCP server for license-verified search across open-access museum collections (The Met, Rijksmuseum, Smithsonian, Cleveland, AIC, SMK, Walters, Wellcome, Wikimedia Commons, Europeana, and growing).",
+  "version": "0.15.0",
+  "description": "MCP server for license-verified search across open-access museum collections (The Met, Rijksmuseum, Smithsonian, Cleveland, AIC, SMK, Walters, Wellcome, National Gallery of Art, Harvard, Wikimedia Commons, Europeana, and growing).",
   "type": "module",
   "main": "dist/server.js",
   "exports": {


### PR DESCRIPTION
Cuts **0.15.0** (npm is still on 0.13.0; this publish covers everything since). Version + (already-merged) CHANGELOG; no source-code changes here.

## Version
`0.14.0 → 0.15.0` in `package.json` + `package-lock.json`. `dist/version.js` auto-reads it (verified `0.15.0`). Description refreshed to list the new sources.

## CHANGELOG [0.15.0] (already on main from the source PRs)
- **#120 National Gallery of Art (Washington)** — the engine's first **gzipped** INGEST (~63k CC0 works, 3.6MB `nga.json.gz`).
- **#122 Harvard Art Museums** — key-gated FEDERATE, **open access via Open Clearance** (`imagepermissionlevel=0` → `OTHER` + `imageOpenAccess`, not promoted to CC0/PD) + the per-fetcher **`noCache`** engine change (Harvard ToS: no caching beyond two weeks).

Wellcome is already under [0.14.0].

## ⚠️ OM-CR — backstop review required
**#122 Harvard merged UNGATED** (the rebase merged before OM-CR could review it). This release review **must include a real OM-CR code pass** on:
- the **`noCache` engine change** (`Fetcher.noCache` + `getArtwork` honoring it: cache read/write skipped for no-cache sources; a cached record from an *unregistered* fetcher is still served; the query-cache holds only IDs) — and its **FP-reachability** (does any path still write a Harvard record to the object cache?);
- the Harvard validator / Open-Clearance `OTHER` tier surfaced honestly.
The federation no-cache test locks the behavior (no-cache source never cached, re-fetched live), but the engine change deserves the explicit gate it missed.

## Gates
- `tscq --noEmit` → 0
- `vitest run` → **594/594**
- `npm run build` → 0 (`nga.json.gz` + `walters.json` ship to `dist/data`)

Then Pramod merges + `npm publish` 0.15.0 → OMA pins `^0.15.0`.

Co-Authored by Pramod Prasanth <pramod@chainalign.com>