### PR TITLE
feat(3d): Cleveland Sketchfab 3D scans + has_3d filter (v0.17.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] — 2026-07-02
+
+### Added
+
+- **`models3d` — openly-licensed 3D scans, first source: Cleveland via Sketchfab.** `Artwork` gains an optional `models3d: Model3D[]` field (`{url, source, licence, format?}`) surfacing 3D scans that are independently rights-verified per scan — never inherited from the 2D image licence. Cleveland's "Open Access in 3-D" policy (`clevelandart.org/open-access`) explicitly extends their open-access declaration to 3D scans they digitized and host on Sketchfab; a new `validateCleveland3DLicense` gate checks `sketchfab_id` + `share_license_status` independently of the 2D decision (verified live against Sketchfab's own public API, which corroborates the CC0 licence). `format` is omitted rather than guessed, since Cleveland's API doesn't publish a download-format list. A new `has_3d` filter on `search_artworks` restricts results to records with at least one gate-verified scan.
+
 ## [0.16.0] — 2026-06-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-museum-mcp",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "MCP server for license-verified search across open-access museum collections (The Met, Rijksmuseum, Smithsonian, Cleveland, AIC, SMK, Walters, Wellcome, National Gallery of Art, Harvard, Wikimedia Commons, Europeana, and growing).",
   "type": "module",
   "main": "dist/server.js",

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -66,6 +66,8 @@ export const SearchParamsSchema = z.object({
     .optional(),
   /** Coarse colour-family filter (one of the controlled bins). */
   color_family: z.enum(COLOR_FAMILY_NAMES).optional(),
+  /** When true, restrict to records with at least one openly-licensed 3D scan. */
+  has_3d: z.boolean().optional(),
 });
 export type SearchParams = z.infer<typeof SearchParamsSchema>;
 
