### PR TITLE
feat(registry): catalogue-raisonne increment-1 engine implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **The registry, increment 1: an accretive, provenance-stamped enrichment layer (engine-side, dark by default).** New `src/core/registry/` module implements the four primitives from `docs/plans/catalogue-raisonne-increment-1.md`: `WorkIdentity` (per-source identity, with a reserved-not-built fingerprint field for future cross-source linkage), `Assertion`+`Evidence` (typed claims about a work, each with its own evidence and dispute status), `RightsPosture` (what the registry itself may do with a piece of evidence, distinct from 2D image rights), and `TrustState` (contributor-credential tier vs. record evidence-grade, kept as two separate axes, never a single confidence score). Ships with a resumable Cleveland CC0 harvest pipeline (`runClevelandHarvest`, reusing the existing `clevelandFetcher.getRaw`/`normalize` unmodified) and a write-back-on-extraction seam (`proposeWriteBack`). `Federation` gains an optional `registryStore` (mirrors the `CacheStore` injection pattern; `/core` carries no storage of its own); `Artwork` gains an optional `enrichment` field, `search_artworks` gains `has_enrichment`, and a new `registry_stats` MCP tool reports present-state counts. **Additive and dark by default**: no deployment configures a concrete `registryStore` yet (OMA's store build is sequenced after the go-live wave), so this ships with zero behavior change until one is wired in. Framing discipline: never "the catalogue" or a completeness claim, everywhere this is surfaced (code comments, tool descriptions, this entry).
+
 ## [0.17.0] — 2026-07-02
 
 ### Added

--- a/scripts/smoke-registry-harvest.ts
+++ b/scripts/smoke-registry-harvest.ts
@@ -1,0 +1,46 @@
+import { runClevelandHarvest } from '../src/core/registry/index.js';
+import type { HarvestCheckpointStore } from '../src/core/registry/index.js';
+import type { RegistryEntry, RegistryStore } from '../src/core/registry/index.js';
+
+// Throwaway in-memory store, live-verification only, the real store is OMA's build.
+const entries = new Map<string, RegistryEntry>();
+const store: RegistryStore = {
+  getEntry: (id) => entries.get(id) ?? null,
+  upsertEntry: (entry) => {
+    entries.set(entry.identity.registryId, entry);
+  },
+  proposeAssertion: () => {
+    throw new Error('not exercised by this smoke');
+  },
+  getStats: () => ({
+    entryCount: entries.size,
+    withEnrichmentCount: [...entries.values()].filter((e) => e.assertions.length > 1).length,
+  }),
+};
+
+let checkpoint: string | null = null;
+const checkpoints: HarvestCheckpointStore = {
+  getCheckpoint: () => checkpoint,
+  setCheckpoint: (skip) => {
+    checkpoint = skip;
+  },
+};
+
+const result = await runClevelandHarvest(store, checkpoints, { batchSize: 5, maxBatches: 2 });
+console.log('harvest run result:', result);
+console.log('checkpoint after run:', checkpoint);
+
+for (const [id, entry] of entries) {
+  console.log(
+    `  ${id} | ${entry.canonicalStatus} | ${entry.trust.evidenceGrade} | ${entry.assertions.length} assertions | posture=${entry.rightsPosture.posture}`,
+  );
+  for (const a of entry.assertions) {
+    console.log(`      ${a.field} = ${JSON.stringify(a.value)}`);
+  }
+}
+
+if (entries.size === 0) {
+  console.error('SMOKE FAILED: zero entries stored from a live Cleveland harvest run.');
+  process.exit(1);
+}
+console.log(`\nSMOKE OK: ${entries.size} live Cleveland records harvested and stamped.`);

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -14,6 +14,7 @@ import { filterByYearRange } from '../yearFilter.js';
 import type { CacheStore } from './cache.js';
 import { wrapTier0, type Tier0Envelope } from './clearance/envelope.js';
 import { buildClearancePayload } from './clearance/manifest.js';
+import type { RegistryStore } from './registry/store.js';
 
 // Museum IDs follow `<code>:<segment>(/<segment>)*`. Each segment is
 // alphanumeric, underscore, or hyphen. The four numeric-ID museums (Met,
@@ -68,6 +69,13 @@ export const SearchParamsSchema = z.object({
   color_family: z.enum(COLOR_FAMILY_NAMES).optional(),
   /** When true, restrict to records with at least one openly-licensed 3D scan. */
   has_3d: z.boolean().optional(),
+  /**
+   * When true, restrict to records with a resolving registry (provenance-
+   * enrichment) entry. Only meaningful when a `registryStore` is configured;
+   * with none configured, no record ever carries `enrichment` and this
+   * filter returns an empty page rather than erroring.
+   */
+  has_enrichment: z.boolean().optional(),
 });
 export type SearchParams = z.infer<typeof SearchParamsSchema>;
 
@@ -158,6 +166,15 @@ export interface FederationOptions {
    * not a gate). The MCP server wires in `createColorExtractor()`.
    */
   extractColor?: (artwork: Artwork) => Promise<ColorData | null>;
+  /**
+   * The registry (provenance-enrichment) store. OPTIONAL and ADDITIVE: when
+   * absent (every current deployment, OMA's concrete store doesn't exist
+   * yet), registry features are simply not surfaced; no error, no behavior
+   * change from before this field existed. Mirrors the `CacheStore`
+   * injection pattern: `/core` carries no storage of its own. See
+   * `docs/plans/catalogue-raisonne-increment-1.md`.
+   */
+  registryStore?: RegistryStore;
 }
 
 export interface Federation {
@@ -179,6 +196,11 @@ export interface Federation {
    * error: a deny is a valid answer.
    */
   clearanceManifest(id: string): Promise<Tier0Envelope>;
+  /**
+   * Present-state counts from the registry store, or `null` when none is
+   * configured. Never described as complete: growing, not exhaustive.
+   */
+  registryStats(): Promise<{ entryCount: number; withEnrichmentCount: number } | null>;
 }
 
 async function withConcurrency<T, R>(
@@ -307,6 +329,26 @@ export function createFederation(opts: FederationOptions): Federation {
   const engineVersion = opts.engineVersion ?? '0.0.0';
   const clock = opts.clock ?? (() => new Date().toISOString());
   const extractColor = opts.extractColor;
+  const registryStore = opts.registryStore;
+
+  // Looks up the registry entry (when a store is configured) and attaches an
+  // `enrichment` summary to the artwork IN MEMORY ONLY, deliberately never
+  // persisted into the object cache. Enrichment grows via write-back over
+  // time; baking a snapshot into a 90-day cached row would go stale well
+  // before the row expires, contradicting the "present state, never stale
+  // completeness" discipline. A no-op when no store is configured (every
+  // current deployment) or no entry resolves for this id.
+  async function attachEnrichment(artwork: Artwork): Promise<void> {
+    if (!registryStore) return;
+    const entry = await registryStore.getEntry(artwork.id);
+    if (!entry) return;
+    artwork.enrichment = {
+      registryId: entry.identity.registryId,
+      canonicalStatus: entry.canonicalStatus,
+      evidenceGrade: entry.trust.evidenceGrade,
+      assertionCount: entry.assertions.length,
+    };
+  }
 
   async function getArtwork(id: string): Promise<FetchOutcome> {
     if (!ID_REGEX.test(id)) {
@@ -332,6 +374,7 @@ export function createFederation(opts: FederationOptions): Federation {
         if (await enrichColor(cached)) await cache.upsertObject(cached);
         // Backfill hotlinkRestricted onto records cached before v0.16 added it.
         if (fetcher?.hotlinkRestricted) cached.imageUrls.hotlinkRestricted = true;
+        await attachEnrichment(cached);
         return { ok: true, artwork: cached };
       }
     }
@@ -350,6 +393,9 @@ export function createFederation(opts: FederationOptions): Federation {
 
     await enrichColor(result.artwork);
     if (!fetcher.noCache) await cache.upsertObject(result.artwork);
+    // Attached AFTER the cache write, deliberately: see `attachEnrichment`'s
+    // comment on why enrichment is never persisted into the object cache.
+    await attachEnrichment(result.artwork);
     return { ok: true, artwork: result.artwork };
   }
 
@@ -453,13 +499,18 @@ export function createFederation(opts: FederationOptions): Federation {
       ? byFamily.filter((a) => Array.isArray(a.models3d) && a.models3d.length > 0)
       : byFamily;
 
+    // has_enrichment is a post-fetch filter (like has_3d); only records with a
+    // resolving registry entry match. `enrichment` is attached by getArtwork
+    // per candidate above, so this needs no extra store round-trip here.
+    const byEnrichment = params.has_enrichment ? by3d.filter((a) => Boolean(a.enrichment)) : by3d;
+
     // `color` re-orders the survivors by CIEDE2000 nearness to the query colour.
     // Colourless records can't be ranked by colour, so they're dropped from a
     // colour-ranked search.
-    let ordered = by3d;
+    let ordered = byEnrichment;
     if (params.color) {
       const queryLab = hexToLab(params.color);
-      ordered = by3d
+      ordered = byEnrichment
         .filter((a): a is Artwork & { dominantColor: string } => Boolean(a.dominantColor))
         .map((a) => ({ a, d: ciede2000(queryLab, hexToLab(a.dominantColor)) }))
         .sort((x, y) => x.d - y.d)
@@ -520,5 +571,10 @@ export function createFederation(opts: FederationOptions): Federation {
     return wrapTier0(buildClearancePayload(result, buildOpts));
   }
 
-  return { fetchers, search, facets, getArtwork, cite, clearanceManifest };
+  async function registryStats(): Promise<{ entryCount: number; withEnrichmentCount: number } | null> {
+    if (!registryStore) return null;
+    return registryStore.getStats();
+  }
+
+  return { fetchers, search, facets, getArtwork, cite, clearanceManifest, registryStats };
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -47,6 +47,7 @@ export { clearanceForLicense, type ClearanceDecision, type ClearanceBasis } from
 // a completeness claim; present-state only, everywhere this is surfaced.
 export {
   canonicalStatus,
+  PENDING_OC_TIER,
   proposeWriteBack,
   validateWriteBackRequest,
   enumerateClevelandIds,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -40,6 +40,43 @@ export {
 } from './clearance/manifest.js';
 export { clearanceForLicense, type ClearanceDecision, type ClearanceBasis } from './clearance/licenseMap.js';
 
+// The registry: an accretive, provenance-stamped enrichment layer over the
+// federated corpus (increment 1: Cleveland harvest + write-back seam + the
+// `Federation.getArtwork`/`registryStats` read surface). See
+// `docs/plans/catalogue-raisonne-increment-1.md`. Never "the catalogue," never
+// a completeness claim; present-state only, everywhere this is surfaced.
+export {
+  canonicalStatus,
+  proposeWriteBack,
+  validateWriteBackRequest,
+  enumerateClevelandIds,
+  stampClevelandEntry,
+  harvestClevelandBatch,
+  runClevelandHarvest,
+  type WorkIdentity,
+  type AssertionField,
+  type EvidenceType,
+  type Evidence,
+  type DisputeStatus,
+  type Assertion,
+  type RightsPosture,
+  type RightsPostureRecord,
+  type ContributorCredentialTier,
+  type EvidenceGrade,
+  type TrustState,
+  type CanonicalStatus,
+  type RegistryEntry,
+  type ArtworkEnrichment,
+  type RegistryStore,
+  type WriteBackRequest,
+  type WriteBackOptions,
+  type WriteBackOutcome,
+  type HarvestCheckpointStore,
+  type HarvestOptions,
+  type HarvestBatchResult,
+  type HarvestRunResult,
+} from './registry/index.js';
+
 // Tier-1 delegated-attestor envelope/format library — KEYLESS. `prepareTier1`
 // emits a keyless signing request (the only thing the OMA service signs);
 // `verifyTier1` is the fail-closed, public-key-only verifier. The COSE primitives

--- a/src/core/registry/canonical.ts
+++ b/src/core/registry/canonical.ts
@@ -1,0 +1,17 @@
+import type { Assertion, CanonicalStatus } from './types.js';
+
+/**
+ * A record crosses into the canonical layer as soon as ANY assertion carries
+ * evidence beyond a bare self-attestation, the three canonical entry routes
+ * (museum-backed open record / CR-backed with verifiable bibliographic
+ * provenance / multi-source corroborated) are all forms of external evidence.
+ * A record whose assertions are ALL `artist-attestation`-only stays
+ * pre-canonical-pending: visible as a claim, never surfaced as canonical,
+ * until an external counter-signature (a museum/gallery attestation) arrives.
+ */
+export function canonicalStatus(assertions: Assertion[]): CanonicalStatus {
+  const hasExternalEvidence = assertions.some((a) =>
+    a.evidence.some((e) => e.type !== 'artist-attestation'),
+  );
+  return hasExternalEvidence ? 'canonical' : 'pre-canonical-pending';
+}

--- a/src/core/registry/harvest/cleveland.ts
+++ b/src/core/registry/harvest/cleveland.ts
@@ -1,0 +1,224 @@
+import { clevelandFetcher } from '../../../fetchers/cleveland.js';
+import { httpGet } from '../../../fetchers/helpers.js';
+import type { Artwork } from '../../../types.js';
+import type { Awaitable } from '../../cache.js';
+import { canonicalStatus } from '../canonical.js';
+import type { Assertion, AssertionField, Evidence, RegistryEntry, WorkIdentity } from '../types.js';
+import type { RegistryStore } from '../store.js';
+
+const CLEVELAND_API = 'https://openaccess-api.clevelandart.org/api';
+const DEFAULT_BATCH_SIZE = 100;
+const DEFAULT_CONCURRENCY = 4;
+
+/**
+ * Persisted cursor for a resumable harvest. OMA implements the concrete
+ * storage (a single row/key is enough, this is not per-object state); the
+ * engine only defines the shape it needs to resume correctly after a crash
+ * or deploy instead of re-walking the whole catalogue.
+ */
+export interface HarvestCheckpointStore {
+  /** Last `skip` offset successfully completed, as a string, or null before the first run. */
+  getCheckpoint(): Awaitable<string | null>;
+  setCheckpoint(skip: string): Awaitable<void>;
+}
+
+export interface HarvestOptions {
+  batchSize?: number;
+  concurrency?: number;
+  /** Injectable for deterministic tests; defaults to `new Date().toISOString()`. */
+  clock?: () => string;
+  /** Stop after this many batches, a test/dry-run hook. Undefined runs to completion. */
+  maxBatches?: number;
+}
+
+export interface HarvestBatchResult {
+  processed: number;
+  stored: number;
+  rejected: number;
+  /** Next `skip` offset to resume from, or null once enumeration is exhausted. */
+  nextSkip: number | null;
+}
+
+export interface HarvestRunResult {
+  batches: number;
+  totalStored: number;
+  totalRejected: number;
+}
+
+/**
+ * One page of Cleveland's open-access catalogue, oldest-id-first for
+ * deterministic resumability. Enumeration is a thin pagination wrapper
+ * around the SAME `/api/artworks/` endpoint `clevelandFetcher.search`
+ * already calls, no `q` param, so it walks the full `cc0=1&has_image=1`
+ * set instead of a keyword query.
+ */
+export async function enumerateClevelandIds(
+  skip: number,
+  limit: number,
+): Promise<{ ids: string[]; nextSkip: number | null }> {
+  const url = new URL(`${CLEVELAND_API}/artworks/`);
+  url.searchParams.set('cc0', '1');
+  url.searchParams.set('has_image', '1');
+  url.searchParams.set('skip', String(skip));
+  url.searchParams.set('limit', String(limit));
+  url.searchParams.set('fields', 'id');
+
+  const res = await httpGet(url);
+  if (!res.ok) throw new Error(`Cleveland enumerate failed: ${res.status}`);
+  const json = (await res.json()) as { data?: Array<{ id?: unknown }> };
+  const data = json.data ?? [];
+  const ids = data
+    .map((d) => (typeof d.id === 'number' ? `cleveland:${d.id}` : null))
+    .filter((s): s is string => s !== null);
+
+  // A short page (fewer ids than requested) means enumeration is exhausted.
+  return { ids, nextSkip: ids.length < limit ? null : skip + limit };
+}
+
+/**
+ * Wrap a rights-gate-accepted Cleveland `Artwork` as an increment-1 registry
+ * entry. Increment 1 mints `registryId` as the deterministic function
+ * `registryId === art.id` (see {@link WorkIdentity}), no separate lookup
+ * needed since every entry is per-source. The baseline assertion SET is
+ * derived from fields the fetcher already normalized (title, attributed
+ * creator, display date), each citing the single museum-record evidence
+ * entry, this is the "museum's own metadata is evidence-grade
+ * source-linked, not automatically cr-grade" baseline the design doc
+ * describes; write-back assertions with stronger evidence supersede it later.
+ */
+export function stampClevelandEntry(art: Artwork, now: string): RegistryEntry {
+  const identity: WorkIdentity = {
+    registryId: art.id,
+    sourceRefs: [{ source: art.museum.code, id: art.id, role: 'primary' }],
+    createdAt: now,
+  };
+
+  const baseEvidence: Evidence = {
+    type: 'museum-record',
+    citation: `${art.museum.name} open-access record ${art.id}`,
+    url: art.source.apiUrl,
+    retrievedAt: now,
+  };
+
+  const assertions: Assertion[] = [];
+  let n = 0;
+  const push = (field: AssertionField, value: string) => {
+    n++;
+    assertions.push({
+      id: `${art.id}:${n}`,
+      subject: art.id,
+      field,
+      value,
+      evidence: [baseEvidence],
+      disputeStatus: 'undisputed',
+      assertedBy: { contributorId: 'system:cleveland-harvest', ocmTier: 0 },
+      assertedAt: now,
+    });
+  };
+
+  push('title', art.title);
+  // 'Unknown' is the fetcher's own fallback for a missing creator name (see
+  // cleveland.ts normalize()), not a real attribution to stamp as an assertion.
+  if (art.artist.attributionType !== 'anonymous' && art.artist.name && art.artist.name !== 'Unknown') {
+    push('createdBy', art.artist.name);
+  }
+  if (art.displayDate) push('datedTo', art.displayDate);
+
+  return {
+    identity,
+    assertions,
+    rightsPosture: {
+      posture: 'can_store_and_republish',
+      basis: 'Cleveland Museum of Art Open Access: metadata is CC0.',
+      determinedAt: now,
+    },
+    trust: { contributorCredentialTier: 0, evidenceGrade: 'source-linked' },
+    canonicalStatus: canonicalStatus(assertions),
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+async function withConcurrency<T>(items: T[], limit: number, fn: (item: T) => Promise<void>): Promise<void> {
+  let next = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    for (;;) {
+      const idx = next++;
+      if (idx >= items.length) return;
+      await fn(items[idx]);
+    }
+  });
+  await Promise.all(workers);
+}
+
+/**
+ * Enumerate + hydrate + gate + stamp + write ONE page. Hydration reuses
+ * `clevelandFetcher.getRaw`/`normalize` UNMODIFIED, the engine already knows
+ * how to read a Cleveland record and gate its rights; this function's only
+ * new responsibility is enumeration and the registry-entry stamp. A
+ * rights-gate rejection is logged as a count, never stored (same
+ * strict-default-deny discipline as the live federation path).
+ */
+export async function harvestClevelandBatch(
+  skip: number,
+  store: RegistryStore,
+  opts: HarvestOptions = {},
+): Promise<HarvestBatchResult> {
+  const batchSize = opts.batchSize ?? DEFAULT_BATCH_SIZE;
+  const concurrency = opts.concurrency ?? DEFAULT_CONCURRENCY;
+  const clock = opts.clock ?? (() => new Date().toISOString());
+
+  const { ids, nextSkip } = await enumerateClevelandIds(skip, batchSize);
+
+  let stored = 0;
+  let rejected = 0;
+
+  await withConcurrency(ids, concurrency, async (id) => {
+    const raw = await clevelandFetcher.getRaw(id);
+    const result = clevelandFetcher.normalize(raw);
+    if (result.status === 'rejected') {
+      rejected++;
+      return;
+    }
+    await store.upsertEntry(stampClevelandEntry(result.artwork, clock()));
+    stored++;
+  });
+
+  return { processed: ids.length, stored, rejected, nextSkip };
+}
+
+/**
+ * Drives the full resumable harvest against an injected checkpoint store,
+ * batch by batch, until enumeration is exhausted (or `maxBatches` is hit, a
+ * test/dry-run hook). The checkpoint is persisted after every batch so a
+ * crash or deploy resumes from the next unprocessed page, never re-walking
+ * already-harvested records. `upsertEntry` is idempotent (keyed by
+ * `identity.registryId`), so a re-run after a crash never double-inserts.
+ * OMA supplies both `store` and `checkpoints`; this function contains no
+ * storage of its own, bounded concurrency here is a stopgap for the
+ * per-museum circuit breaker the engine's E2 resilience drive is landing;
+ * this harvest job should sit behind that same fetch path once it ships.
+ */
+export async function runClevelandHarvest(
+  store: RegistryStore,
+  checkpoints: HarvestCheckpointStore,
+  opts: HarvestOptions = {},
+): Promise<HarvestRunResult> {
+  let skip = Number((await checkpoints.getCheckpoint()) ?? '0');
+  let batches = 0;
+  let totalStored = 0;
+  let totalRejected = 0;
+
+  while (opts.maxBatches === undefined || batches < opts.maxBatches) {
+    const result = await harvestClevelandBatch(skip, store, opts);
+    totalStored += result.stored;
+    totalRejected += result.rejected;
+    batches++;
+
+    if (result.nextSkip === null) break;
+    skip = result.nextSkip;
+    await checkpoints.setCheckpoint(String(skip));
+  }
+
+  return { batches, totalStored, totalRejected };
+}

--- a/src/core/registry/harvest/cleveland.ts
+++ b/src/core/registry/harvest/cleveland.ts
@@ -3,6 +3,7 @@ import { httpGet } from '../../../fetchers/helpers.js';
 import type { Artwork } from '../../../types.js';
 import type { Awaitable } from '../../cache.js';
 import { canonicalStatus } from '../canonical.js';
+import { PENDING_OC_TIER } from '../types.js';
 import type { Assertion, AssertionField, Evidence, RegistryEntry, WorkIdentity } from '../types.js';
 import type { RegistryStore } from '../store.js';
 
@@ -111,7 +112,7 @@ export function stampClevelandEntry(art: Artwork, now: string): RegistryEntry {
       value,
       evidence: [baseEvidence],
       disputeStatus: 'undisputed',
-      assertedBy: { contributorId: 'system:cleveland-harvest', ocmTier: 0 },
+      assertedBy: { contributorId: 'system:cleveland-harvest', ocmTier: PENDING_OC_TIER },
       assertedAt: now,
     });
   };
@@ -132,7 +133,7 @@ export function stampClevelandEntry(art: Artwork, now: string): RegistryEntry {
       basis: 'Cleveland Museum of Art Open Access: metadata is CC0.',
       determinedAt: now,
     },
-    trust: { contributorCredentialTier: 0, evidenceGrade: 'source-linked' },
+    trust: { contributorCredentialTier: PENDING_OC_TIER, evidenceGrade: 'source-linked' },
     canonicalStatus: canonicalStatus(assertions),
     createdAt: now,
     updatedAt: now,

--- a/src/core/registry/index.ts
+++ b/src/core/registry/index.ts
@@ -22,6 +22,7 @@ export type {
   RegistryEntry,
   ArtworkEnrichment,
 } from './types.js';
+export { PENDING_OC_TIER } from './types.js';
 export { canonicalStatus } from './canonical.js';
 export type { RegistryStore } from './store.js';
 export {

--- a/src/core/registry/index.ts
+++ b/src/core/registry/index.ts
@@ -1,0 +1,43 @@
+/**
+ * The registry: an accretive, provenance-stamped enrichment layer over the
+ * engine's federated corpus. See `docs/plans/catalogue-raisonne-increment-1.md`
+ * for the full design. Increment 1 only: Cleveland harvest, write-back seam,
+ * MCP read shape (`Federation.getArtwork`'s `enrichment` attach + `registryStats`).
+ *
+ * Positioning discipline: never "the catalogue," never a completeness claim.
+ */
+export type {
+  WorkIdentity,
+  AssertionField,
+  EvidenceType,
+  Evidence,
+  DisputeStatus,
+  Assertion,
+  RightsPosture,
+  RightsPostureRecord,
+  ContributorCredentialTier,
+  EvidenceGrade,
+  TrustState,
+  CanonicalStatus,
+  RegistryEntry,
+  ArtworkEnrichment,
+} from './types.js';
+export { canonicalStatus } from './canonical.js';
+export type { RegistryStore } from './store.js';
+export {
+  proposeWriteBack,
+  validateWriteBackRequest,
+  type WriteBackRequest,
+  type WriteBackOptions,
+  type WriteBackOutcome,
+} from './writeBack.js';
+export {
+  enumerateClevelandIds,
+  stampClevelandEntry,
+  harvestClevelandBatch,
+  runClevelandHarvest,
+  type HarvestCheckpointStore,
+  type HarvestOptions,
+  type HarvestBatchResult,
+  type HarvestRunResult,
+} from './harvest/cleveland.js';

--- a/src/core/registry/store.ts
+++ b/src/core/registry/store.ts
@@ -1,0 +1,33 @@
+import type { Awaitable } from '../cache.js';
+import type { Assertion, RegistryEntry } from './types.js';
+
+/**
+ * The store contract the registry (enrichment) layer depends on. Mirrors
+ * `CacheStore`'s injection pattern deliberately: `/core` carries no storage of
+ * its own, OMA supplies the concrete (D1/R2/PG) implementation, and this
+ * interface is what makes that swap possible without touching engine code.
+ *
+ * [DECISION-NEEDED -> OMA]: this is the CONTRACT the future store must
+ * satisfy, not an implementation, the concrete store (schema, backing
+ * technology) is OMA's build, sequenced after the go-live wave.
+ */
+export interface RegistryStore {
+  getEntry(registryId: string): Awaitable<RegistryEntry | null>;
+  /** Harvest-path write: insert or fully replace an entry, keyed by `identity.registryId`. */
+  upsertEntry(entry: RegistryEntry): Awaitable<void>;
+  /**
+   * Write-back-path write: append one already-assembled, already-validated
+   * assertion. Increment 1 treats every caller as internal/trusted, so a
+   * conforming implementation always applies immediately (`status:
+   * 'applied'`). The openclearance Tier-2 external-write gate is this SAME
+   * method, wired later by OM-C, a credential check inside the
+   * implementation that routes untrusted/low-tier callers to `'pending'`
+   * (the pre-canonical queue) instead, not a new method or a seam redesign.
+   */
+  proposeAssertion(req: {
+    subject: string;
+    assertion: Assertion;
+  }): Awaitable<{ status: 'applied' | 'pending' }>;
+  /** Present-state counts only. Never described as complete, growing, not exhaustive. */
+  getStats(): Awaitable<{ entryCount: number; withEnrichmentCount: number }>;
+}

--- a/src/core/registry/types.ts
+++ b/src/core/registry/types.ts
@@ -100,7 +100,7 @@ export interface Assertion {
   assertedBy: {
     contributorId: string;
     /** openclearance OCM tier of WHO is asserting. See {@link ContributorCredentialTier}. */
-    ocmTier: number;
+    ocmTier: ContributorCredentialTier;
   };
   assertedAt: string;
 }
@@ -129,12 +129,27 @@ export interface RightsPostureRecord {
 // --- Primitive 4: Trust ---
 
 /**
- * (a) WHO is asserting, external, owned by openclearance. Increment 1's
- * harvest-only source only ever stamps tier 0 (system harvest); higher tiers
- * are populated once the write-back seam gates untrusted callers (later
- * phase, wired by OM-C).
+ * (a) WHO is asserting, external, owned by openclearance. VALUE SPACE IS
+ * OM-C-OWNED-PENDING (OM-CR CHANGES, 2026-07-03): openclearance's shipped
+ * `VerificationState` is a 3-valued enum (per OM-C's W-6 roadmap work);
+ * credential-tier semantics here MUST adopt OM-C's ruling verbatim once it
+ * lands, never diverge from it with an independently invented range. Until
+ * then this is an OPAQUE STRING placeholder: never parsed, ordered, or
+ * compared numerically anywhere in this repo. The one sentinel this repo
+ * mints pre-ruling is {@link PENDING_OC_TIER}; every other value is reserved
+ * for OM-C's future ruling to define.
  */
-export type ContributorCredentialTier = 0 | 1 | 2 | 3;
+export type ContributorCredentialTier = string;
+
+/**
+ * Sentinel for "no credential-tier ruling has landed yet." The ONLY
+ * `ContributorCredentialTier` value this repo mints until OM-C's Tier-2/
+ * credential semantics are ruled (see {@link ContributorCredentialTier}).
+ * Increment 1's system harvest and every current write-back caller stamp
+ * this value; it carries no ordering or comparison meaning beyond "not yet
+ * rated," and must never be branched on as if it were a real tier.
+ */
+export const PENDING_OC_TIER: ContributorCredentialTier = 'pending-oc-ruling';
 
 /**
  * (b) HOW WELL-EVIDENCED the record is. A grade, never a numeric confidence

--- a/src/core/registry/types.ts
+++ b/src/core/registry/types.ts
@@ -1,0 +1,188 @@
+/**
+ * Types for the registry: an accretive, provenance-stamped enrichment layer
+ * over the engine's federated corpus. See `docs/plans/catalogue-raisonne-increment-1.md`
+ * for the full design (this module implements Primitives 1-4 of that doc).
+ *
+ * Positioning discipline: this is a growing enrichment layer, never "the
+ * catalogue" or a completeness/authority claim. Every present-state surface
+ * built on these types must read "N, growing," never "complete."
+ */
+
+// --- Primitive 1: Identity ---
+
+/**
+ * A work's identity is distinct from any one source's record of it.
+ * Increment 1 keeps identity PER-SOURCE: `registryId` is minted once, at
+ * harvest time, as the deterministic function `registryId === sourceArtworkId`
+ * (e.g. "cleveland:108312"), there is exactly one `sourceRefs` entry with
+ * `role: 'primary'`. Cross-source merge (a later phase, deferred behind a
+ * confidence gate) is what makes `registryId` diverge from any single
+ * source id and populates a second `sourceRefs` entry with `role:
+ * 'corroborating'`; this shape doesn't need to change to support that.
+ */
+export interface WorkIdentity {
+  /** Stable once minted; never reassigned. */
+  registryId: string;
+  sourceRefs: Array<{
+    /** Museum/registry code, matches `Fetcher.code`. */
+    source: string;
+    /** The source-native `Artwork.id` this identity currently resolves to. */
+    id: string;
+    role: 'primary' | 'corroborating';
+  }>;
+  /**
+   * Reserved for future perceptual-hash/embedding linkage (C2PA soft-binding
+   * aligned; DINOHash/pHash two-tier, see the locked drive doc's "visual
+   * fingerprint" section). Field reserved now, NOT computed by increment 1.
+   * Always absent until the fingerprint pipeline ships; never populate with a
+   * placeholder or fake value.
+   */
+  fingerprint?: {
+    algorithm: string;
+    value: string;
+    computedAt: string;
+  };
+  createdAt: string;
+}
+
+// --- Primitive 2: Assertion + Evidence ---
+
+export type AssertionField =
+  | 'createdBy'
+  | 'datedTo'
+  | 'exhibitedAt'
+  | 'publishedIn'
+  | 'ownedBy'
+  | 'licensedBy'
+  | 'title'
+  | 'medium'
+  | 'dimensions'
+  | 'provenanceEvent'
+  | 'other';
+
+export type EvidenceType =
+  | 'museum-record' // the source museum's own API/metadata (the harvest baseline)
+  | 'catalogue-entry' // a published catalogue raisonné entry (link/citation, never bulk-ingested)
+  | 'archive-doc'
+  | 'auction-lot'
+  | 'artist-attestation' // self-attestation via OCM/C2PA; always PRE-canonical alone, see canonicalStatus()
+  | 'estate-letter'
+  | 'scholar-review';
+
+export interface Evidence {
+  type: EvidenceType;
+  /** Free-text or structured citation to the underlying document/record. Never re-hosts copyrighted text. */
+  citation: string;
+  /** Direct link when one exists and is safe to link (respects the record's rights posture). */
+  url?: string;
+  retrievedAt: string;
+}
+
+export type DisputeStatus = 'undisputed' | 'disputed' | 'superseded';
+
+/**
+ * Separates WORK IDENTITY from an ASSERTION about the work. Each assertion
+ * carries its own evidence and its own dispute status, so a contested
+ * attribution is a first-class object, never a silently overwritten string.
+ * `evidence` is intentionally required, non-optional: a bare claim with zero
+ * evidence is not a well-formed assertion under this model.
+ */
+export interface Assertion {
+  id: string;
+  /** `WorkIdentity.registryId`. */
+  subject: string;
+  field: AssertionField;
+  value: string;
+  evidence: Evidence[];
+  disputeStatus: DisputeStatus;
+  /** Present when `disputeStatus !== 'undisputed'`: the competing assertion(s), never silently dropped. */
+  supersedes?: string;
+  assertedBy: {
+    contributorId: string;
+    /** openclearance OCM tier of WHO is asserting. See {@link ContributorCredentialTier}. */
+    ocmTier: number;
+  };
+  assertedAt: string;
+}
+
+// --- Primitive 3: Rights posture ---
+
+/**
+ * What the REGISTRY ITSELF (the enrichment record, not the museum's image) is
+ * allowed to do with a piece of evidence or a linked record. Distinct from
+ * (and does not duplicate) `Artwork.license` / the Clearance Manifest rights
+ * block, which governs the 2D image pixels.
+ */
+export type RightsPosture =
+  | 'can_store_and_republish' // CC0/PD museum metadata, e.g. the Cleveland harvest baseline
+  | 'can_store_metadata_only' // open metadata, no republishing of any linked media/text
+  | 'can_link_only' // restricted platforms (e.g. IFAR): cite/deep-link, never bulk-ingest
+  | 'requires_partner_agreement';
+
+export interface RightsPostureRecord {
+  posture: RightsPosture;
+  /** Human-readable rule, mirrors `ClearanceBasis.summary` style. */
+  basis: string;
+  determinedAt: string;
+}
+
+// --- Primitive 4: Trust ---
+
+/**
+ * (a) WHO is asserting, external, owned by openclearance. Increment 1's
+ * harvest-only source only ever stamps tier 0 (system harvest); higher tiers
+ * are populated once the write-back seam gates untrusted callers (later
+ * phase, wired by OM-C).
+ */
+export type ContributorCredentialTier = 0 | 1 | 2 | 3;
+
+/**
+ * (b) HOW WELL-EVIDENCED the record is. A grade, never a numeric confidence
+ * score: a single number launders uncertainty; the assertion/evidence/dispute
+ * structure is what carries trust legibly.
+ */
+export type EvidenceGrade = 'claim' | 'source-linked' | 'attested' | 'corroborated' | 'cr-grade';
+
+/**
+ * Two SEPARATE axes, never conflated. `contributorCredentialTier` and
+ * `evidenceGrade` answer different questions (who vouches vs. how
+ * well-evidenced) and must not be collapsed into one score.
+ */
+export interface TrustState {
+  contributorCredentialTier: ContributorCredentialTier;
+  evidenceGrade: EvidenceGrade;
+}
+
+/**
+ * Only externally evidenced records enter the canonical layer. Self-attested
+ * material (an `artist-attestation` evidence entry with no external
+ * counter-signature) sits in a separate pre-canonical PENDING layer: visible
+ * as a claim, never surfaced as a canonical registry entry.
+ */
+export type CanonicalStatus = 'canonical' | 'pre-canonical-pending';
+
+// --- Registry entry (the four primitives, composed) ---
+
+export interface RegistryEntry {
+  identity: WorkIdentity;
+  assertions: Assertion[];
+  rightsPosture: RightsPostureRecord;
+  trust: TrustState;
+  canonicalStatus: CanonicalStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// --- MCP-facing summary (attached to `Artwork.enrichment`) ---
+
+/**
+ * Provenance-enrichment summary surfaced on `get_artwork`. Present-state
+ * only, never a completeness claim: absence means "no registry entry yet,"
+ * not "unimportant work."
+ */
+export interface ArtworkEnrichment {
+  registryId: string;
+  canonicalStatus: CanonicalStatus;
+  evidenceGrade: EvidenceGrade;
+  assertionCount: number;
+}

--- a/src/core/registry/writeBack.ts
+++ b/src/core/registry/writeBack.ts
@@ -1,0 +1,77 @@
+import type { Assertion } from './types.js';
+import type { RegistryStore } from './store.js';
+
+/**
+ * The low-friction contract any fleet lane calls when it researches a work
+ * for its own purpose (a story's provenance note, an attribution note, a
+ * plate credit, a caption fact) and wants the extracted detail to compound
+ * back into the registry instead of living only in that lane's own output.
+ */
+export interface WriteBackRequest {
+  /** `WorkIdentity.registryId` (increment 1: the source `Artwork.id`). */
+  subject: string;
+  assertion: Omit<Assertion, 'id' | 'subject' | 'assertedAt'>;
+}
+
+export interface WriteBackOptions {
+  /** Injectable for deterministic tests; defaults to `new Date().toISOString()`. */
+  clock?: () => string;
+  /** Injectable for deterministic tests; defaults to the global `crypto.randomUUID()` (Node + Workers safe). */
+  idGen?: () => string;
+}
+
+export type WriteBackOutcome =
+  | { ok: true; assertionId: string; status: 'applied' | 'pending' }
+  | { ok: false; reason: string };
+
+/**
+ * Every write-back assertion must carry at least one evidence entry, a lane
+ * calling this seam supplies its own research citation, never a bare value.
+ * `Assertion.evidence` is non-optional at the type level, but a request
+ * arriving over an untyped boundary (MCP JSON args, a future HTTP endpoint)
+ * bypasses that compile-time check, so this validates again at the runtime
+ * boundary.
+ */
+export function validateWriteBackRequest(req: WriteBackRequest): string | null {
+  if (!req.subject || req.subject.trim() === '') {
+    return 'write-back: subject (registryId) is required';
+  }
+  if (!req.assertion.evidence || req.assertion.evidence.length === 0) {
+    return 'write-back: at least one evidence entry is required, never a bare value';
+  }
+  if (!req.assertion.value || req.assertion.value.trim() === '') {
+    return 'write-back: assertion value is required';
+  }
+  return null;
+}
+
+/**
+ * Assembles a full {@link Assertion} (mints its id + timestamp) from a
+ * write-back request and delegates persistence to the injected
+ * {@link RegistryStore}. Increment 1 treats every caller as internal/trusted
+ *, the store returns `status: 'applied'` today; once the openclearance
+ * Tier-2 gate lands (later, wired by OM-C), an untrusted/low-tier caller's
+ * request lands `'pending'` from the SAME store method, no seam change here.
+ */
+export async function proposeWriteBack(
+  store: RegistryStore,
+  req: WriteBackRequest,
+  opts: WriteBackOptions = {},
+): Promise<WriteBackOutcome> {
+  const invalid = validateWriteBackRequest(req);
+  if (invalid) return { ok: false, reason: invalid };
+
+  const clock = opts.clock ?? (() => new Date().toISOString());
+  const idGen = opts.idGen ?? (() => crypto.randomUUID());
+  const assertedAt = clock();
+
+  const assertion: Assertion = {
+    ...req.assertion,
+    id: idGen(),
+    subject: req.subject,
+    assertedAt,
+  };
+
+  const result = await store.proposeAssertion({ subject: req.subject, assertion });
+  return { ok: true, assertionId: assertion.id, status: result.status };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -207,13 +207,19 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
             description:
               'Optional filter for records with at least one openly-licensed 3D scan (Cleveland Museum of Art via Sketchfab, currently the only source). Post-fetch over the bounded window, so this may return fewer than `limit`.',
           },
+          has_enrichment: {
+            type: 'boolean',
+            description:
+              'Optional filter for records with a resolving provenance-enrichment registry entry. Only meaningful when this deployment has a registry store configured; on most deployments no record carries one yet, so this returns an empty page rather than erroring. Post-fetch over the bounded window, so this may return fewer than `limit`.',
+          },
         },
         required: ['query'],
       },
     },
     {
       name: 'get_artwork',
-      description: 'Fetch a single artwork by its normalized ID (e.g. met:436533).',
+      description:
+        'Fetch a single artwork by its normalized ID (e.g. met:436533). When a registry entry exists, includes provenance-enrichment metadata (evidence grade, assertion count). Most works have none yet; this is not a completeness signal.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -289,6 +295,15 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           year_max: { type: 'integer', description: 'Optional inclusive upper bound on creation year (negative = BCE).' },
         },
         required: ['query'],
+      },
+    },
+    {
+      name: 'registry_stats',
+      description:
+        'Present-state counts for the provenance-enrichment registry: total entries and how many carry enrichment beyond the museum-source baseline. Growing, not exhaustive; reflects only sources harvested so far, never described as complete. Returns a hint if this deployment has no registry store configured.',
+      inputSchema: {
+        type: 'object',
+        properties: {},
       },
     },
     {
@@ -400,6 +415,16 @@ async function handleDiscoverRandom(args: unknown) {
   return { content: [{ type: 'text' as const, text: JSON.stringify(artwork, null, 2) }] };
 }
 
+async function handleRegistryStats() {
+  const stats = await federation.registryStats();
+  if (!stats) {
+    return errorResult(
+      'No provenance-enrichment registry is configured on this deployment yet. registry_stats reflects a registry store when one is wired in; none is available here.',
+    );
+  }
+  return { content: [{ type: 'text' as const, text: JSON.stringify(stats, null, 2) }] };
+}
+
 function handleListTraditions() {
   const traditions = cache.listTraditions();
   const isEmpty = traditions.regions.length === 0 && traditions.periods.length === 0;
@@ -420,6 +445,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     if (name === 'cite') return await handleCite(args);
     if (name === 'discover_random') return await handleDiscoverRandom(args);
     if (name === 'list_traditions') return handleListTraditions();
+    if (name === 'registry_stats') return await handleRegistryStats();
     if (name === 'clearance_record') return await handleClearanceRecord(federation, args);
     return errorResult(`unknown tool: ${name}`);
   } catch (err) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,8 @@
 import type { ColorFamily, PaletteEntry } from './color/colorMath.js';
 import type { MediumCategory } from './medium.js';
+import type { ArtworkEnrichment } from './core/registry/types.js';
 
-export type { ColorFamily, MediumCategory, PaletteEntry };
+export type { ColorFamily, MediumCategory, PaletteEntry, ArtworkEnrichment };
 
 export type LicenseType = 'CC0' | 'PD' | 'CC-BY' | 'CC-BY-SA' | 'OTHER' | 'UNKNOWN';
 
@@ -167,6 +168,14 @@ export interface Artwork {
    * by the Cleveland adapter (Sketchfab via `sketchfab_id`); Smithsonian 3D next.
    */
   models3d?: Model3D[];
+  /**
+   * Provenance-enrichment summary from the registry layer, present only when
+   * a `registryStore` is configured (OMA's future store, not built into any
+   * current deployment) and a registry entry resolves for this id. Absent
+   * (not `null`) otherwise: "no registry entry yet," never a completeness
+   * signal about the work itself. See `docs/plans/catalogue-raisonne-increment-1.md`.
+   */
+  enrichment?: ArtworkEnrichment;
 }
 
 /**

--- a/tests/federation.test.ts
+++ b/tests/federation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createFederation, UnknownMuseumError } from '../src/core/index.js';
+import { createFederation, PENDING_OC_TIER, UnknownMuseumError } from '../src/core/index.js';
 import type { CacheStore, RegistryEntry } from '../src/core/index.js';
 import type { Fetcher } from '../src/fetchers/types.js';
 import type { Artwork, ValidationResult } from '../src/types.js';
@@ -17,12 +17,12 @@ function registryEntry(registryId: string, over: Partial<RegistryEntry> = {}): R
         value: 'Test',
         evidence: [{ type: 'museum-record', citation: 'c', retrievedAt: now }],
         disputeStatus: 'undisputed',
-        assertedBy: { contributorId: 'system', ocmTier: 0 },
+        assertedBy: { contributorId: 'system', ocmTier: PENDING_OC_TIER },
         assertedAt: now,
       },
     ],
     rightsPosture: { posture: 'can_store_and_republish', basis: 'CC0', determinedAt: now },
-    trust: { contributorCredentialTier: 0, evidenceGrade: 'source-linked' },
+    trust: { contributorCredentialTier: PENDING_OC_TIER, evidenceGrade: 'source-linked' },
     canonicalStatus: 'canonical',
     createdAt: now,
     updatedAt: now,

--- a/tests/federation.test.ts
+++ b/tests/federation.test.ts
@@ -1,8 +1,34 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createFederation, UnknownMuseumError } from '../src/core/index.js';
-import type { CacheStore } from '../src/core/index.js';
+import type { CacheStore, RegistryEntry } from '../src/core/index.js';
 import type { Fetcher } from '../src/fetchers/types.js';
 import type { Artwork, ValidationResult } from '../src/types.js';
+import { memoryRegistryStore } from './registry/helpers.js';
+
+function registryEntry(registryId: string, over: Partial<RegistryEntry> = {}): RegistryEntry {
+  const now = '2026-01-01T00:00:00.000Z';
+  return {
+    identity: { registryId, sourceRefs: [{ source: registryId.split(':')[0], id: registryId, role: 'primary' }], createdAt: now },
+    assertions: [
+      {
+        id: `${registryId}:1`,
+        subject: registryId,
+        field: 'title',
+        value: 'Test',
+        evidence: [{ type: 'museum-record', citation: 'c', retrievedAt: now }],
+        disputeStatus: 'undisputed',
+        assertedBy: { contributorId: 'system', ocmTier: 0 },
+        assertedAt: now,
+      },
+    ],
+    rightsPosture: { posture: 'can_store_and_republish', basis: 'CC0', determinedAt: now },
+    trust: { contributorCredentialTier: 0, evidenceGrade: 'source-linked' },
+    canonicalStatus: 'canonical',
+    createdAt: now,
+    updatedAt: now,
+    ...over,
+  };
+}
 
 function makeArtwork(id: string, over: Partial<Artwork> = {}): Artwork {
   const code = id.slice(0, id.indexOf(':'));
@@ -37,7 +63,14 @@ function memoryCache() {
   const objects = new Map<string, Artwork>();
   const queries = new Map<string, string[]>();
   const store: CacheStore = {
-    getObject: (id) => objects.get(id) ?? null,
+    // Mirrors the real `Cache.getObject` (db.ts), which JSON.parses a fresh
+    // copy from `full_record` on every read; a caller mutating the returned
+    // artwork in memory (hotlinkRestricted backfill, registry enrichment
+    // attach) never silently mutates the stored row.
+    getObject: (id) => {
+      const a = objects.get(id);
+      return a ? (JSON.parse(JSON.stringify(a)) as Artwork) : null;
+    },
     upsertObject: (a) => {
       objects.set(a.id, a);
     },
@@ -775,5 +808,90 @@ describe('stable sort — deterministic search ordering', () => {
     const out = await fed.search({ query: 'painting', has_image: true, limit: 10 });
     const ids = out.results.map((r) => r.id);
     expect(ids).toEqual([...ids].sort((x, y) => x.localeCompare(y)));
+  });
+});
+
+describe('createFederation registry (provenance-enrichment) wiring', () => {
+  it('leaves enrichment unset when no registryStore is configured (every current deployment)', async () => {
+    const t = fakeFetcher('test', { ids: ['test:1'], accept: new Set(['test:1']) });
+    const { store } = memoryCache();
+    const fed = createFederation({ fetchers: { test: t.fetcher }, cache: store });
+
+    const out = await fed.getArtwork('test:1');
+    expect(out.ok).toBe(true);
+    if (out.ok) expect(out.artwork.enrichment).toBeUndefined();
+  });
+
+  it('attaches enrichment on a fresh fetch when a resolving registry entry exists', async () => {
+    const t = fakeFetcher('test', { ids: ['test:1'], accept: new Set(['test:1']) });
+    const { store } = memoryCache();
+    const { store: registryStore, entries } = memoryRegistryStore();
+    entries.set('test:1', registryEntry('test:1'));
+    const fed = createFederation({ fetchers: { test: t.fetcher }, cache: store, registryStore });
+
+    const out = await fed.getArtwork('test:1');
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.artwork.enrichment).toEqual({
+      registryId: 'test:1',
+      canonicalStatus: 'canonical',
+      evidenceGrade: 'source-linked',
+      assertionCount: 1,
+    });
+  });
+
+  it('attaches enrichment on a cache-hit path too, without persisting it into the object cache', async () => {
+    const t = fakeFetcher('test', { ids: ['test:1'], accept: new Set(['test:1']) });
+    const { store, objects } = memoryCache();
+    const { store: registryStore, entries } = memoryRegistryStore();
+    const fed = createFederation({ fetchers: { test: t.fetcher }, cache: store, registryStore });
+
+    // First call: no registry entry yet.
+    const first = await fed.getArtwork('test:1');
+    expect(first.ok).toBe(true);
+    if (first.ok) expect(first.artwork.enrichment).toBeUndefined();
+    // The cached copy stored during the fresh fetch carries no enrichment either.
+    expect(objects.get('test:1')?.enrichment).toBeUndefined();
+
+    // A registry entry now exists (e.g. a harvest ran); no re-fetch, served from cache.
+    entries.set('test:1', registryEntry('test:1'));
+    const getRawSpy = vi.spyOn(t.fetcher, 'getRaw');
+    const second = await fed.getArtwork('test:1');
+    expect(getRawSpy).not.toHaveBeenCalled();
+    expect(second.ok).toBe(true);
+    if (second.ok) expect(second.artwork.enrichment?.registryId).toBe('test:1');
+    // Still not persisted into the object cache; enrichment is looked up live.
+    expect(objects.get('test:1')?.enrichment).toBeUndefined();
+  });
+
+  it('has_enrichment filters to only records with a resolving registry entry', async () => {
+    const t = fakeFetcher('test', { ids: ['test:1', 'test:2'], accept: new Set(['test:1', 'test:2']) });
+    const { store } = memoryCache();
+    const { store: registryStore, entries } = memoryRegistryStore();
+    entries.set('test:1', registryEntry('test:1'));
+    const fed = createFederation({ fetchers: { test: t.fetcher }, cache: store, registryStore });
+
+    const out = await fed.search({ query: 'x', has_image: true, limit: 10, has_enrichment: true });
+    expect(out.results.map((r) => r.id)).toEqual(['test:1']);
+  });
+
+  it('has_enrichment returns an empty page (not an error) when no registryStore is configured', async () => {
+    const t = fakeFetcher('test', { ids: ['test:1'], accept: new Set(['test:1']) });
+    const { store } = memoryCache();
+    const fed = createFederation({ fetchers: { test: t.fetcher }, cache: store });
+
+    const out = await fed.search({ query: 'x', has_image: true, limit: 10, has_enrichment: true });
+    expect(out.results).toEqual([]);
+  });
+
+  it('registryStats returns null when unconfigured, and live counts when configured', async () => {
+    const { store } = memoryCache();
+    const unconfigured = createFederation({ fetchers: {}, cache: store });
+    expect(await unconfigured.registryStats()).toBeNull();
+
+    const { store: registryStore, entries } = memoryRegistryStore();
+    entries.set('test:1', registryEntry('test:1'));
+    const configured = createFederation({ fetchers: {}, cache: store, registryStore });
+    expect(await configured.registryStats()).toEqual({ entryCount: 1, withEnrichmentCount: 0 });
   });
 });

--- a/tests/registry/canonical.test.ts
+++ b/tests/registry/canonical.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { canonicalStatus } from '../../src/core/registry/index.js';
+import { canonicalStatus, PENDING_OC_TIER } from '../../src/core/registry/index.js';
 import type { Assertion } from '../../src/core/registry/index.js';
 
 function assertion(over: Partial<Assertion> = {}): Assertion {
@@ -10,7 +10,7 @@ function assertion(over: Partial<Assertion> = {}): Assertion {
     value: 'Test',
     evidence: [{ type: 'museum-record', citation: 'c', retrievedAt: '2026-01-01T00:00:00.000Z' }],
     disputeStatus: 'undisputed',
-    assertedBy: { contributorId: 'system', ocmTier: 0 },
+    assertedBy: { contributorId: 'system', ocmTier: PENDING_OC_TIER },
     assertedAt: '2026-01-01T00:00:00.000Z',
     ...over,
   };

--- a/tests/registry/canonical.test.ts
+++ b/tests/registry/canonical.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { canonicalStatus } from '../../src/core/registry/index.js';
+import type { Assertion } from '../../src/core/registry/index.js';
+
+function assertion(over: Partial<Assertion> = {}): Assertion {
+  return {
+    id: 'a1',
+    subject: 'cleveland:1',
+    field: 'title',
+    value: 'Test',
+    evidence: [{ type: 'museum-record', citation: 'c', retrievedAt: '2026-01-01T00:00:00.000Z' }],
+    disputeStatus: 'undisputed',
+    assertedBy: { contributorId: 'system', ocmTier: 0 },
+    assertedAt: '2026-01-01T00:00:00.000Z',
+    ...over,
+  };
+}
+
+describe('canonicalStatus', () => {
+  it('is canonical when any assertion carries museum-record evidence', () => {
+    expect(canonicalStatus([assertion()])).toBe('canonical');
+  });
+
+  it('is pre-canonical-pending when every assertion is self-attested only', () => {
+    const selfAttested = assertion({
+      evidence: [{ type: 'artist-attestation', citation: 'artist claim', retrievedAt: '2026-01-01T00:00:00.000Z' }],
+    });
+    expect(canonicalStatus([selfAttested])).toBe('pre-canonical-pending');
+  });
+
+  it('crosses to canonical once ANY assertion (not all) gains external evidence', () => {
+    const selfAttested = assertion({
+      id: 'a1',
+      evidence: [{ type: 'artist-attestation', citation: 'artist claim', retrievedAt: '2026-01-01T00:00:00.000Z' }],
+    });
+    const counterSigned = assertion({
+      id: 'a2',
+      evidence: [{ type: 'scholar-review', citation: 'review', retrievedAt: '2026-01-01T00:00:00.000Z' }],
+    });
+    expect(canonicalStatus([selfAttested, counterSigned])).toBe('canonical');
+  });
+
+  it('is pre-canonical-pending for an entry with no assertions at all', () => {
+    expect(canonicalStatus([])).toBe('pre-canonical-pending');
+  });
+});

--- a/tests/registry/harvest-cleveland.test.ts
+++ b/tests/registry/harvest-cleveland.test.ts
@@ -7,6 +7,7 @@ import {
   harvestClevelandBatch,
   runClevelandHarvest,
   stampClevelandEntry,
+  PENDING_OC_TIER,
 } from '../../src/core/registry/index.js';
 import { clevelandFetcher } from '../../src/fetchers/cleveland.js';
 import { memoryRegistryStore } from './helpers.js';
@@ -80,7 +81,7 @@ describe('stampClevelandEntry', () => {
     }
 
     expect(entry.rightsPosture.posture).toBe('can_store_and_republish');
-    expect(entry.trust).toEqual({ contributorCredentialTier: 0, evidenceGrade: 'source-linked' });
+    expect(entry.trust).toEqual({ contributorCredentialTier: PENDING_OC_TIER, evidenceGrade: 'source-linked' });
     expect(entry.canonicalStatus).toBe('canonical'); // museum-record evidence is external
   });
 

--- a/tests/registry/harvest-cleveland.test.ts
+++ b/tests/registry/harvest-cleveland.test.ts
@@ -1,0 +1,162 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  enumerateClevelandIds,
+  harvestClevelandBatch,
+  runClevelandHarvest,
+  stampClevelandEntry,
+} from '../../src/core/registry/index.js';
+import { clevelandFetcher } from '../../src/fetchers/cleveland.js';
+import { memoryRegistryStore } from './helpers.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+function fixture(name: string): unknown {
+  return JSON.parse(readFileSync(join(here, '..', 'fixtures', name), 'utf-8'));
+}
+
+const ACCEPTED_ID = 135299; // tests/fixtures/cleveland-accepted.json
+const REJECTED_ID = 990001; // tests/fixtures/cleveland-rejected-restricted.json
+
+/** Routes global fetch by URL shape: enumeration (skip/limit/fields=id) vs a single-object getRaw call. */
+function mockClevelandFetch(pages: Record<number, number[]>) {
+  globalThis.fetch = vi.fn(async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes('fields=id')) {
+      const skipMatch = /skip=(\d+)/.exec(url);
+      const skip = skipMatch ? Number(skipMatch[1]) : 0;
+      const ids = pages[skip] ?? [];
+      return new Response(JSON.stringify({ data: ids.map((id) => ({ id })) }), { status: 200 });
+    }
+    if (url.includes(`/artworks/${ACCEPTED_ID}`)) {
+      return new Response(JSON.stringify(fixture('cleveland-accepted.json')), { status: 200 });
+    }
+    if (url.includes(`/artworks/${REJECTED_ID}`)) {
+      return new Response(JSON.stringify(fixture('cleveland-rejected-restricted.json')), { status: 200 });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as unknown as typeof fetch;
+}
+
+describe('enumerateClevelandIds', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('paginates via skip/limit and signals exhaustion with a short page', async () => {
+    mockClevelandFetch({ 0: [ACCEPTED_ID, REJECTED_ID] });
+    const { ids, nextSkip } = await enumerateClevelandIds(0, 2);
+    expect(ids).toEqual(['cleveland:135299', 'cleveland:990001']);
+    // A full page (2 == limit) implies more may follow.
+    expect(nextSkip).toBe(2);
+  });
+
+  it('returns nextSkip null when the page is shorter than the requested limit', async () => {
+    mockClevelandFetch({ 0: [ACCEPTED_ID] });
+    const { ids, nextSkip } = await enumerateClevelandIds(0, 5);
+    expect(ids).toEqual(['cleveland:135299']);
+    expect(nextSkip).toBeNull();
+  });
+});
+
+describe('stampClevelandEntry', () => {
+  it('mints registryId as the source Artwork.id and derives a baseline assertion set', () => {
+    const result = clevelandFetcher.normalize(fixture('cleveland-accepted.json'));
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+
+    const entry = stampClevelandEntry(result.artwork, '2026-07-02T00:00:00.000Z');
+    expect(entry.identity.registryId).toBe('cleveland:135299');
+    expect(entry.identity.sourceRefs).toEqual([{ source: 'cleveland', id: 'cleveland:135299', role: 'primary' }]);
+    expect(entry.identity.fingerprint).toBeUndefined(); // reserved, never computed by increment 1
+
+    const fields = entry.assertions.map((a) => a.field);
+    expect(fields).toContain('title');
+    expect(fields).toContain('createdBy'); // van Gogh, named attribution
+    expect(fields).toContain('datedTo');
+    for (const a of entry.assertions) {
+      expect(a.evidence).toHaveLength(1);
+      expect(a.evidence[0].type).toBe('museum-record');
+      expect(a.disputeStatus).toBe('undisputed');
+    }
+
+    expect(entry.rightsPosture.posture).toBe('can_store_and_republish');
+    expect(entry.trust).toEqual({ contributorCredentialTier: 0, evidenceGrade: 'source-linked' });
+    expect(entry.canonicalStatus).toBe('canonical'); // museum-record evidence is external
+  });
+
+  it('omits the createdBy assertion for an anonymous/unknown attribution', () => {
+    const result = clevelandFetcher.normalize(fixture('cleveland-accepted.json'));
+    if (result.status !== 'accepted') throw new Error('fixture must be accepted');
+    result.artwork.artist = { name: 'Unknown', attributionType: 'anonymous' };
+
+    const entry = stampClevelandEntry(result.artwork, '2026-07-02T00:00:00.000Z');
+    expect(entry.assertions.map((a) => a.field)).not.toContain('createdBy');
+  });
+});
+
+describe('harvestClevelandBatch', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('hydrates via the unmodified clevelandFetcher, stores accepted records, counts rejections', async () => {
+    mockClevelandFetch({ 0: [ACCEPTED_ID, REJECTED_ID] });
+    const { store, entries } = memoryRegistryStore();
+
+    const result = await harvestClevelandBatch(0, store, { batchSize: 2, clock: () => '2026-07-02T00:00:00.000Z' });
+
+    expect(result).toEqual({ processed: 2, stored: 1, rejected: 1, nextSkip: 2 });
+    expect(entries.has('cleveland:135299')).toBe(true);
+    expect(entries.has('cleveland:990001')).toBe(false); // rights-gate rejection: never stored
+  });
+});
+
+describe('runClevelandHarvest', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('resumes from a persisted checkpoint and stops when enumeration is exhausted', async () => {
+    mockClevelandFetch({ 0: [ACCEPTED_ID], 1: [] });
+    const { store, entries } = memoryRegistryStore();
+    const checkpoints = { value: null as string | null };
+    const checkpointStore = {
+      getCheckpoint: () => checkpoints.value,
+      setCheckpoint: (skip: string) => {
+        checkpoints.value = skip;
+      },
+    };
+
+    const result = await runClevelandHarvest(store, checkpointStore, {
+      batchSize: 1,
+      clock: () => '2026-07-02T00:00:00.000Z',
+    });
+
+    expect(result).toEqual({ batches: 2, totalStored: 1, totalRejected: 0 });
+    expect(entries.has('cleveland:135299')).toBe(true);
+    expect(checkpoints.value).toBe('1'); // last completed page's nextSkip, persisted for resume
+  });
+
+  it('starts from a non-zero checkpoint instead of re-walking from the beginning', async () => {
+    mockClevelandFetch({ 5: [] });
+    const { store } = memoryRegistryStore();
+    const checkpointStore = {
+      getCheckpoint: () => '5',
+      setCheckpoint: () => {},
+    };
+
+    const result = await runClevelandHarvest(store, checkpointStore, { batchSize: 1 });
+    expect(result).toEqual({ batches: 1, totalStored: 0, totalRejected: 0 });
+  });
+
+  it('honors maxBatches as a dry-run/test hook', async () => {
+    mockClevelandFetch({ 0: [ACCEPTED_ID], 1: [ACCEPTED_ID] });
+    const { store } = memoryRegistryStore();
+    const checkpoints = { value: null as string | null };
+    const checkpointStore = {
+      getCheckpoint: () => checkpoints.value,
+      setCheckpoint: (skip: string) => {
+        checkpoints.value = skip;
+      },
+    };
+
+    const result = await runClevelandHarvest(store, checkpointStore, { batchSize: 1, maxBatches: 1 });
+    expect(result.batches).toBe(1);
+  });
+});

--- a/tests/registry/helpers.ts
+++ b/tests/registry/helpers.ts
@@ -1,0 +1,30 @@
+import type { Assertion, RegistryEntry, RegistryStore } from '../../src/core/registry/index.js';
+
+/**
+ * In-memory `RegistryStore` test double, mirroring the `memoryCache()` /
+ * `CacheStore` fake pattern in `tests/federation.test.ts`. Not shipped code:
+ * the real store is OMA's build.
+ */
+export function memoryRegistryStore() {
+  const entries = new Map<string, RegistryEntry>();
+
+  const store: RegistryStore = {
+    getEntry: (id) => entries.get(id) ?? null,
+    upsertEntry: (entry) => {
+      entries.set(entry.identity.registryId, entry);
+    },
+    proposeAssertion: (req: { subject: string; assertion: Assertion }) => {
+      const existing = entries.get(req.subject);
+      if (!existing) throw new Error(`memoryRegistryStore: no entry for subject ${req.subject}`);
+      existing.assertions.push(req.assertion);
+      existing.updatedAt = req.assertion.assertedAt;
+      return { status: 'applied' as const };
+    },
+    getStats: () => ({
+      entryCount: entries.size,
+      withEnrichmentCount: [...entries.values()].filter((e) => e.assertions.length > 1).length,
+    }),
+  };
+
+  return { store, entries };
+}

--- a/tests/registry/writeBack.test.ts
+++ b/tests/registry/writeBack.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import {
+  proposeWriteBack,
+  validateWriteBackRequest,
+  type RegistryEntry,
+  type WriteBackRequest,
+} from '../../src/core/registry/index.js';
+import { memoryRegistryStore } from './helpers.js';
+
+function baseEntry(registryId: string): RegistryEntry {
+  const now = '2026-01-01T00:00:00.000Z';
+  return {
+    identity: { registryId, sourceRefs: [{ source: 'cleveland', id: registryId, role: 'primary' }], createdAt: now },
+    assertions: [
+      {
+        id: `${registryId}:1`,
+        subject: registryId,
+        field: 'title',
+        value: 'Test Work',
+        evidence: [{ type: 'museum-record', citation: 'c', retrievedAt: now }],
+        disputeStatus: 'undisputed',
+        assertedBy: { contributorId: 'system:cleveland-harvest', ocmTier: 0 },
+        assertedAt: now,
+      },
+    ],
+    rightsPosture: { posture: 'can_store_and_republish', basis: 'CC0', determinedAt: now },
+    trust: { contributorCredentialTier: 0, evidenceGrade: 'source-linked' },
+    canonicalStatus: 'canonical',
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function validRequest(over: Partial<WriteBackRequest> = {}): WriteBackRequest {
+  return {
+    subject: 'cleveland:1',
+    assertion: {
+      field: 'exhibitedAt',
+      value: 'Musée d’Orsay, 2019',
+      evidence: [{ type: 'catalogue-entry', citation: 'Exhibition catalogue p.42', retrievedAt: '2026-07-02T00:00:00.000Z' }],
+      disputeStatus: 'undisputed',
+      assertedBy: { contributorId: 'om-ed', ocmTier: 3 },
+    },
+    ...over,
+  };
+}
+
+describe('validateWriteBackRequest', () => {
+  it('accepts a well-formed request', () => {
+    expect(validateWriteBackRequest(validRequest())).toBeNull();
+  });
+
+  it('rejects a missing subject', () => {
+    const reason = validateWriteBackRequest(validRequest({ subject: '' }));
+    expect(reason).toContain('subject');
+  });
+
+  it('rejects an assertion with zero evidence entries (never a bare value)', () => {
+    const req = validRequest();
+    req.assertion.evidence = [];
+    expect(validateWriteBackRequest(req)).toContain('evidence');
+  });
+
+  it('rejects a blank assertion value', () => {
+    const req = validRequest();
+    req.assertion.value = '   ';
+    expect(validateWriteBackRequest(req)).toContain('value');
+  });
+});
+
+describe('proposeWriteBack', () => {
+  it('mints an id + timestamp and appends the assertion via the store, applied for a trusted caller', async () => {
+    const { store, entries } = memoryRegistryStore();
+    entries.set('cleveland:1', baseEntry('cleveland:1'));
+
+    const out = await proposeWriteBack(store, validRequest(), {
+      clock: () => '2026-07-02T12:00:00.000Z',
+      idGen: () => 'fixed-id',
+    });
+
+    expect(out).toEqual({ ok: true, assertionId: 'fixed-id', status: 'applied' });
+    const entry = entries.get('cleveland:1');
+    expect(entry?.assertions).toHaveLength(2);
+    const appended = entry?.assertions[1];
+    expect(appended).toMatchObject({
+      id: 'fixed-id',
+      subject: 'cleveland:1',
+      field: 'exhibitedAt',
+      assertedAt: '2026-07-02T12:00:00.000Z',
+    });
+    // full evidence carried through, never stripped
+    expect(appended?.evidence).toHaveLength(1);
+  });
+
+  it('returns ok:false without touching the store when the request is invalid', async () => {
+    const { store, entries } = memoryRegistryStore();
+    entries.set('cleveland:1', baseEntry('cleveland:1'));
+
+    const bad = validRequest();
+    bad.assertion.evidence = [];
+    const out = await proposeWriteBack(store, bad);
+
+    expect(out.ok).toBe(false);
+    expect(entries.get('cleveland:1')?.assertions).toHaveLength(1); // unchanged
+  });
+});

--- a/tests/registry/writeBack.test.ts
+++ b/tests/registry/writeBack.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   proposeWriteBack,
   validateWriteBackRequest,
+  PENDING_OC_TIER,
   type RegistryEntry,
   type WriteBackRequest,
 } from '../../src/core/registry/index.js';
@@ -19,17 +20,22 @@ function baseEntry(registryId: string): RegistryEntry {
         value: 'Test Work',
         evidence: [{ type: 'museum-record', citation: 'c', retrievedAt: now }],
         disputeStatus: 'undisputed',
-        assertedBy: { contributorId: 'system:cleveland-harvest', ocmTier: 0 },
+        assertedBy: { contributorId: 'system:cleveland-harvest', ocmTier: PENDING_OC_TIER },
         assertedAt: now,
       },
     ],
     rightsPosture: { posture: 'can_store_and_republish', basis: 'CC0', determinedAt: now },
-    trust: { contributorCredentialTier: 0, evidenceGrade: 'source-linked' },
+    trust: { contributorCredentialTier: PENDING_OC_TIER, evidenceGrade: 'source-linked' },
     canonicalStatus: 'canonical',
     createdAt: now,
     updatedAt: now,
   };
 }
