### PR TITLE
feat(walters): Workers-safe bundle-loader seam + /core export (v0.19.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.0] — 2026-07-14
+
+### Added
+
+- **`waltersFetcher` + `createWaltersFetcher` on the `/core` surface (Workers-safe bundle-loader seam).** The Walters adapter (an ingest source: bundled `walters.json` index, no live API) was previously kept OFF `/core` because it read its bundle via a static `node:fs` import, which would break the core's Workers-safety guarantee. The bundle access is now an injectable seam: `createWaltersFetcher(loadBundle?)` takes a `WaltersBundleLoader` (sync or async), mirroring the `CacheStore` injection pattern, and the default loader reaches `node:fs`/`node:url` only through a lazy dynamic import inside the loader body — so importing `/core` stays safe in a Workers bundle, and only *calling* the default loader requires Node. A Workers host (e.g. the open-museum.art federation) constructs its own instance and injects the bundle as a bundler-imported JSON asset. The default `waltersFetcher` instance is unchanged in behaviour (package-shipped bundle, lazy single load per instance, identical search ranking and rights gating); the MCP server keeps using it as before. `WaltersBundle`, `WaltersBundleLoader`, and `WaltersRecord` types are exported alongside. A source-level guard test now enforces that the module never regains a static `node:` import.
+
 ## [0.18.0] — 2026-07-03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-museum-mcp",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "MCP server for license-verified search across open-access museum collections (The Met, Rijksmuseum, Smithsonian, Cleveland, AIC, SMK, Walters, Wellcome, National Gallery of Art, Harvard, Getty, Wikimedia Commons, Europeana, and growing).",
   "type": "module",
   "main": "dist/server.js",

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -104,6 +104,17 @@ export { wikimediaFetcher } from '../fetchers/wikimedia.js';
 export { europeanaFetcher } from '../fetchers/europeana.js';
 export { smithsonianFetcher } from '../fetchers/smithsonian.js';
 export { rijksmuseumFetcher } from '../fetchers/rijksmuseum.js';
+// Walters is an INGEST source (bundled index, no live API). The default instance
+// reads the package-shipped bundle via a lazily-imported node:fs — safe to IMPORT
+// from Workers, but a Workers host must construct its own via createWaltersFetcher
+// and inject the bundle (bundler JSON asset / KV), mirroring CacheStore injection.
+export {
+  waltersFetcher,
+  createWaltersFetcher,
+  type WaltersBundle,
+  type WaltersBundleLoader,
+  type WaltersRecord,
+} from '../fetchers/walters.js';
 
 // Coverage foundation: the reusable IIIF client + the shared commercial-POD
 // rights gate (CC0/PDM/CC-BY/CC-BY-SA allow; NC/ND/unknown deny; >=3000px floor).

--- a/src/fetchers/walters.ts
+++ b/src/fetchers/walters.ts
@@ -1,5 +1,3 @@
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import { parseDisplayDate } from '../dateParser.js';
 import { validateWaltersLicense } from '../licenseGate.js';
 import { cleanArtistName, detectAttributionType, normalizeRegion } from '../mappings.js';
@@ -19,7 +17,7 @@ const IMAGE_BASE = 'https://art.thewalters.org/images/raw';
 const PURL_BASE = 'https://purl.thewalters.org/art';
 
 /** One bundled object (compact keys to keep the shipped JSON small). */