@@ -444,13 +446,20 @@ export function createFederation(opts: FederationOptions): Federation {
       ? byMedium.filter((a) => a.colorFamily === params.color_family)
       : byMedium;
 
+    // has_3d is a post-fetch filter (like medium/color_family); only records
+    // with at least one gate-verified 3D scan match. Currently populated by
+    // the Cleveland adapter only.
+    const by3d = params.has_3d
+      ? byFamily.filter((a) => Array.isArray(a.models3d) && a.models3d.length > 0)
+      : byFamily;
+
     // `color` re-orders the survivors by CIEDE2000 nearness to the query colour.
     // Colourless records can't be ranked by colour, so they're dropped from a
     // colour-ranked search.
-    let ordered = byFamily;
+    let ordered = by3d;
     if (params.color) {
       const queryLab = hexToLab(params.color);
-      ordered = byFamily
+      ordered = by3d
         .filter((a): a is Artwork & { dominantColor: string } => Boolean(a.dominantColor))
         .map((a) => ({ a, d: ciede2000(queryLab, hexToLab(a.dominantColor)) }))
         .sort((x, y) => x.d - y.d)

--- a/src/fetchers/cleveland.ts
+++ b/src/fetchers/cleveland.ts
@@ -1,8 +1,8 @@
 import { parseDisplayDate } from '../dateParser.js';
-import { validateClevelandLicense } from '../licenseGate.js';
+import { validateCleveland3DLicense, validateClevelandLicense } from '../licenseGate.js';
 import { cleanArtistName, detectAttributionType, normalizeRegion } from '../mappings.js';
 import { normalizeMedium } from '../medium.js';
-import type { Artwork, ValidationResult } from '../types.js';
+import type { Artwork, Model3D, ValidationResult } from '../types.js';
 import {
   asFiniteNumber,
   asOptionalString,
@@ -163,6 +163,24 @@ export const clevelandFetcher: Fetcher = {
       { width: displayWidth, height: displayHeight },
     );
 
+    // Cleveland's Open Access initiative extends to 3D scans they digitized
+    // and host on Sketchfab (see validateCleveland3DLicense). Gated per-scan,
+    // independent of the 2D imageOpenAccess/metadataOpenAccess above — never
+    // inherited. Absent (not an empty array) when no scan exists or the gate
+    // rejects it, matching every other optional Artwork field's convention.
+    const sketchfabUrl = asOptionalString(r.sketchfab_url);
+    let models3d: Model3D[] | undefined;
+    const model3dDecision = validateCleveland3DLicense(inner);
+    if (model3dDecision.accepted && model3dDecision.license && sketchfabUrl) {
+      models3d = [
+        {
+          url: sketchfabUrl,
+          source: 'sketchfab',
+          licence: model3dDecision.license,
+        },
+      ];
+    }
+
     const artwork: Artwork = {
       id,
       museum: {
@@ -201,6 +219,7 @@ export const clevelandFetcher: Fetcher = {
         pageUrl: asString(r.url),
       },
       description: asOptionalString(r.accession_number),
+      ...(models3d ? { models3d } : {}),
     };
 
     return { status: 'accepted', artwork };

--- a/src/licenseGate.ts
+++ b/src/licenseGate.ts
@@ -84,6 +84,52 @@ export const validateClevelandLicense: LicenseValidator = (raw) => {
   );
 };
 
+// Cleveland's Open Access initiative explicitly extends to 3D: their own
+// published policy ("Open Access in 3-D", clevelandart.org/open-access) states
+// the museum's open-access declaration covers 3D scans of public-domain works
+// that THEY digitized and host on Sketchfab, not just the 2D image. Verified
+// live against Sketchfab's own public API (2026-07-02): the CMA's Sketchfab
+// upload for `sketchfab_id=9b2fbfe552ac4107a3623e19c1ddb4e4` independently
+// reports `license.slug: 'cc0'`, corroborating Cleveland's declaration.
+// `share_license_status` is Cleveland's single per-record rights field — it
+// covers the whole record, 2D and 3D alike, so this validator necessarily
+// reads the same field as `validateClevelandLicense`. It is kept as its own
+// function (rather than reusing the 2D decision object) so the *gate* is
+// structurally per-scan: if Cleveland ever introduces a distinct 3D-specific
+// field, only this function needs to change, and nothing here assumes the 2D
+// verdict. This does NOT extend to third-party 3D platforms (Scan the World,
+// user Sketchfab uploads) — those carry independently-set licences that must
+// never be inferred from a museum's 2D declaration.
+export const validateCleveland3DLicense: LicenseValidator = (raw) => {
+  if (!raw || typeof raw !== 'object') {
+    return reject('cleveland-3d: object missing or not an object');
+  }
+  const obj = raw as Record<string, unknown>;
+  const sketchfabId = obj.sketchfab_id;
+  if (typeof sketchfabId !== 'string' || sketchfabId.trim() === '') {
+    return reject('cleveland-3d: no sketchfab_id (no 3D scan for this record)');
+  }
+  const status = obj.share_license_status;
+  if (typeof status === 'string' && status.toUpperCase() === 'CC0') {
+    return {
+      accepted: true,
+      license: {
+        type: 'CC0',
+        rawValue: status,
+        verificationSource: 'cleveland.share_license_status+sketchfab_id',
+        verifiedAt: nowIso(),
+        confidence: 'high',
+      },
+      imageOpenAccess: true,
+      metadataOpenAccess: true,
+      reason: 'cleveland-3d: share_license_status=CC0, sketchfab_id present',
+    };
+  }
+  return reject(
+    `cleveland-3d: share_license_status=${typeof status === 'string' ? status : 'missing'} (strict default reject)`,
+  );
+};
+
 // The Art Institute of Chicago's API returns is_public_domain as a per-object
 // boolean. AIC's documentation explicitly notes that the API's CC0 framing
 // covers the catalog data, while image reuse rights are described separately

--- a/src/server.ts
+++ b/src/server.ts
@@ -202,6 +202,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
             description:
               'Optional coarse colour-family filter (red, orange, yellow, green, blue, purple, pink, brown, neutral, black, white). Post-fetch over the bounded window, so a rare family may return fewer than `limit`. Use the facets tool to see which families are present.',
           },
+          has_3d: {
+            type: 'boolean',
+            description:
+              'Optional filter for records with at least one openly-licensed 3D scan (Cleveland Museum of Art via Sketchfab, currently the only source). Post-fetch over the bounded window, so this may return fewer than `limit`.',
+          },
         },
         required: ['query'],
       },

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,6 +103,22 @@ export interface MuseumRef {
   url: string;
 }
 
