### PR TITLE
chore: add a pre-commit guard against placeholder code

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Shokunin craft gate — blocks stub/fake-demo code in staged shipping lines.
+# Policy (single source) lives at ~/.claude/scripts/craft-check.py via the `craft-check` wrapper.
+# No-ops where the tool isn't installed (CI / other machines), so it's safe to commit.
+if type craft-check >/dev/null 2>&1; then
+  craft-check
+  code=$?
+  if [ "$code" -eq 2 ]; then
+    echo ""
+    echo "✗ Shokunin craft gate BLOCKED this commit (stub / fake-demo in shipping code)."
+    echo "  Build the planned feature fully, or get an explicit scope decision from Pramod."
+    echo "  Deliberate, authorised override (logged): git commit --no-verify"
+    exit 1
+  fi
+fi
+exit 0

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build": "tsc && node scripts/copy-data-assets.mjs",
     "build:mcpb": "node scripts/build-mcpb.mjs",
     "dev": "NODE_OPTIONS=--experimental-sqlite tsx src/server.ts",
-    "prepare": "npm run build",
+    "prepare": "npm run build && (git config core.hooksPath .githooks || true)",
     "test": "NODE_OPTIONS=--experimental-sqlite vitest run",
     "test:watch": "NODE_OPTIONS=--experimental-sqlite vitest",
     "smoke:smithsonian": "NODE_OPTIONS=--experimental-sqlite tsx scripts/smoke-smithsonian.ts",


### PR DESCRIPTION
## What

Adds a pre-commit hook (`.githooks/pre-commit`) that blocks placeholder code — mock returns, deferral markers, demo-only implementations — from entering shipping source. Wired via `core.hooksPath`, re-armed on fresh clones through the existing `prepare` script.

## Mechanism

- No husky in this repo, so the hook uses `git config core.hooksPath .githooks`.
- `prepare` becomes `npm run build && (git config core.hooksPath .githooks || true)` — build failures still propagate; the guard only absorbs the git-config step in non-git contexts such as tarball installs.
- The hook no-ops where the checker isn't installed (CI, other machines, outside contributors), so it adds no friction to external contributions.
- `git commit --no-verify` remains available for a deliberate, visible override.

## Verification

A staged file containing a mock return with a demo comment is blocked, exit 1. A real change passes clean, exit 0. Unsetting `core.hooksPath` and re-running `npm run prepare` re-arms it.

## Status

Closed unmerged. The guard itself is being re-landed separately; this PR is retained only as a record.
