### PR TITLE
fix: hotlinkRestricted for all blocking CDNs; stable search sort; v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] — 2026-06-30
+
+### Added
+
+- **`imageUrls.hotlinkRestricted` — engine-level signal for CDN-blocked image URLs.** Three sources return 403 (or a Cloudflare WAF bot-challenge) from server / cloud / CLI environments; their image URLs are browser-only. A new `hotlinkRestricted?: boolean` field on `ArtworkImages` surfaces this for surfaces to handle gracefully — link to `source.pageUrl` instead of embedding, or route through OMA's image proxy once available. Applied centrally by the federation via a one-line `Fetcher.hotlinkRestricted = true` property; no per-record adapter logic needed. Confirmed blocking sources: **AIC** (Cloudflare WAF on `www.artic.edu/iiif/2`), **Walters** (`art.thewalters.org`), **Smithsonian** (`ids.si.edu`). Adding a new blocking source requires a single-line change to its fetcher. Also backfills records already in the object cache on the next access.
+- **Stable-sort / deterministic federation ordering.** Search results previously varied run-to-run because the federation fires museum API calls in parallel and whichever returned first led the page. All `search_artworks` results are now sorted by `id` lexicographically after gathering, so the same query always returns the same ordered set regardless of API timing.
+- **AIC pixel dimensions from `thumbnail` API field.** AIC's data API carries full scan pixel dimensions in the `thumbnail.width` / `thumbnail.height` sub-object — a field we weren't requesting. Adding it to `AIC_FIELDS` surfaces these as `imageUrls.width`, `.height`, and `.maxResolution`, removing the previous "AIC has no pixel dimensions" limitation.
+
 ## [0.15.0] — 2026-06-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ This is what "rights-verified" means here: validated against published museum me
 |---|---|---|---|
 | The Metropolitan Museum of Art | `met` | none | ✅ v0.1 |
 | Cleveland Museum of Art | `cleveland` | none | ✅ v0.2 |
-| Art Institute of Chicago | `aic` | none | ✅ v0.2 |
+| Art Institute of Chicago | `aic` | none | ✅ v0.2 — `imageUrls.hotlinkRestricted: true` (IIIF CDN is browser-only; use `source.pageUrl` in server contexts) |
 | Wikimedia Commons | `wikimedia` | none | ✅ v0.3 |
 | Europeana | `europeana` | API key (free, per-user) | ✅ v0.4 |
 | Walters Art Museum | `walters` | none (bundled CC0 dataset) | ✅ v0.14 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-museum-mcp",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-museum-mcp",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-museum-mcp",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "MCP server for license-verified search across open-access museum collections (The Met, Rijksmuseum, Smithsonian, Cleveland, AIC, SMK, Walters, Wellcome, National Gallery of Art, Harvard, Wikimedia Commons, Europeana, and growing).",
   "type": "module",
   "main": "dist/server.js",

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -328,6 +328,8 @@ export function createFederation(opts: FederationOptions): Federation {
         // process. Without this, such rows would stay colourless until natural
         // expiry and silently under-return from colour search/facets.
         if (await enrichColor(cached)) await cache.upsertObject(cached);
+        // Backfill hotlinkRestricted onto records cached before v0.16 added it.
+        if (fetcher?.hotlinkRestricted) cached.imageUrls.hotlinkRestricted = true;
         return { ok: true, artwork: cached };
       }
     }
@@ -340,6 +342,9 @@ export function createFederation(opts: FederationOptions): Federation {
       onReject?.(id, result.rejection.reason);
       return { ok: false, reason: result.rejection.reason };
     }
+
+    // Apply per-fetcher hotlink flag centrally so every adapter stays flag-free.
+    if (fetcher.hotlinkRestricted) result.artwork.imageUrls.hotlinkRestricted = true;
 
     await enrichColor(result.artwork);
     if (!fetcher.noCache) await cache.upsertObject(result.artwork);
@@ -452,7 +457,11 @@ export function createFederation(opts: FederationOptions): Federation {
         .map((x) => x.a);
     }
 
-    const results = ordered.slice(0, params.limit);
+    // Stable-sort the final page by id when no ranking override (colour) is active.
+    // Colour ranking is already deterministic by CIEDE2000 distance. For plain
+    // searches, this guarantees the same query always returns the same ordered set.
+    const page = ordered.slice(0, params.limit);
+    const results = params.color ? page : page.sort((a, b) => a.id.localeCompare(b.id));
 
     return { count: results.length, results };
   }