+/**
+ * An openly-licensed 3D scan of the artwork. Rights are verified per scan —
+ * the 3D licence is often DIFFERENT from the 2D image licence (e.g. a CC0 image
+ * may have a CC BY-NC-SA scan on Scan the World). Never inherit the 2D verdict.
+ */
+export interface Model3D {
+  /** Canonical URL for the 3D model (Sketchfab page URL, Smithsonian 3D URL, etc.). */
+  url: string;
+  /** Hosting platform or catalogue: 'sketchfab', 'smithsonian-3d', etc. */
+  source: string;
+  /** Verified licence of the scan itself. Independently checked; never derived from the 2D licence. */
+  licence: ArtworkLicense;
+  /** Format identifiers available for download, e.g. ['glb', 'gltf'] or ['stl']. */
+  format: string[];
+}
+
 export interface Artwork {
   id: string;
   museum: MuseumRef;
@@ -140,6 +156,12 @@ export interface Artwork {
   colorFamily?: ColorFamily;
   /** Reserved for v1.0 artist-obscurity scoring across the federated corpus. Not yet populated by any fetcher. */
   obscurityScore?: number;
+  /**
+   * Openly-licensed 3D scans of the work, each rights-verified independently.
+   * Empty array or absent when no open 3D asset is known. Currently populated
+   * by the Cleveland adapter (Sketchfab via `sketchfab_id`); Smithsonian 3D next.
+   */
+  models3d?: Model3D[];
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,8 +115,13 @@ export interface Model3D {
   source: string;
   /** Verified licence of the scan itself. Independently checked; never derived from the 2D licence. */
   licence: ArtworkLicense;
-  /** Format identifiers available for download, e.g. ['glb', 'gltf'] or ['stl']. */
-  format: string[];
+  /**
+   * Format identifiers available for download, e.g. ['glb', 'gltf'] or ['stl'].
+   * Absent when the source's API doesn't publish a format list (e.g. Cleveland's
+   * API surfaces `sketchfab_id` but not the model's download formats) — never
+   * guessed from the hosting platform's typical defaults.
+   */
+  format?: string[];
 }
 
 export interface Artwork {

--- a/tests/cleveland.test.ts
+++ b/tests/cleveland.test.ts
@@ -170,3 +170,42 @@ describe('Cleveland adapter image resolution (master/displayable split + maxReso
     expect(iu.maxResolution).toEqual({ width: 3400, height: 3389 });
   });
 });
+
+describe('Cleveland adapter 3D models (Sketchfab, Open Access in 3-D)', () => {
+  // Real record (cleveland:108312, Portrait Bust of the Empress Claudia Octavia),
+  // Cleveland's own Sketchfab upload, verified live 2026-07-02 against both
+  // Cleveland's API and Sketchfab's own public API (license.slug: 'cc0').
+  it('surfaces a gate-verified 3D scan when sketchfab_id is present and CC0', () => {
+    const result = clevelandFetcher.normalize(fixture('cleveland-accepted-3d.json'));
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+
+    expect(result.artwork.models3d).toHaveLength(1);
+    const model = result.artwork.models3d?.[0];
+    expect(model?.url).toBe('https://sketchfab.com/models/9b2fbfe552ac4107a3623e19c1ddb4e4');
+    expect(model?.source).toBe('sketchfab');
+    expect(model?.licence.type).toBe('CC0');
+    expect(model?.licence.confidence).toBe('high');
+    expect(model?.licence.verificationSource).toBe('cleveland.share_license_status+sketchfab_id');
+    // 2D and 3D rights are checked independently, never inherited from one another.
+    expect(result.artwork.imageOpenAccess).toBe(true);
+  });
+
+  it('omits models3d entirely when no sketchfab_id is published (the common case)', () => {
+    const result = clevelandFetcher.normalize(fixture('cleveland-accepted.json'));
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.models3d).toBeUndefined();
+  });
+
+  it('omits models3d when sketchfab_id is present but sketchfab_url is missing', () => {
+    const raw = structuredClone(fixture('cleveland-accepted-3d.json')) as {
+      data: Record<string, unknown>;
+    };
+    delete raw.data.sketchfab_url;
+    const result = clevelandFetcher.normalize(raw);
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.models3d).toBeUndefined();
+  });
+});