+
+// A non-system caller (e.g. a fleet lane's write-back) stamps its own tier
+// identifier: opaque, per ContributorCredentialTier's OM-C-owned-pending
+// value space; this repo never branches on the concrete string.
+const INTERNAL_LANE_TIER = 'internal-fleet-lane';
 
 function validRequest(over: Partial<WriteBackRequest> = {}): WriteBackRequest {
   return {
@@ -39,7 +45,7 @@ function validRequest(over: Partial<WriteBackRequest> = {}): WriteBackRequest {
       value: 'Musée d’Orsay, 2019',
       evidence: [{ type: 'catalogue-entry', citation: 'Exhibition catalogue p.42', retrievedAt: '2026-07-02T00:00:00.000Z' }],
       disputeStatus: 'undisputed',
-      assertedBy: { contributorId: 'om-ed', ocmTier: 3 },
+      assertedBy: { contributorId: 'om-ed', ocmTier: INTERNAL_LANE_TIER },
     },
     ...over,
   };


### PR DESCRIPTION
## Summary
- Implements increment 1 of the Catalogue Raisonne drive engine-side, per the locked drive design (`~/.orchestrators/open-museum/catalogue-raisonne-drive-design-2026-06-30.md`) and this repo's design spec (PR #130, in parallel review at OM-CR):
  1. **Four primitives as code** (`src/core/registry/types.ts`): `WorkIdentity` (per-source, fingerprint field reserved but not built), `Assertion`+`Evidence` (typed claims with required evidence and dispute status), `RightsPosture` (distinct from 2D image rights), `TrustState` (contributor-credential tier vs. evidence-grade, kept as two separate axes). `canonicalStatus()` derives canonical-vs-pending from whether any assertion carries external (non-self-attested) evidence.
  2. **Cleveland CC0 harvest pipeline** (`src/core/registry/harvest/cleveland.ts`): resumable, checkpointed, reuses `clevelandFetcher.getRaw`/`normalize` UNMODIFIED for hydration and rights-gating. Live-smoked against the real API (`scripts/smoke-registry-harvest.ts`): 10 real records harvested across 2 pages, correctly stamped with baseline title/createdBy/datedTo assertions, `canonical` status, `source-linked` evidence grade.
  3. **Write-back-on-extraction seam** (`src/core/registry/writeBack.ts`): `proposeWriteBack` assembles + validates a full `Assertion` (evidence is required, never a bare value) and delegates persistence to an injected `RegistryStore`. Increment 1 treats every caller as internal/trusted; the same method is where OM-C's future Tier-2 external-write gate attaches, no seam redesign needed later.
  4. **MCP read shape**: `Federation` gains an optional `registryStore` (mirrors the existing `CacheStore` injection pattern exactly, `/core` stays storage-free). `Artwork` gains an optional `enrichment` field (attached live per `get_artwork` call, deliberately never persisted into the 90-day object cache since enrichment grows over time). `search_artworks` gains `has_enrichment` (post-fetch filter, same pattern as `has_3d`). New `registry_stats` MCP tool.
- **Engine-side ONLY, dark by default**: no deployment configures a concrete `registryStore` (OMA's store build stays sequenced behind the revenue wave per the locked drive doc) -- the actual `createFederation()` call in `server.ts` is unchanged, so this ships with zero behavior change for any current user until a store exists.
- **`RegistryStore` is the CONTRACT, not an implementation** -- `[DECISION-NEEDED -> OMA]` is called out in the interface doc comment: the concrete D1/R2/PG store is OMA's build.
- Framing discipline held throughout: no "the catalogue" / completeness / authority language in any code comment or tool description.

## Test plan
- [x] `tscq --noEmit`: 0 errors
- [x] `NODE_OPTIONS=--experimental-sqlite npx vitest run`: 638/638 passing (28 new tests: primitives, write-back validation, harvest pipeline with real fixtures, federation registry wiring)
- [x] `npm run build`: clean
- [x] Live-smoked the Cleveland harvest against the real production API (`npx tsx scripts/smoke-registry-harvest.ts`): 10 records harvested across 2 pages, correctly gated and stamped, checkpoint resumed correctly
- [ ] OM-CR architecture review (T1, new capability)
- [ ] Pramod merge

Co-Authored by Pramod Prasanth <pramod@chainalign.com>