--- a/src/fetchers/aic.ts
+++ b/src/fetchers/aic.ts
@@ -66,6 +66,7 @@ function parseArtistDisplay(display: string): { nationality?: string; lifespan?:
 export const aicFetcher: Fetcher = {
   code: 'aic',
   name: 'Art Institute of Chicago',
+  hotlinkRestricted: true,
 
   async search(query: string, limit: number, options: SearchOptions = {}): Promise<string[]> {
     const url = new URL(`${AIC_API}/artworks/search`);
@@ -155,10 +156,8 @@ export const aicFetcher: Fetcher = {
     const imageId = asString(r.image_id);
     // AIC publishes through IIIF Image API 2.x. `/full/843,/` is AIC's standard
     // public-DISPLAY size — but the source holds the full scan at 3.5–4× that.
-    // `/full/max/` returns the largest the IIIF server will produce. However,
-    // www.artic.edu/iiif/2 is behind Cloudflare WAF: server/cloud/CLI environments
-    // get a CF challenge (effectively 403). `hotlinkRestricted: true` flags this
-    // so surfaces skip SSR embedding and link to source.pageUrl instead.
+    // `/full/max/` returns the largest the IIIF server will produce. hotlinkRestricted
+    // is applied centrally by the federation (aicFetcher.hotlinkRestricted = true).
     const fullImage = imageId ? `${AIC_IIIF}/${imageId}/full/max/0/default.jpg` : '';
     const thumbnailUrl = imageId ? `${AIC_IIIF}/${imageId}/full/200,/0/default.jpg` : undefined;
 
@@ -194,7 +193,6 @@ export const aicFetcher: Fetcher = {
         full: fullImage,
         thumbnail: thumbnailUrl,
         ...(maxResolution ? { width: maxResolution.width, height: maxResolution.height, maxResolution } : {}),
-        hotlinkRestricted: true,
       },
       imageOpenAccess: decision.imageOpenAccess,
       metadataOpenAccess: decision.metadataOpenAccess,

--- a/src/fetchers/aic.ts
+++ b/src/fetchers/aic.ts
@@ -34,6 +34,7 @@ const AIC_FIELDS = [
   'medium_display',
   'classification_title',
   'image_id',
+  'thumbnail',
 ].join(',');
 
 const reject = (id: string, reason: string, rawSnapshot: unknown): ValidationResult =>
@@ -153,15 +154,20 @@ export const aicFetcher: Fetcher = {
 
     const imageId = asString(r.image_id);
     // AIC publishes through IIIF Image API 2.x. `/full/843,/` is AIC's standard
-    // public-DISPLAY size — but the source holds the full scan at 3.5–4× that
-    // (e.g. a Tokaido plate is 843px wide via this size and ~3500px via `max`).
-    // `/full/max/` returns the largest the IIIF server will produce (AIC's level-2
-    // profile supports it; `max` was added in Image API 2.1 and AIC honors it),
-    // so we ask for the true maximum here and keep 200px as the thumbnail tier.
-    // AIC's data API publishes no PIXEL dimensions (only physical cm), so
-    // `width`/`height`/`maxResolution` stay unset rather than carrying a guess.
+    // public-DISPLAY size — but the source holds the full scan at 3.5–4× that.
+    // `/full/max/` returns the largest the IIIF server will produce. However,
+    // www.artic.edu/iiif/2 is behind Cloudflare WAF: server/cloud/CLI environments
+    // get a CF challenge (effectively 403). `hotlinkRestricted: true` flags this
+    // so surfaces skip SSR embedding and link to source.pageUrl instead.
     const fullImage = imageId ? `${AIC_IIIF}/${imageId}/full/max/0/default.jpg` : '';
-    const thumbnail = imageId ? `${AIC_IIIF}/${imageId}/full/200,/0/default.jpg` : undefined;
+    const thumbnailUrl = imageId ? `${AIC_IIIF}/${imageId}/full/200,/0/default.jpg` : undefined;
+
+    // AIC's `thumbnail` API field carries the full scan pixel dimensions.
+    const thumbObj = r.thumbnail && typeof r.thumbnail === 'object' ? (r.thumbnail as Record<string, unknown>) : null;
+    const thumbW = thumbObj ? asFiniteNumber(thumbObj.width) : null;
+    const thumbH = thumbObj ? asFiniteNumber(thumbObj.height) : null;
+    const maxResolution =
+      thumbW !== null && thumbH !== null ? { width: thumbW, height: thumbH } : undefined;
 
     const artwork: Artwork = {
       id,
@@ -186,7 +192,9 @@ export const aicFetcher: Fetcher = {
       period: null,
       imageUrls: {
         full: fullImage,
-        thumbnail,
+        thumbnail: thumbnailUrl,
+        ...(maxResolution ? { width: maxResolution.width, height: maxResolution.height, maxResolution } : {}),
+        hotlinkRestricted: true,
       },
       imageOpenAccess: decision.imageOpenAccess,
       metadataOpenAccess: decision.metadataOpenAccess,

--- a/src/fetchers/smithsonian.ts
+++ b/src/fetchers/smithsonian.ts
@@ -366,6 +366,7 @@ function apiKey(): string {
 export const smithsonianFetcher: Fetcher = {
   code: 'smithsonian',
   name: 'Smithsonian Institution',
+  hotlinkRestricted: true,
 
   async search(query: string, limit: number, options: SearchOptions = {}): Promise<string[]> {
     const url = new URL(`${SI_API}/search`);

--- a/src/fetchers/types.ts
+++ b/src/fetchers/types.ts
@@ -16,4 +16,16 @@ export interface Fetcher {
    * terms forbid caching (e.g. Harvard Art Museums: no caching beyond two weeks).
    */
   noCache?: boolean;
+  /**
+   * When true, ALL image URLs from this fetcher are hotlink-restricted: they 403
+   * (or serve a bot-challenge page) from server / cloud / CLI environments and are
+   * only reliably loadable in a browser. The federation sets
+   * `imageUrls.hotlinkRestricted = true` centrally on every record from this
+   * fetcher — no per-record logic needed in adapters. Adding a new blocking source
+   * is a one-line change here; no normalize changes required.
+   *
+   * Confirmed blocking sources: AIC (Cloudflare WAF on iiif/2),
+   * Walters (art.thewalters.org), Smithsonian (ids.si.edu).
+   */
+  hotlinkRestricted?: true;
 }

--- a/src/fetchers/walters.ts
+++ b/src/fetchers/walters.ts
@@ -97,6 +97,7 @@ const reject = (id: string, reason: string, rawSnapshot: unknown): ValidationRes
 export const waltersFetcher: Fetcher = {
   code: 'walters',
   name: 'Walters Art Museum',
+  hotlinkRestricted: true,
 
   // Local keyword search over the bundled index (no live API exists). OR-ranked:
   // a record qualifies if it matches ANY query token, and is ranked first by how

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,10 +75,11 @@ export interface ArtworkImages {
   /**
    * When `true`, the `full` / `thumbnail` URLs are hotlink-restricted by the
    * museum's CDN and will 403 from server / cloud / CLI environments — browser
-   * context only (Cloudflare WAF challenge). Surfaces must NOT embed these URLs
-   * in SSR-rendered `<img>` tags or use them in server-side image pipelines.
-   * Link to `source.pageUrl` instead, or route through OMA's image proxy once
-   * available. Currently set for AIC only.
+   * context only. Surfaces must NOT embed these URLs in SSR-rendered `<img>`
+   * tags or use them in server-side image pipelines. Link to `source.pageUrl`
+   * instead, or route through OMA's image proxy once available.
+   * Set centrally by the federation when `Fetcher.hotlinkRestricted = true`.
+   * Confirmed: AIC (Cloudflare WAF), Walters, Smithsonian.
    */
   hotlinkRestricted?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,9 +69,18 @@ export interface ArtworkImages {
    * `master`. The single field the OMA image-quality filter and calendar plate
    * selection should rank on — so consumers never under-rate a work by reading a
    * default-size derivative's dims. Absent only when the source publishes no
-   * pixel dimensions at all (e.g. AIC's data API). Additive v0.13 field.
+   * pixel dimensions at all. Additive v0.13 field.
    */
   maxResolution?: { width: number; height: number };
+  /**
+   * When `true`, the `full` / `thumbnail` URLs are hotlink-restricted by the
+   * museum's CDN and will 403 from server / cloud / CLI environments — browser
+   * context only (Cloudflare WAF challenge). Surfaces must NOT embed these URLs
+   * in SSR-rendered `<img>` tags or use them in server-side image pipelines.
+   * Link to `source.pageUrl` instead, or route through OMA's image proxy once
+   * available. Currently set for AIC only.
+   */
+  hotlinkRestricted?: boolean;
 }
 
 export interface ArtworkSource {

--- a/tests/aic.test.ts
+++ b/tests/aic.test.ts
@@ -43,8 +43,9 @@ describe('AIC adapter normalization', () => {
     );
     expect(a.imageUrls.full).not.toContain('/full/843,/');
     expect(a.imageUrls.thumbnail).toContain('/full/200,/');
-    // AIC IIIF is behind Cloudflare WAF — 403 from server/cloud/CLI contexts.
-    expect(a.imageUrls.hotlinkRestricted).toBe(true);
+    // hotlinkRestricted is applied centrally by the federation (aicFetcher.hotlinkRestricted = true),
+    // not by normalize — so it is absent on the raw normalize output.
+    expect(a.imageUrls.hotlinkRestricted).toBeUndefined();
     // AIC thumbnail field carries full scan pixel dims — exposed as maxResolution.
     expect(a.imageUrls.maxResolution).toEqual({ width: 1024, height: 768 });
     expect(a.imageUrls.width).toBe(1024);
@@ -131,17 +132,16 @@ describe('AIC adapter normalization', () => {
     if (result.status !== 'accepted') return;
     expect(result.artwork.imageUrls.full).toBe('');
     expect(result.artwork.imageUrls.thumbnail).toBeUndefined();
-    // hotlinkRestricted applies regardless — the CDN restricts AIC's IIIF endpoint.
-    expect(result.artwork.imageUrls.hotlinkRestricted).toBe(true);
+    // hotlinkRestricted is applied by the federation, not by normalize.
+    expect(result.artwork.imageUrls.hotlinkRestricted).toBeUndefined();
   });
 
-  it('sets hotlinkRestricted without maxResolution when thumbnail dims are absent', () => {
+  it('omits maxResolution when thumbnail dims are absent', () => {
     const baseline = fixture('aic-accepted.json') as { data: Record<string, unknown> };
     const noThumb = { data: { ...baseline.data, thumbnail: null } };
     const result = aicFetcher.normalize(noThumb);
     expect(result.status).toBe('accepted');
     if (result.status !== 'accepted') return;
-    expect(result.artwork.imageUrls.hotlinkRestricted).toBe(true);
     expect(result.artwork.imageUrls.maxResolution).toBeUndefined();
     expect(result.artwork.imageUrls.width).toBeUndefined();
     expect(result.artwork.imageUrls.height).toBeUndefined();

--- a/tests/aic.test.ts
+++ b/tests/aic.test.ts
@@ -43,6 +43,12 @@ describe('AIC adapter normalization', () => {
     );
     expect(a.imageUrls.full).not.toContain('/full/843,/');
     expect(a.imageUrls.thumbnail).toContain('/full/200,/');
+    // AIC IIIF is behind Cloudflare WAF — 403 from server/cloud/CLI contexts.
+    expect(a.imageUrls.hotlinkRestricted).toBe(true);
+    // AIC thumbnail field carries full scan pixel dims — exposed as maxResolution.
+    expect(a.imageUrls.maxResolution).toEqual({ width: 1024, height: 768 });
+    expect(a.imageUrls.width).toBe(1024);
+    expect(a.imageUrls.height).toBe(768);
     expect(a.source.pageUrl).toBe('https://www.artic.edu/artworks/16568');
     expect(a.source.apiUrl).toContain('api.artic.edu');
     expect(a.description).toBe('oil on canvas');
@@ -125,6 +131,20 @@ describe('AIC adapter normalization', () => {
     if (result.status !== 'accepted') return;
     expect(result.artwork.imageUrls.full).toBe('');
     expect(result.artwork.imageUrls.thumbnail).toBeUndefined();
+    // hotlinkRestricted applies regardless — the CDN restricts AIC's IIIF endpoint.
+    expect(result.artwork.imageUrls.hotlinkRestricted).toBe(true);
+  });
+
+  it('sets hotlinkRestricted without maxResolution when thumbnail dims are absent', () => {
+    const baseline = fixture('aic-accepted.json') as { data: Record<string, unknown> };
+    const noThumb = { data: { ...baseline.data, thumbnail: null } };
+    const result = aicFetcher.normalize(noThumb);
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.imageUrls.hotlinkRestricted).toBe(true);
+    expect(result.artwork.imageUrls.maxResolution).toBeUndefined();
+    expect(result.artwork.imageUrls.width).toBeUndefined();
+    expect(result.artwork.imageUrls.height).toBeUndefined();
   });
 
   it('does not surface "born YYYY" tokens as artist nationality', () => {

--- a/tests/federation.test.ts
+++ b/tests/federation.test.ts
@@ -101,9 +101,10 @@ describe('createFederation.search', () => {
   });
 
   it('interleaves museums round-robin so no single fetcher fills the page', async () => {
-    // Two museums each return 4 accepted candidates. With flat() concatenation,
-    // the first fetcher (met) would fill the limit-4 page entirely. Round-robin
-    // interleaving must yield an alternating mix.
+    // Two museums each return 4 accepted candidates. Round-robin interleaving
+    // draws from both before the overfetch window is exhausted, so both museums
+    // are represented in the final page. Results are then stable-sorted by id, so
+    // the assertion checks coverage and stable order, not a specific interleave position.
     const met = fakeFetcher('met', {
       ids: ['met:1', 'met:2', 'met:3', 'met:4'],
       accept: new Set(['met:1', 'met:2', 'met:3', 'met:4']),
@@ -116,7 +117,9 @@ describe('createFederation.search', () => {
     const fed = createFederation({ fetchers: { met: met.fetcher, cleveland: cle.fetcher }, cache: store });
 
     const out = await fed.search({ query: 'x', has_image: true, limit: 4 });
-    expect(out.results.map((r) => r.id)).toEqual(['met:1', 'cleveland:1', 'met:2', 'cleveland:2']);
+    const ids = out.results.map((r) => r.id);
+    // Stable sort: 'cleveland:...' < 'met:...' lexicographically.
+    expect(ids).toEqual([...ids].sort((a, b) => a.localeCompare(b)));
     const codes = out.results.map((r) => r.museum.code);
     expect(codes.filter((c) => c === 'met')).toHaveLength(2);
     expect(codes.filter((c) => c === 'cleveland')).toHaveLength(2);
@@ -665,5 +668,66 @@ describe('createFederation colour backfill on cached records', () => {
     const out = await fed.getArtwork('test:1');
     expect(out.ok).toBe(true);
     expect(extractColor).not.toHaveBeenCalled();
+  });
+});
+
+describe('hotlinkRestricted — centrally applied by federation', () => {
+  it('sets hotlinkRestricted on records from a fetcher with hotlinkRestricted = true (live path)', async () => {
+    const t = fakeFetcher('aic', { ids: ['aic:1'], accept: new Set(['aic:1']) });
+    (t.fetcher as Fetcher).hotlinkRestricted = true;
+    const { store } = memoryCache();
+    const fed = createFederation({ fetchers: { aic: t.fetcher }, cache: store });
+
+    const out = await fed.getArtwork('aic:1');
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.artwork.imageUrls.hotlinkRestricted).toBe(true);
+  });
+
+  it('sets hotlinkRestricted on a PRE-EXISTING cached record (backfill path)', async () => {
+    const { store, objects } = memoryCache();
+    objects.set('aic:1', makeArtwork('aic:1'));
+
+    const t = fakeFetcher('aic', { ids: ['aic:1'], accept: new Set(['aic:1']) });
+    (t.fetcher as Fetcher).hotlinkRestricted = true;
+    const fed = createFederation({ fetchers: { aic: t.fetcher }, cache: store });
+
+    const out = await fed.getArtwork('aic:1');
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.artwork.imageUrls.hotlinkRestricted).toBe(true);
+  });
+
+  it('does NOT set hotlinkRestricted for a fetcher without the flag', async () => {
+    const t = fakeFetcher('met', { ids: ['met:1'], accept: new Set(['met:1']) });
+    const { store } = memoryCache();
+    const fed = createFederation({ fetchers: { met: t.fetcher }, cache: store });
+
+    const out = await fed.getArtwork('met:1');
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.artwork.imageUrls.hotlinkRestricted).toBeUndefined();
+  });
+});
+
+describe('stable sort — deterministic search ordering', () => {
+  it('returns results in consistent id-lexicographic order regardless of parallel resolution order', async () => {
+    // Two fetchers returning ids that interleave round-robin; the resolved artwork
+    // order depends on network timing. After the stable sort, results must always
+    // be in id-lexicographic order.
+    const a = fakeFetcher('aic', {
+      ids: ['aic:2', 'aic:1'],
+      accept: new Set(['aic:1', 'aic:2']),
+    });
+    const m = fakeFetcher('met', {
+      ids: ['met:10', 'met:5'],
+      accept: new Set(['met:5', 'met:10']),
+    });
+    const { store } = memoryCache();
+    const fed = createFederation({ fetchers: { aic: a.fetcher, met: m.fetcher }, cache: store });
+
+    const out = await fed.search({ query: 'painting', has_image: true, limit: 10 });
+    const ids = out.results.map((r) => r.id);
+    expect(ids).toEqual([...ids].sort((x, y) => x.localeCompare(y)));
   });
 });

--- a/tests/fixtures/aic-accepted.json
+++ b/tests/fixtures/aic-accepted.json
@@ -11,6 +11,12 @@
     "place_of_origin": "France",
     "medium_display": "Oil on canvas",
     "classification_title": "oil on canvas",
-    "image_id": "3c27b499-af56-f0d5-93b5-a7f2f1ad5813"
+    "image_id": "3c27b499-af56-f0d5-93b5-a7f2f1ad5813",
+    "thumbnail": {
+      "lqip": "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==",
+      "width": 1024,
+      "height": 768,
+      "alt_text": "Water lilies floating on a pond"
+    }
   }
 }


### PR DESCRIPTION
## Changes

### Hotlink restriction — generalised to all confirmed blocking sources

AIC IIIF, Walters CDN, and Smithsonian CDN all return 403/CF-challenge from server/cloud/CLI. A new `Fetcher.hotlinkRestricted?: true` property in `src/fetchers/types.ts` replaces the per-record AIC flag from the original commit. The federation applies it centrally in `getArtwork`:

- **Live path** (after normalize): `result.artwork.imageUrls.hotlinkRestricted = true`
- **Cached path** (backfill): old cached records without the flag get it on next access

Adding a new blocking source = one line on its fetcher. No normalize changes.

Confirmed blocking fetchers set: **AIC** (Cloudflare WAF on `www.artic.edu/iiif/2`), **Walters** (`art.thewalters.org`), **Smithsonian** (`ids.si.edu`).

### Stable sort — deterministic search ordering

`search_artworks` now sorts the final page by `id` lexicographically after slicing. Sorting happens on the result page (post-slice), not on the full candidate window, so round-robin museum diversity is preserved. Colour ranking skips the sort (CIEDE2000 order is already deterministic).

### AIC pixel dimensions

AIC's API `thumbnail` field carries full scan pixel dimensions not previously requested. Now surfaced as `imageUrls.width`, `.height`, and `.maxResolution`.

### v0.16.0

Bump + CHANGELOG entry covering all three additions.

## Surfaces impact

- **OM-A / SSR**: check `imageUrls.hotlinkRestricted` before `<img src>` — affects AIC, Walters, Smithsonian. Link to `source.pageUrl` until OMA proxy is live.
- **OM-D / deck gen**: AIC, Walters, SI works cannot be server-side embedded; re-source from museum website.

## NOT in scope

R2 image-cache pipeline (durable site-wide fix) = OMA infra, not OMM. OM-OR scopes separately.

## Verification

```
599/599 vitest pass, tscq 0
```

New tests: federation-level hotlinkRestricted live path, cached-record backfill, no-flag case; stable sort; updated AIC normalize tests (flag now absent from normalize output, applied by federation).

Co-Authored-By: Pramod Prasanth <pramod@chainalign.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for image dimension details on select artwork pages, improving media display accuracy.
  * Some image sources are now clearly marked as browser-only, helping prevent broken image embeds in non-browser contexts.

* **Bug Fixes**
  * Search results are now returned in a consistent order.
  * Cached artwork data now more reliably includes image restriction status when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->