--- a/tests/federation.test.ts
+++ b/tests/federation.test.ts
@@ -602,6 +602,52 @@ describe('createFederation.search colour', () => {
   });
 });
 
+describe('createFederation.search has_3d', () => {
+  function models3dFetcher() {
+    const over: Record<string, Partial<Artwork>> = {
+      'test:1': {
+        models3d: [
+          {
+            url: 'https://sketchfab.com/models/abc',
+            source: 'sketchfab',
+            licence: {
+              type: 'CC0',
+              rawValue: 'CC0',
+              verificationSource: 'cleveland.share_license_status+sketchfab_id',
+              verifiedAt: '2026-01-01T00:00:00.000Z',
+              confidence: 'high',
+            },
+          },
+        ],
+      },
+      'test:2': {}, // no 3D scan
+    };
+    return fakeFetcher('test', {
+      ids: ['test:1', 'test:2'],
+      accept: new Set(['test:1', 'test:2']),
+      over,
+    });
+  }
+
+  it('restricts to records with at least one 3D scan when has_3d is true', async () => {
+    const t = models3dFetcher();
+    const { store } = memoryCache();
+    const fed = createFederation({ fetchers: { test: t.fetcher }, cache: store });
+
+    const out = await fed.search({ query: 'x', has_image: true, limit: 10, has_3d: true });
+    expect(out.results.map((r) => r.id)).toEqual(['test:1']);
+  });
+
+  it('returns all records when has_3d is omitted', async () => {
+    const t = models3dFetcher();
+    const { store } = memoryCache();
+    const fed = createFederation({ fetchers: { test: t.fetcher }, cache: store });
+
+    const out = await fed.search({ query: 'x', has_image: true, limit: 10 });
+    expect(out.results.map((r) => r.id)).toEqual(['test:1', 'test:2']);
+  });
+});
+
 describe('createFederation.facets colour', () => {
   it('aggregates a colorFamily bucket over the sample (skipping colourless)', async () => {
     const t = fakeFetcher('test', {

--- a/tests/fixtures/cleveland-accepted-3d.json
+++ b/tests/fixtures/cleveland-accepted-3d.json
@@ -1,0 +1,38 @@
+{
+  "data": {
+    "id": 108312,
+    "accession_number": "1925.943",
+    "share_license_status": "CC0",
+    "title": "Portrait Bust of the Empress Claudia Octavia",
+    "creation_date": "50–70 CE",
+    "creation_date_earliest": 1,
+    "creation_date_latest": 99,
+    "culture": ["Italy, Roman"],
+    "technique": "marble",
+    "type": "Sculpture",
+    "url": "https://clevelandart.org/art/1925.943",
+    "images": {
+      "web": {
+        "url": "https://openaccess-cdn.clevelandart.org/1925.943/1925.943_web.jpg",
+        "width": "651",
+        "height": "893",
+        "filesize": "319549"
+      },
+      "print": {
+        "url": "https://openaccess-cdn.clevelandart.org/1925.943/1925.943_print.jpg",
+        "width": "2479",
+        "height": "3400",
+        "filesize": "4559469"
+      },
+      "full": {
+        "url": "https://openaccess-cdn.clevelandart.org/1925.943/1925.943_full.tif",
+        "width": "4471",
+        "height": "6133",
+        "filesize": "82292744"
+      }
+    },
+    "creators": [],
+    "sketchfab_id": "9b2fbfe552ac4107a3623e19c1ddb4e4",
+    "sketchfab_url": "https://sketchfab.com/models/9b2fbfe552ac4107a3623e19c1ddb4e4"
+  }
+}

--- a/tests/licenseGate.test.ts
+++ b/tests/licenseGate.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   validateAicLicense,
+  validateCleveland3DLicense,
   validateClevelandLicense,
   validateLicense,
   validateMetLicense,
@@ -48,6 +49,38 @@ describe('licenseGate', () => {
     it('rejects missing field (strict default)', () => {
       const r = validateClevelandLicense({});
       expect(r.accepted).toBe(false);
+    });
+  });
+
+  describe('Cleveland 3D validator', () => {
+    it('accepts sketchfab_id + share_license_status=CC0', () => {
+      const r = validateCleveland3DLicense({
+        sketchfab_id: '9b2fbfe552ac4107a3623e19c1ddb4e4',
+        share_license_status: 'CC0',
+      });
+      expect(r.accepted).toBe(true);
+      expect(r.license?.type).toBe('CC0');
+      expect(r.license?.verificationSource).toBe('cleveland.share_license_status+sketchfab_id');
+    });
+
+    it('rejects when no sketchfab_id is present (no 3D scan) even if the record is CC0', () => {
+      const r = validateCleveland3DLicense({ share_license_status: 'CC0' });
+      expect(r.accepted).toBe(false);
+      expect(r.reason).toContain('no sketchfab_id');
+    });
+
+    it('rejects sketchfab_id present but non-CC0 status (never inherits an open 2D verdict)', () => {
+      const r = validateCleveland3DLicense({
+        sketchfab_id: 'some-id',
+        share_license_status: 'Copyrighted',
+      });
+      expect(r.accepted).toBe(false);
+      expect(r.reason).toContain('strict default reject');
+    });
+
+    it('rejects malformed input', () => {
+      expect(validateCleveland3DLicense(null).accepted).toBe(false);
+      expect(validateCleveland3DLicense('not an object').accepted).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary
- `Artwork.models3d?: Model3D[]` — openly-licensed 3D scans, independently rights-verified per scan, never inherited from the 2D licence (per the fleet's 3D rights principle).
- First (only) source populated: Cleveland Museum of Art via Sketchfab. Cleveland's own "Open Access in 3-D" policy (clevelandart.org/open-access) explicitly extends their open-access declaration to 3D scans they digitized and host — `validateCleveland3DLicense` gates on `sketchfab_id` + `share_license_status` as its own function, verified live against both Cleveland's API and Sketchfab's public API (which independently corroborates the CC0 licence on the test object).
- `Model3D.format` is optional and left unset for Cleveland — their API doesn't publish a download-format list, and nothing here guesses one.
- `search_artworks` gains an optional `has_3d` filter (post-fetch, like `medium`/`color_family`).
- **Not in scope, deliberately:** the Clearance Manifest payload (`src/core/clearance/manifest.ts`) is untouched. That's a byte-exact, hashed contract coordinated with OM-C — extending it with a per-scan 3D clearance block needs a `[DECISION-NEEDED]` conversation, not a guess in this PR. Filed to escalations for OM-OR/OM-C.
- v0.17.0 bump + CHANGELOG.

## Test plan
- [x] `tscq --noEmit` — 0 errors
- [x] `NODE_OPTIONS=--experimental-sqlite npx vitest run` — 608/608 passed (9 new: 4 licenseGate unit tests, 3 Cleveland adapter tests, 2 federation `has_3d` tests)
- [x] `npm run build` — exit 0
- [x] Live smoke against the real Cleveland API (not just fixtures): `cleveland:108312` (Portrait Bust of the Empress Claudia Octavia) → `models3d` populated, CC0; `cleveland:132819` (Horse, Tang dynasty) → `models3d` undefined (no `sketchfab_id`), confirmed true negative.

Co-Authored by Pramod Prasanth <pramod@chainalign.com>