### PR TITLE
docs(hotlink): fix self-contradicting hotlinkRestricted comment

### DIFF
--- a/src/fetchers/types.ts
+++ b/src/fetchers/types.ts
@@ -18,8 +18,10 @@ export interface Fetcher {
   noCache?: boolean;
   /**
    * When true, ALL image URLs from this fetcher are hotlink-restricted: they 403
-   * (or serve a bot-challenge page) from server / cloud / CLI environments and are
-   * only reliably loadable in a browser. The federation sets
+   * (or serve a bot-challenge page) from server / cloud / CLI environments, and
+   * also from a browser when embedded cross-origin (e.g. an `<img>` on another
+   * site's page) — only a direct, same-origin visit to the source museum's own
+   * page loads reliably. The federation sets
    * `imageUrls.hotlinkRestricted = true` centrally on every record from this
    * fetcher — no per-record logic needed in adapters. Adding a new blocking source
    * is a one-line change here; no normalize changes required.


### PR DESCRIPTION
## Summary
- OM-CR flagged during #124 review: the `Fetcher.hotlinkRestricted` doc comment claimed images are "only reliably loadable in a browser," which contradicts the confirmed AIC browser-hotlink 403 (the reason #52 links out to `source.pageUrl` instead of embedding).
- Tightens the wording: reliable only for a direct, same-origin visit to the source page; cross-origin embeds (hotlinking) still fail in a browser too. Behaviour unchanged, comment-only.

## Test plan
- [x] `tscq --noEmit` — 0 errors
- [x] `NODE_OPTIONS=--experimental-sqlite npx vitest run` — 599/599 passed

Co-Authored by Pramod Prasanth <pramod@chainalign.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the help text for image loading restrictions to better explain when content will reliably load.
  * Updated wording to note that direct visits to the museum’s own page are required for dependable loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->