-interface WaltersRecord {
+export interface WaltersRecord {
   i: string; // ObjectID
   n: string; // ObjectNumber (accession)
   t: string; // Title
@@ -36,10 +34,19 @@ interface WaltersRecord {
   g: string; // primary image filename
 }
 
-interface WaltersBundle {
+export interface WaltersBundle {
   meta: Record<string, unknown>;
   objects: WaltersRecord[];
 }
+
+/**
+ * Supplies the bundle to a fetcher instance. The default loader reads the
+ * package-shipped `walters.json` via `node:fs` (lazily imported, so this module
+ * stays Workers-safe to import); a Workers host injects its own loader instead —
+ * e.g. a bundler-imported JSON asset — mirroring the `CacheStore` injection
+ * pattern. Sync or async both work.
+ */
+export type WaltersBundleLoader = () => WaltersBundle | Promise<WaltersBundle>;
 
 interface LoadedIndex {
   byId: Map<string, WaltersRecord>;
@@ -47,8 +54,6 @@ interface LoadedIndex {
   records: WaltersRecord[];
   blobs: string[];
 }
-
-let indexPromise: Promise<LoadedIndex> | null = null;
 
 /**
  * Normalize text for matching: lowercase, DROP apostrophes (so the museum's
@@ -64,146 +69,184 @@ function normalizeText(s: string): string {
     .trim();
 }
 
-// Bundle path resolved relative to this module (dist/fetchers -> dist/data after
-// build; the build step copies src/data/walters.json into dist/data).
-const BUNDLE_PATH = fileURLToPath(new URL('../data/walters.json', import.meta.url));
-
-/** Lazily load + index the bundle. The ~5MB JSON is read + parsed only on first
- *  Walters use (native readFileSync + JSON.parse — NOT a bundler-transformed JSON
- *  import, which is pathologically slow on a file this size), so processes that
- *  never query Walters pay nothing. */
-async function loadIndex(): Promise<LoadedIndex> {
-  if (!indexPromise) {
-    indexPromise = (async () => {
-      const bundle = JSON.parse(readFileSync(BUNDLE_PATH, 'utf-8')) as WaltersBundle;
-      const objects = bundle.objects ?? [];
-      const byId = new Map<string, WaltersRecord>();
-      const blobs: string[] = [];
-      for (const r of objects) {
-        byId.set(r.i, r);
-        blobs.push(
-          normalizeText(`${r.t} ${r.c} ${r.l} ${r.m} ${r.p} ${r.y} ${r.k} ${r.r} ${r.d}`),
-        );
-      }
-      return { byId, records: objects, blobs };
-    })();
+/**
+ * Default loader: read the package-shipped bundle from disk. Bundle path is
+ * resolved relative to this module (dist/fetchers -> dist/data after build; the
+ * build step copies src/data/walters.json into dist/data). `node:fs`/`node:url`
+ * are imported DYNAMICALLY here — never statically at module top — so importing
+ * this module (and therefore `/core`) stays safe in a Workers bundle; only
+ * actually CALLING the default loader requires Node. The ~5MB JSON is read with
+ * native readFileSync + JSON.parse — NOT a bundler-transformed JSON import,
+ * which is pathologically slow on a file this size.
+ */
+async function defaultBundleLoader(): Promise<WaltersBundle> {
+  let readFileSync: (typeof import('node:fs'))['readFileSync'];
+  let fileURLToPath: (typeof import('node:url'))['fileURLToPath'];
+  try {
+    ({ readFileSync } = await import('node:fs'));
+    ({ fileURLToPath } = await import('node:url'));
+  } catch {
+    throw new Error(
+      'walters: the default bundle loader needs Node (node:fs). In a Workers ' +
+        'runtime, construct the fetcher with createWaltersFetcher(loadBundle) and ' +
+        'inject the walters.json bundle yourself.',
+    );
   }
-  return indexPromise;
+  const bundlePath = fileURLToPath(new URL('../data/walters.json', import.meta.url));
+  return JSON.parse(readFileSync(bundlePath, 'utf-8')) as WaltersBundle;
 }
 
 const reject = (id: string, reason: string, rawSnapshot: unknown): ValidationResult =>
   rejectFor('walters', id, reason, rawSnapshot);
 
-export const waltersFetcher: Fetcher = {
-  code: 'walters',
-  name: 'Walters Art Museum',
-  hotlinkRestricted: true,
+/**
+ * Build a Walters fetcher over an injectable bundle source. Each instance lazily
+ * loads + indexes the bundle ONCE on first use (processes that never query
+ * Walters pay nothing) and caches it for the instance's lifetime. The default
+ * instance below uses the Node fs loader; Workers hosts inject their own.
+ */
+export function createWaltersFetcher(
+  loadBundle: WaltersBundleLoader = defaultBundleLoader,
+): Fetcher {
+  let indexPromise: Promise<LoadedIndex> | null = null;
 
-  // Local keyword search over the bundled index (no live API exists). OR-ranked:
-  // a record qualifies if it matches ANY query token, and is ranked first by how
-  // MANY distinct query tokens it matches, then by total occurrences. This gives a
-  // federated source the right recall — "Persian manuscript" surfaces Persian works
-  // and manuscripts even though the museum codes no single record as both (Persian
-  // mss are catalogued "Iranian"/"Islamic"). Matching is punctuation-normalized so
-  // "Quran" finds the museum's "Qur'an". `hasImage` is always satisfied — the
-  // bundle only contains image-bearing records.
-  async search(query: string, limit: number, _options: SearchOptions = {}): Promise<string[]> {
-    const tokens = [...new Set(normalizeText(query).split(' ').filter(Boolean))];
-    if (tokens.length === 0) return [];
-    const { records, blobs } = await loadIndex();
-    const scored: Array<{ id: string; distinct: number; hits: number }> = [];
-    for (let idx = 0; idx < records.length; idx++) {
-      const blob = blobs[idx];
-      let distinct = 0;
-      let hits = 0;
-      for (const tok of tokens) {
-        const n = blob.split(tok).length - 1;
-        if (n > 0) { distinct++; hits += n; }
+  async function loadIndex(): Promise<LoadedIndex> {
+    if (!indexPromise) {
+      indexPromise = (async () => {
+        const bundle = await loadBundle();
+        const objects = bundle.objects ?? [];
+        const byId = new Map<string, WaltersRecord>();
+        const blobs: string[] = [];
+        for (const r of objects) {
+          byId.set(r.i, r);
+          blobs.push(
+            normalizeText(`${r.t} ${r.c} ${r.l} ${r.m} ${r.p} ${r.y} ${r.k} ${r.r} ${r.d}`),
+          );
+        }
+        return { byId, records: objects, blobs };
+      })();
+    }
+    return indexPromise;
+  }
+
+  return {
+    code: 'walters',
+    name: 'Walters Art Museum',
+    hotlinkRestricted: true,
+
+    // Local keyword search over the bundled index (no live API exists). OR-ranked:
+    // a record qualifies if it matches ANY query token, and is ranked first by how
+    // MANY distinct query tokens it matches, then by total occurrences. This gives a
+    // federated source the right recall — "Persian manuscript" surfaces Persian works
+    // and manuscripts even though the museum codes no single record as both (Persian
+    // mss are catalogued "Iranian"/"Islamic"). Matching is punctuation-normalized so
+    // "Quran" finds the museum's "Qur'an". `hasImage` is always satisfied — the
+    // bundle only contains image-bearing records.
+    async search(query: string, limit: number, _options: SearchOptions = {}): Promise<string[]> {
+      const tokens = [...new Set(normalizeText(query).split(' ').filter(Boolean))];
+      if (tokens.length === 0) return [];
+      const { records, blobs } = await loadIndex();
+      const scored: Array<{ id: string; distinct: number; hits: number }> = [];
+      for (let idx = 0; idx < records.length; idx++) {
+        const blob = blobs[idx];
+        let distinct = 0;
+        let hits = 0;
+        for (const tok of tokens) {
+          const n = blob.split(tok).length - 1;
+          if (n > 0) {
+            distinct++;
+            hits += n;
+          }
+        }
+        if (distinct > 0) scored.push({ id: records[idx].i, distinct, hits });
       }
-      if (distinct > 0) scored.push({ id: records[idx].i, distinct, hits });
-    }
-    // Distinct-token coverage dominates; total occurrences break ties.
-    scored.sort((a, b) => b.distinct - a.distinct || b.hits - a.hits);
-    return scored.slice(0, limit).map((s) => `walters:${s.id}`);
-  },
+      // Distinct-token coverage dominates; total occurrences break ties.
+      scored.sort((a, b) => b.distinct - a.distinct || b.hits - a.hits);
+      return scored.slice(0, limit).map((s) => `walters:${s.id}`);
+    },
 
-  async getRaw(id: string): Promise<unknown> {
-    const numeric = id.replace(/^walters:/, '');
-    const { byId } = await loadIndex();
-    return byId.get(numeric) ?? null;
-  },
+    async getRaw(id: string): Promise<unknown> {
+      const numeric = id.replace(/^walters:/, '');
+      const { byId } = await loadIndex();
+      return byId.get(numeric) ?? null;
+    },
 
-  normalize(raw: unknown): ValidationResult {
-    if (!raw || typeof raw !== 'object') {
-      return reject('walters:unknown', 'walters: record not an object', raw);
-    }
-    const r = raw as WaltersRecord;
-    const objectId = typeof r.i === 'string' && r.i.length > 0 ? r.i : '';
-    const id = objectId ? `walters:${objectId}` : 'walters:unknown';
+    normalize(raw: unknown): ValidationResult {
+      if (!raw || typeof raw !== 'object') {
+        return reject('walters:unknown', 'walters: record not an object', raw);
+      }
+      const r = raw as WaltersRecord;
+      const objectId = typeof r.i === 'string' && r.i.length > 0 ? r.i : '';
+      const id = objectId ? `walters:${objectId}` : 'walters:unknown';
 
-    const decision = validateWaltersLicense(raw);
-    if (!decision.accepted || !decision.license) {
-      return reject(id, decision.reason, raw);
-    }
-    if (!objectId) {
-      return reject(id, 'walters: missing ObjectID', raw);
-    }
+      const decision = validateWaltersLicense(raw);
+      if (!decision.accepted || !decision.license) {
+        return reject(id, decision.reason, raw);
+      }
+      if (!objectId) {
+        return reject(id, 'walters: missing ObjectID', raw);
+      }
 
-    // Dates: trust the bundled integer years; fall back to parsing the display
-    // string (dynasty-aware) when a bound is absent.
-    const displayDate = typeof r.d === 'string' ? r.d : '';
-    const dateRange =
-      typeof r.a === 'number' && typeof r.b === 'number'
-        ? { yearStart: r.a, yearEnd: r.b }
-        : parseDisplayDate(displayDate);
+      // Dates: trust the bundled integer years; fall back to parsing the display
+      // string (dynasty-aware) when a bound is absent.
+      const displayDate = typeof r.d === 'string' ? r.d : '';
+      const dateRange =
+        typeof r.a === 'number' && typeof r.b === 'number'
+          ? { yearStart: r.a, yearEnd: r.b }
+          : parseDisplayDate(displayDate);
 
-    // Artist: the primary (first) creator name; pipe-joined extras are dropped to
-    // a single attributed maker, matching the other adapters' single-artist shape.
-    // Walters catalogs anonymous works with the CULTURE as the creator ("Egyptian",
-    // "Persian", "Turkish"). A single-word creator that resolves to a region is a
-    // culture label, not a person — treat it as anonymous rather than surfacing a
-    // demonym as a named artist.
-    const primaryRaw = ((typeof r.r === 'string' ? r.r : '').split('|')[0] ?? '').trim();
-    const isCultureLabel = primaryRaw !== '' && !/\s/.test(primaryRaw) && normalizeRegion(primaryRaw) !== null;
-    const primaryName = isCultureLabel ? '' : sanitizeArtistName(primaryRaw);
-    const attributionType = primaryName ? detectAttributionType(primaryName) : 'anonymous';
-    const cleanName = primaryName ? cleanArtistName(primaryName) : '';
+      // Artist: the primary (first) creator name; pipe-joined extras are dropped to
+      // a single attributed maker, matching the other adapters' single-artist shape.
+      // Walters catalogs anonymous works with the CULTURE as the creator ("Egyptian",
+      // "Persian", "Turkish"). A single-word creator that resolves to a region is a
+      // culture label, not a person — treat it as anonymous rather than surfacing a
+      // demonym as a named artist.
+      const primaryRaw = ((typeof r.r === 'string' ? r.r : '').split('|')[0] ?? '').trim();
+      const isCultureLabel =
+        primaryRaw !== '' && !/\s/.test(primaryRaw) && normalizeRegion(primaryRaw) !== null;
+      const primaryName = isCultureLabel ? '' : sanitizeArtistName(primaryRaw);
+      const attributionType = primaryName ? detectAttributionType(primaryName) : 'anonymous';
+      const cleanName = primaryName ? cleanArtistName(primaryName) : '';
 
-    const image = typeof r.g === 'string' ? r.g : '';
+      const image = typeof r.g === 'string' ? r.g : '';
 
-    const artwork: Artwork = {
-      id,
-      museum: {
-        code: 'walters',
-        name: 'Walters Art Museum',
-        url: 'https://thewalters.org',
-      },
-      title: sanitizeTitle(typeof r.t === 'string' ? r.t : '') || '(Untitled)',
-      artist: {
-        name: cleanName || 'Unknown',
-        attributionType,
-      },
-      displayDate,
-      yearStart: dateRange.yearStart,
-      yearEnd: dateRange.yearEnd,
-      medium: typeof r.m === 'string' ? r.m : '',
-      mediumCategory: normalizeMedium(typeof r.m === 'string' ? r.m : ''),
-      region: normalizeRegion(typeof r.c === 'string' ? r.c : ''),
-      period: asOptionalString(r.p) ?? null,
-      imageUrls: {
-        full: `${IMAGE_BASE}/${image}`,
-        thumbnail: undefined,
-      },
-      imageOpenAccess: decision.imageOpenAccess,
-      metadataOpenAccess: decision.metadataOpenAccess,
-      license: decision.license,
-      source: {
-        apiUrl: 'https://github.com/WaltersArtMuseum/api-thewalters-org',
-        pageUrl: `${PURL_BASE}/${r.n}`,
-      },
-      description: asOptionalString(r.l),
-    };
+      const artwork: Artwork = {
+        id,
+        museum: {
+          code: 'walters',
+          name: 'Walters Art Museum',
+          url: 'https://thewalters.org',
+        },
+        title: sanitizeTitle(typeof r.t === 'string' ? r.t : '') || '(Untitled)',
+        artist: {
+          name: cleanName || 'Unknown',
+          attributionType,
+        },
+        displayDate,
+        yearStart: dateRange.yearStart,
+        yearEnd: dateRange.yearEnd,
+        medium: typeof r.m === 'string' ? r.m : '',
+        mediumCategory: normalizeMedium(typeof r.m === 'string' ? r.m : ''),
+        region: normalizeRegion(typeof r.c === 'string' ? r.c : ''),
+        period: asOptionalString(r.p) ?? null,
+        imageUrls: {
+          full: `${IMAGE_BASE}/${image}`,
+          thumbnail: undefined,
+        },
+        imageOpenAccess: decision.imageOpenAccess,
+        metadataOpenAccess: decision.metadataOpenAccess,
+        license: decision.license,
+        source: {
+          apiUrl: 'https://github.com/WaltersArtMuseum/api-thewalters-org',
+          pageUrl: `${PURL_BASE}/${r.n}`,
+        },
+        description: asOptionalString(r.l),
+      };
 
-    return { status: 'accepted', artwork };
-  },
-};
+      return { status: 'accepted', artwork };
+    },
+  };
+}
+
+/** The default Walters fetcher: package-shipped bundle via the Node fs loader. */
+export const waltersFetcher: Fetcher = createWaltersFetcher();

--- a/tests/walters.test.ts
+++ b/tests/walters.test.ts
@@ -113,3 +113,68 @@ describe('Walters adapter search + getRaw (bundled index)', () => {
     expect(ids.length).toBeLessThanOrEqual(3);
   });
 });
+
+// --- Bundle-loader seam (v0.19.0): Workers-safe /core export -------------------
+
+import { createWaltersFetcher, type WaltersBundle } from '../src/fetchers/walters.js';
+
+const TINY_BUNDLE: WaltersBundle = {
+  meta: { source: 'test' },
+  objects: [
+    {
+      i: '90607', n: 'W.554.1A', t: "Leaf from Qur'an", d: '1300-1400', a: 1300, b: 1400,
+      m: 'ink and gold on paper', c: 'Egyptian', l: 'Manuscripts', p: 'Mamluk', y: '',
+      k: 'quran calligraphy', r: 'Egyptian', g: 'w554_000a.jpg',
+    },
+    {
+      i: '12345', n: 'W.100', t: 'Persian Astrolabe', d: '1600', a: 1600, b: 1600,
+      m: 'brass', c: 'Iranian', l: 'Metalwork', p: 'Safavid', y: '',
+      k: 'astronomy instrument', r: 'Persian', g: 'w100_000a.jpg',
+    },
+  ],
+};
+
+describe('Walters bundle-loader seam (createWaltersFetcher)', () => {
+  it('searches and hydrates against an INJECTED bundle (no filesystem)', async () => {
+    let loads = 0;
+    const fetcher = createWaltersFetcher(() => { loads++; return TINY_BUNDLE; });
+    const ids = await fetcher.search('quran', 10);
+    expect(ids).toEqual(['walters:90607']);
+    const raw = await fetcher.getRaw('walters:90607');
+    const result = fetcher.normalize(raw);
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.id).toBe('walters:90607');
+    // Loader runs once; the parsed index is cached per fetcher instance.
+    await fetcher.search('astrolabe', 10);
+    expect(loads).toBe(1);
+  });
+
+  it('accepts an async loader (Promise-returning), matching the CacheStore Awaitable pattern', async () => {
+    const fetcher = createWaltersFetcher(async () => TINY_BUNDLE);
+    const ids = await fetcher.search('persian astrolabe', 10);
+    expect(ids[0]).toBe('walters:12345');
+  });
+
+  it('keeps instances isolated: injected bundle never leaks into the default fetcher', async () => {
+    const injected = createWaltersFetcher(() => TINY_BUNDLE);
+    await injected.search('quran', 5);
+    // The default (fs-backed) fetcher still resolves real bundle records.
+    const raw = await waltersFetcher.getRaw('walters:90607');
+    expect(raw).not.toBeNull();
+  });
+
+  it('module stays Workers-safe: no static node:* imports in the source', () => {
+    // The /core export guarantee: importing walters.js must not crash a Workers
+    // bundle. Node built-ins may only be reached via lazy dynamic import inside
+    // the DEFAULT loader. This guards the module's import graph at source level.
+    const src = readFileSync(join(here, '..', 'src', 'fetchers', 'walters.ts'), 'utf-8');
+    expect(src).not.toMatch(/^import .* from 'node:/m);
+  });
+
+  it('exports from /core: waltersFetcher + createWaltersFetcher are on the public surface', async () => {
+    const core = await import('../src/core/index.js');
+    expect(core.waltersFetcher.code).toBe('walters');
+    expect(typeof core.createWaltersFetcher).toBe('function');
+  });
+});


### PR DESCRIPTION
## What

Exposes the Walters Art Museum adapter on the `/core` public surface so Workers hosts (the open-museum.art federation) can federate it — via an injectable bundle-loader seam that preserves core's Workers-safety guarantee.

## Why the seam

Walters is an ingest source: no live API since 2023; search/getRaw run against the package-shipped `walters.json` bundle. The adapter previously read that bundle through a **static** `node:fs` import, which is exactly why it was kept off `/core` (a Workers bundle importing core would crash at module load). This PR makes the bundle source injectable:

- `createWaltersFetcher(loadBundle?: WaltersBundleLoader): Fetcher` — mirrors the existing `CacheStore` injection pattern; loader may be sync or async.
- The **default** loader reaches `node:fs`/`node:url` only through lazy dynamic `import()` inside the loader body: importing the module (and `/core`) is Workers-safe; only *calling* the default loader requires Node, and it fails with an instructive error otherwise.
- `waltersFetcher` (default instance) behaviour is unchanged: same lazy single-load, same OR-ranked search, same rights gate. The MCP server keeps using it untouched.
- Exported types: `WaltersBundle`, `WaltersBundleLoader`, `WaltersRecord`. Semver **minor** (additive) → v0.19.0.

A Workers host injects the bundle as a bundler-imported JSON asset (or KV): `createWaltersFetcher(() => waltersJson)`.

## Diff note

Most of the line count in `walters.ts` is mechanical re-indentation from nesting the fetcher literal inside the factory; the logic bodies of `search`/`getRaw`/`normalize` are unchanged.

## Verification

- `tsc --noEmit` clean; `vitest run` **633/633** (5 new tests: injected-bundle search/hydrate/normalize, async loader, per-instance isolation, source-level no-static-`node:` guard, /core export surface); `npm run build` clean.
- Smoke (`scripts/smoke-walters.ts`) against the real bundle through the refactored path: all queries resolve, rights-gated, CC0.

## Context

Closes the site-side half of the horse-plates source gap (with Smithsonian, which needs no engine change — already exported in the published v0.16.0). Also widens the best-scan T3 corpus. Reaches the site as an npm pin only after the queued v0.18.0 publish + this release.

Co-Authored by Pramod Prasanth <pramod@chainalign.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Walters data fetching support for Workers-compatible environments.
  * Added configurable bundle loading, including support for synchronous and asynchronous loaders.
  * Exposed Walters bundle and record types for integrations.
  * Preserved local search, raw record lookup, normalization, license checks, and image URL handling.

* **Chores**
  * Updated the package version to 0.19.0.
  * Added release documentation for the new Walters fetching capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->