### PR TITLE
feat(core): fetcher coverage registry + close 5-source /core export gap

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -103,7 +103,11 @@ export { aicFetcher } from '../fetchers/aic.js';
 export { wikimediaFetcher } from '../fetchers/wikimedia.js';
 export { europeanaFetcher } from '../fetchers/europeana.js';
 export { smithsonianFetcher } from '../fetchers/smithsonian.js';
+export { harvardFetcher } from '../fetchers/harvard.js';
 export { rijksmuseumFetcher } from '../fetchers/rijksmuseum.js';
+export { smkFetcher } from '../fetchers/smk.js';
+export { wellcomeFetcher } from '../fetchers/wellcome.js';
+export { gettyFetcher } from '../fetchers/getty.js';
 // Walters is an INGEST source (bundled index, no live API). The default instance
 // reads the package-shipped bundle via a lazily-imported node:fs — safe to IMPORT
 // from Workers, but a Workers host must construct its own via createWaltersFetcher
@@ -115,6 +119,20 @@ export {
   type WaltersBundleLoader,
   type WaltersRecord,
 } from '../fetchers/walters.js';
+// NGA is an INGEST source (gzipped bundle, no live API) — same Workers-safe
+// injectable-loader seam as Walters.
+export {
+  ngaFetcher,
+  createNgaFetcher,
+  type NgaBundle,
+  type NgaBundleLoader,
+} from '../fetchers/nga.js';
+
+// Static per-source coverage metadata (code, display name, key requirement,
+// federate-vs-ingest) — derived from the fetchers above, never hand-listed, so
+// a host can render "which museums are federated" (e.g. a `/museums` page)
+// without re-deriving or drifting from the engine's actual registry.
+export { FETCHER_REGISTRY, type FetcherRegistryEntry } from '../fetchers/registry.js';
 
 // Coverage foundation: the reusable IIIF client + the shared commercial-POD
 // rights gate (CC0/PDM/CC-BY/CC-BY-SA allow; NC/ND/unknown deny; >=3000px floor).

--- a/src/fetchers/europeana.ts
+++ b/src/fetchers/europeana.ts
@@ -135,6 +135,7 @@ function parseRecord(raw: Record<string, unknown>): {
 export const europeanaFetcher: Fetcher = {
   code: 'europeana',
   name: 'Europeana',
+  requiresApiKey: 'EUROPEANA_API_KEY',
 
   async search(query: string, limit: number, options: SearchOptions = {}): Promise<string[]> {
     const key = apiKey();

--- a/src/fetchers/harvard.ts
+++ b/src/fetchers/harvard.ts
@@ -60,6 +60,7 @@ function imageDims(images: unknown): { width?: number; height?: number } {
 export const harvardFetcher: Fetcher = {
   code: 'harvard',
   name: 'Harvard Art Museums',
+  requiresApiKey: 'HARVARD_API_KEY',
   // Harvard ToS: no caching beyond two weeks → never cache full records.
   noCache: true,
 

--- a/src/fetchers/nga.ts
+++ b/src/fetchers/nga.ts
@@ -1,6 +1,3 @@
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { gunzipSync } from 'node:zlib';
 import { parseDisplayDate } from '../dateParser.js';
 import { validateNgaLicense } from '../licenseGate.js';
 import { cleanArtistName, detectAttributionType, normalizeRegion } from '../mappings.js';
@@ -34,10 +31,20 @@ interface NgaRecord {
   o: number; // open-access flag (1)
 }
 
-interface NgaBundle {
+export interface NgaBundle {
   meta: Record<string, unknown>;
   objects: NgaRecord[];
 }
+
+/**
+ * Supplies the bundle to a fetcher instance. The default loader reads +
+ * gunzips the package-shipped `nga.json.gz` via dynamically-imported
+ * `node:fs`/`node:url`/`node:zlib` (so this module stays Workers-safe to
+ * import); a Workers host injects its own loader instead — e.g. a
+ * bundler-imported asset — mirroring the Walters `WaltersBundleLoader`
+ * pattern. Sync or async both work.
+ */
+export type NgaBundleLoader = () => NgaBundle | Promise<NgaBundle>;
 
 interface LoadedIndex {
   byId: Map<string, NgaRecord>;
@@ -45,132 +52,167 @@ interface LoadedIndex {
   blobs: string[];
 }
 
-let indexPromise: Promise<LoadedIndex> | null = null;
-
-const BUNDLE_PATH = fileURLToPath(new URL('../data/nga.json.gz', import.meta.url));
-
-/** Lazily decompress + index the gzipped bundle (only on first NGA use). */
-async function loadIndex(): Promise<LoadedIndex> {
-  if (!indexPromise) {
-    indexPromise = (async () => {
-      const bundle = JSON.parse(gunzipSync(readFileSync(BUNDLE_PATH)).toString('utf-8')) as NgaBundle;
-      const objects = bundle.objects ?? [];
-      const byId = new Map<string, NgaRecord>();
-      const blobs: string[] = [];
-      for (const r of objects) {
-        byId.set(r.i, r);
-        blobs.push(`${r.t} ${r.c} ${r.l} ${r.m} ${r.d}`.toLowerCase());
-      }
-      return { byId, records: objects, blobs };
-    })();
+/**
+ * Default loader: decompress + read the package-shipped gzipped bundle from
+ * disk. `node:fs`/`node:url`/`node:zlib` are imported DYNAMICALLY here — never
+ * statically at module top — so importing this module (and therefore `/core`)
+ * stays safe in a Workers bundle; only actually CALLING the default loader
+ * requires Node.
+ */
+async function defaultBundleLoader(): Promise<NgaBundle> {
+  let readFileSync: (typeof import('node:fs'))['readFileSync'];
+  let fileURLToPath: (typeof import('node:url'))['fileURLToPath'];
+  let gunzipSync: (typeof import('node:zlib'))['gunzipSync'];
+  try {
+    ({ readFileSync } = await import('node:fs'));
+    ({ fileURLToPath } = await import('node:url'));
+    ({ gunzipSync } = await import('node:zlib'));
+  } catch {
+    throw new Error(
+      'nga: the default bundle loader needs Node (node:fs/node:zlib). In a Workers ' +
+        'runtime, construct the fetcher with createNgaFetcher(loadBundle) and inject ' +
+        'the decompressed nga.json bundle yourself.',
+    );
   }
-  return indexPromise;
+  const bundlePath = fileURLToPath(new URL('../data/nga.json.gz', import.meta.url));
+  return JSON.parse(gunzipSync(readFileSync(bundlePath)).toString('utf-8')) as NgaBundle;
 }
 
 const reject = (id: string, reason: string, rawSnapshot: unknown): ValidationResult =>
   rejectFor('nga', id, reason, rawSnapshot);
 
-export const ngaFetcher: Fetcher = {
-  code: 'nga',
-  name: 'National Gallery of Art',
+/**
+ * Build an NGA fetcher over an injectable bundle source. Each instance lazily
+ * loads + indexes the bundle ONCE on first use and caches it for the
+ * instance's lifetime. The default instance below uses the Node fs+zlib
+ * loader; Workers hosts inject their own.
+ */
+export function createNgaFetcher(loadBundle: NgaBundleLoader = defaultBundleLoader): Fetcher {
+  let indexPromise: Promise<LoadedIndex> | null = null;
 
-  // Local keyword search over the bundled index (no live API). AND semantics
-  // ranked by total token hits. `hasImage` is always satisfied (bundle is
-  // image-bearing only).
-  async search(query: string, limit: number, _options: SearchOptions = {}): Promise<string[]> {
-    const tokens = query.toLowerCase().split(/\s+/).filter(Boolean);
-    if (tokens.length === 0) return [];
-    const { records, blobs } = await loadIndex();
-    const scored: Array<{ id: string; score: number }> = [];
-    for (let idx = 0; idx < records.length; idx++) {
-      const blob = blobs[idx];
-      let score = 0;
-      let matchedAll = true;
-      for (const tok of tokens) {
-        const hits = blob.split(tok).length - 1;
-        if (hits === 0) { matchedAll = false; break; }
-        score += hits;
+  async function loadIndex(): Promise<LoadedIndex> {
+    if (!indexPromise) {
+      indexPromise = (async () => {
+        const bundle = await loadBundle();
+        const objects = bundle.objects ?? [];
+        const byId = new Map<string, NgaRecord>();
+        const blobs: string[] = [];
+        for (const r of objects) {
+          byId.set(r.i, r);
+          blobs.push(`${r.t} ${r.c} ${r.l} ${r.m} ${r.d}`.toLowerCase());
+        }
+        return { byId, records: objects, blobs };
+      })();
+    }
+    return indexPromise;
+  }
+
+  return {
+    code: 'nga',
+    name: 'National Gallery of Art',
+    ingestOnly: true,
+
+    // Local keyword search over the bundled index (no live API). AND semantics
+    // ranked by total token hits. `hasImage` is always satisfied (bundle is
+    // image-bearing only).
+    async search(query: string, limit: number, _options: SearchOptions = {}): Promise<string[]> {
+      const tokens = query.toLowerCase().split(/\s+/).filter(Boolean);
+      if (tokens.length === 0) return [];
+      const { records, blobs } = await loadIndex();
+      const scored: Array<{ id: string; score: number }> = [];
+      for (let idx = 0; idx < records.length; idx++) {
+        const blob = blobs[idx];
+        let score = 0;
+        let matchedAll = true;
+        for (const tok of tokens) {
+          const hits = blob.split(tok).length - 1;
+          if (hits === 0) { matchedAll = false; break; }
+          score += hits;
+        }
+        if (matchedAll) scored.push({ id: records[idx].i, score });
       }
-      if (matchedAll) scored.push({ id: records[idx].i, score });
-    }
-    scored.sort((a, b) => b.score - a.score);
-    return scored.slice(0, limit).map((s) => `nga:${s.id}`);
-  },
+      scored.sort((a, b) => b.score - a.score);
+      return scored.slice(0, limit).map((s) => `nga:${s.id}`);
+    },
 
-  async getRaw(id: string): Promise<unknown> {
-    const numeric = id.replace(/^nga:/, '');
-    const { byId } = await loadIndex();
-    return byId.get(numeric) ?? null;
-  },
+    async getRaw(id: string): Promise<unknown> {
+      const numeric = id.replace(/^nga:/, '');
+      const { byId } = await loadIndex();
+      return byId.get(numeric) ?? null;
+    },
 
-  normalize(raw: unknown): ValidationResult {
-    if (!raw || typeof raw !== 'object') {
-      return reject('nga:unknown', 'nga: record not an object', raw);
-    }
-    const r = raw as NgaRecord;
-    const objectId = typeof r.i === 'string' && r.i.length > 0 ? r.i : '';
-    const id = objectId ? `nga:${objectId}` : 'nga:unknown';
+    normalize(raw: unknown): ValidationResult {
+      if (!raw || typeof raw !== 'object') {
+        return reject('nga:unknown', 'nga: record not an object', raw);
+      }
+      const r = raw as NgaRecord;
+      const objectId = typeof r.i === 'string' && r.i.length > 0 ? r.i : '';
+      const id = objectId ? `nga:${objectId}` : 'nga:unknown';
 
-    const decision = validateNgaLicense(raw);
-    if (!decision.accepted || !decision.license) {
-      return reject(id, decision.reason, raw);
-    }
-    if (!objectId) {
-      return reject(id, 'nga: missing objectid', raw);
-    }
+      const decision = validateNgaLicense(raw);
+      if (!decision.accepted || !decision.license) {
+        return reject(id, decision.reason, raw);
+      }
+      if (!objectId) {
+        return reject(id, 'nga: missing objectid', raw);
+      }
 
-    const displayDate = typeof r.d === 'string' ? r.d : '';
-    const dateRange =
-      typeof r.a === 'number' && typeof r.b === 'number'
-        ? { yearStart: r.a, yearEnd: r.b }
-        : parseDisplayDate(displayDate);
+      const displayDate = typeof r.d === 'string' ? r.d : '';
+      const dateRange =
+        typeof r.a === 'number' && typeof r.b === 'number'
+          ? { yearStart: r.a, yearEnd: r.b }
+          : parseDisplayDate(displayDate);
 
-    const artistRaw = sanitizeArtistName(typeof r.c === 'string' ? r.c : '');
-    const attributionType = detectAttributionType(artistRaw);
-    const cleanName = cleanArtistName(artistRaw);
+      const artistRaw = sanitizeArtistName(typeof r.c === 'string' ? r.c : '');
+      const attributionType = detectAttributionType(artistRaw);
+      const cleanName = cleanArtistName(artistRaw);
 
-    const width = typeof r.w === 'number' && r.w > 0 ? r.w : undefined;
-    const height = typeof r.h === 'number' && r.h > 0 ? r.h : undefined;
+      const width = typeof r.w === 'number' && r.w > 0 ? r.w : undefined;
+      const height = typeof r.h === 'number' && r.h > 0 ? r.h : undefined;
 
-    const artwork: Artwork = {
-      id,
-      museum: {
-        code: 'nga',
-        name: 'National Gallery of Art',
-        url: 'https://www.nga.gov',
-      },
-      title: sanitizeTitle(typeof r.t === 'string' ? r.t : '') || '(Untitled)',
-      artist: {
-        name: cleanName || 'Unknown',
-        attributionType,
-      },
-      displayDate,
-      yearStart: dateRange.yearStart,
-      yearEnd: dateRange.yearEnd,
-      medium: typeof r.m === 'string' ? r.m : '',
-      mediumCategory: normalizeMedium(typeof r.m === 'string' ? r.m : ''),
-      // NGA records no structured culture/place in the dump; region stays null
-      // unless the attribution carries one (rare). Honest absence over a guess.
-      region: normalizeRegion(typeof r.c === 'string' ? r.c : ''),
-      period: null,
-      imageUrls: {
-        // NGA IIIF Image API: full-resolution request off the service base.
-        full: `${IIIF_BASE}/${r.g}/full/full/0/default.jpg`,
-        thumbnail: `${IIIF_BASE}/${r.g}/full/!200,200/0/default.jpg`,
-        width,
-        height,
-        maxResolution: pickMaxResolution({ width, height }),
-      },
-      imageOpenAccess: decision.imageOpenAccess,
-      metadataOpenAccess: decision.metadataOpenAccess,
-      license: decision.license,
-      source: {
-        apiUrl: 'https://github.com/NationalGalleryOfArt/opendata',
-        pageUrl: `${NGA_PAGE}.${objectId}.html`,
-      },
-      description: asOptionalString(r.l),
-    };
+      const artwork: Artwork = {
+        id,
+        museum: {
+          code: 'nga',
+          name: 'National Gallery of Art',
+          url: 'https://www.nga.gov',
+        },
+        title: sanitizeTitle(typeof r.t === 'string' ? r.t : '') || '(Untitled)',
+        artist: {
+          name: cleanName || 'Unknown',
+          attributionType,
+        },
+        displayDate,
+        yearStart: dateRange.yearStart,
+        yearEnd: dateRange.yearEnd,
+        medium: typeof r.m === 'string' ? r.m : '',
+        mediumCategory: normalizeMedium(typeof r.m === 'string' ? r.m : ''),
+        // NGA records no structured culture/place in the dump; region stays null
+        // unless the attribution carries one (rare). Honest absence over a guess.
+        region: normalizeRegion(typeof r.c === 'string' ? r.c : ''),
+        period: null,
+        imageUrls: {
+          // NGA IIIF Image API: full-resolution request off the service base.
+          full: `${IIIF_BASE}/${r.g}/full/full/0/default.jpg`,
+          thumbnail: `${IIIF_BASE}/${r.g}/full/!200,200/0/default.jpg`,
+          width,
+          height,
+          maxResolution: pickMaxResolution({ width, height }),
+        },
+        imageOpenAccess: decision.imageOpenAccess,
+        metadataOpenAccess: decision.metadataOpenAccess,
+        license: decision.license,
+        source: {
+          apiUrl: 'https://github.com/NationalGalleryOfArt/opendata',
+          pageUrl: `${NGA_PAGE}.${objectId}.html`,
+        },
+        description: asOptionalString(r.l),
+      };
 
-    return { status: 'accepted', artwork };
-  },
-};
+      return { status: 'accepted', artwork };
+    },
+  };
+}
+
+/** The default NGA fetcher: package-shipped gzipped bundle via the Node fs+zlib loader. */
+export const ngaFetcher: Fetcher = createNgaFetcher();

--- a/src/fetchers/registry.ts
+++ b/src/fetchers/registry.ts
@@ -1,0 +1,57 @@
+import { aicFetcher } from './aic.js';
+import { clevelandFetcher } from './cleveland.js';
+import { europeanaFetcher } from './europeana.js';
+import { gettyFetcher } from './getty.js';
+import { harvardFetcher } from './harvard.js';
+import { metFetcher } from './met.js';
+import { ngaFetcher } from './nga.js';
+import { rijksmuseumFetcher } from './rijksmuseum.js';
+import { smithsonianFetcher } from './smithsonian.js';
+import { smkFetcher } from './smk.js';
+import type { Fetcher } from './types.js';
+import { waltersFetcher } from './walters.js';
+import { wellcomeFetcher } from './wellcome.js';
+import { wikimediaFetcher } from './wikimedia.js';
+
+/**
+ * Static, per-source metadata a host needs to DESCRIBE the federation's
+ * coverage (e.g. a `/museums` page) without querying it — code, display name,
+ * whether a key is required to enable it, and whether it federates a live API
+ * or serves an ingested snapshot.
+ */
+export interface FetcherRegistryEntry {
+  code: string;
+  name: string;
+  requiresApiKey?: string;
+  ingestOnly?: true;
+}
+
+// Every fetcher the engine ships, regardless of whether a given host's env
+// currently has the keys to REGISTER the key-gated ones. Import the live
+// instances (not hand-typed literals) so an added/renamed/removed source can't
+// silently drift from this list — the class of bug this registry exists to end.
+const ALL_FETCHERS: readonly Fetcher[] = [
+  metFetcher,
+  clevelandFetcher,
+  aicFetcher,
+  wikimediaFetcher,
+  rijksmuseumFetcher,
+  waltersFetcher,
+  smkFetcher,
+  wellcomeFetcher,
+  ngaFetcher,
+  gettyFetcher,
+  europeanaFetcher,
+  smithsonianFetcher,
+  harvardFetcher,
+];
+
+/**
+ * Every source the engine knows how to fetch, in registration order. A host
+ * still decides which to actually REGISTER (e.g. a key-gated source only once
+ * its key is present) — this list describes engine capability, not any one
+ * deployment's current live set.
+ */
+export const FETCHER_REGISTRY: readonly FetcherRegistryEntry[] = ALL_FETCHERS.map(
+  ({ code, name, requiresApiKey, ingestOnly }) => ({ code, name, requiresApiKey, ingestOnly }),
+);

--- a/src/fetchers/smithsonian.ts
+++ b/src/fetchers/smithsonian.ts
@@ -367,6 +367,8 @@ export const smithsonianFetcher: Fetcher = {
   code: 'smithsonian',
   name: 'Smithsonian Institution',
   hotlinkRestricted: true,
+  // Canonical env var (SI_API_KEY is an accepted alias — see smithsonianApiKey()).
+  requiresApiKey: 'SMITHSONIAN_API_KEY',
 
   async search(query: string, limit: number, options: SearchOptions = {}): Promise<string[]> {
     const url = new URL(`${SI_API}/search`);

--- a/src/fetchers/types.ts
+++ b/src/fetchers/types.ts
@@ -30,4 +30,20 @@ export interface Fetcher {
    * Walters (art.thewalters.org), Smithsonian (ids.si.edu).
    */
   hotlinkRestricted?: true;
+  /**
+   * Env var name a host must set to enable this source (e.g.
+   * `'EUROPEANA_API_KEY'`). Unset for sources that need no key. Purely
+   * descriptive — each adapter still reads its own env var itself (or via a
+   * helper like `smithsonianApiKey()`); this field lets a caller (e.g. a
+   * `/museums` page) describe the federation's coverage without hand-listing
+   * it separately from the fetchers themselves.
+   */
+  requiresApiKey?: string;
+  /**
+   * True when this source has no live query API and instead serves a bundled,
+   * build-time-ingested snapshot (e.g. Walters, NGA) rather than fetching per
+   * query. Distinguishes FEDERATE from INGEST sources for anything describing
+   * the federation's coverage.
+   */
+  ingestOnly?: true;
 }

--- a/src/fetchers/walters.ts
+++ b/src/fetchers/walters.ts
@@ -133,6 +133,7 @@ export function createWaltersFetcher(
     code: 'walters',
     name: 'Walters Art Museum',
     hotlinkRestricted: true,
+    ingestOnly: true,
 
     // Local keyword search over the bundled index (no live API exists). OR-ranked:
     // a record qualifies if it matches ANY query token, and is ranked first by how

--- a/tests/nga.test.ts
+++ b/tests/nga.test.ts
@@ -80,3 +80,68 @@ describe('NGA adapter search + getRaw (gzipped bundle)', () => {
     expect(ids.length).toBeLessThanOrEqual(3);
   });
 });
+
+// --- Bundle-loader seam (Workers-safe /core export, mirrors Walters) -----------
+
+import { createNgaFetcher, type NgaBundle } from '../src/fetchers/nga.js';
+
+const TINY_BUNDLE: NgaBundle = {
+  meta: { source: 'test' },
+  objects: [
+    {
+      i: '60', t: 'Girl with the Red Hat', d: 'c. 1665/1666', a: 1665, b: 1666,
+      m: 'oil on panel', c: 'Johannes Vermeer', l: 'painting', g: 'nga-60-uuid',
+      w: 12070, h: 15257, o: 1,
+    },
+    {
+      i: '61', t: 'Woman Holding a Balance', d: 'c. 1664', a: 1664, b: 1664,
+      m: 'oil on canvas', c: 'Johannes Vermeer', l: 'painting', g: 'nga-61-uuid',
+      w: 4000, h: 4600, o: 1,
+    },
+  ],
+};
+
+describe('NGA bundle-loader seam (createNgaFetcher)', () => {
+  it('searches and hydrates against an INJECTED bundle (no filesystem)', async () => {
+    let loads = 0;
+    const fetcher = createNgaFetcher(() => { loads++; return TINY_BUNDLE; });
+    const ids = await fetcher.search('red hat', 10);
+    expect(ids).toEqual(['nga:60']);
+    const raw = await fetcher.getRaw('nga:60');
+    const result = fetcher.normalize(raw);
+    expect(result.status).toBe('accepted');
+    if (result.status !== 'accepted') return;
+    expect(result.artwork.id).toBe('nga:60');
+    // Loader runs once; the parsed index is cached per fetcher instance.
+    await fetcher.search('balance', 10);
+    expect(loads).toBe(1);
+  });
+
+  it('accepts an async loader (Promise-returning), matching the CacheStore Awaitable pattern', async () => {
+    const fetcher = createNgaFetcher(async () => TINY_BUNDLE);
+    const ids = await fetcher.search('woman balance', 10);
+    expect(ids[0]).toBe('nga:61');
+  });
+
+  it('keeps instances isolated: injected bundle never leaks into the default fetcher', async () => {
+    const injected = createNgaFetcher(() => TINY_BUNDLE);
+    await injected.search('red hat', 5);
+    // The default (fs-backed) fetcher still resolves real bundle records.
+    const raw = await ngaFetcher.getRaw('nga:60');
+    expect(raw).not.toBeNull();
+  });
+
+  it('module stays Workers-safe: no static node:* imports in the source', () => {
+    // The /core export guarantee: importing nga.js must not crash a Workers
+    // bundle. Node built-ins may only be reached via lazy dynamic import inside
+    // the DEFAULT loader. This guards the module's import graph at source level.
+    const src = readFileSync(join(here, '..', 'src', 'fetchers', 'nga.ts'), 'utf-8');
+    expect(src).not.toMatch(/^import .* from 'node:/m);
+  });
+
+  it('exports from /core: ngaFetcher + createNgaFetcher are on the public surface', async () => {
+    const core = await import('../src/core/index.js');
+    expect(core.ngaFetcher.code).toBe('nga');
+    expect(typeof core.createNgaFetcher).toBe('function');
+  });
+});

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { FETCHER_REGISTRY } from '../src/fetchers/registry.js';
+
+describe('FETCHER_REGISTRY (engine coverage metadata)', () => {
+  it('lists every fetcher the engine ships, code-unique', () => {
+    expect(FETCHER_REGISTRY.length).toBe(13);
+    const codes = FETCHER_REGISTRY.map((e) => e.code);
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+
+  it('marks exactly the 3 key-gated sources, matching server.ts registration', () => {
+    const keyGated = FETCHER_REGISTRY.filter((e) => e.requiresApiKey).map((e) => e.code).sort();
+    expect(keyGated).toEqual(['europeana', 'harvard', 'smithsonian']);
+    expect(FETCHER_REGISTRY.find((e) => e.code === 'europeana')?.requiresApiKey).toBe(
+      'EUROPEANA_API_KEY',
+    );
+    expect(FETCHER_REGISTRY.find((e) => e.code === 'smithsonian')?.requiresApiKey).toBe(
+      'SMITHSONIAN_API_KEY',
+    );
+    expect(FETCHER_REGISTRY.find((e) => e.code === 'harvard')?.requiresApiKey).toBe(
+      'HARVARD_API_KEY',
+    );
+  });
+
+  it('marks exactly the 2 ingest-only sources (no live query API)', () => {
+    const ingestOnly = FETCHER_REGISTRY.filter((e) => e.ingestOnly).map((e) => e.code).sort();
+    expect(ingestOnly).toEqual(['nga', 'walters']);
+  });
+
+  it('matches the fleet-confirmed ground truth: 10 always-available (no key) + 3 key-gated', () => {
+    const alwaysAvailable = FETCHER_REGISTRY.filter((e) => !e.requiresApiKey);
+    expect(alwaysAvailable.length).toBe(10);
+  });
+
+  it('leaves the other 8 sources always-federated, with neither flag set', () => {
+    const alwaysLive = FETCHER_REGISTRY.filter((e) => !e.requiresApiKey && !e.ingestOnly);
+    expect(alwaysLive.length).toBe(8);
+  });
+
+  it('carries a non-empty display name for every source', () => {
+    for (const entry of FETCHER_REGISTRY) {
+      expect(entry.name.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('is importable from /core', async () => {
+    const core = await import('../src/core/index.js');
+    expect(core.FETCHER_REGISTRY.length).toBe(13);
+  });
+
+  it('closes the /core export gap: getty/smk/wellcome/harvard/nga are on the public surface', async () => {
+    const core = await import('../src/core/index.js');
+    expect(core.gettyFetcher.code).toBe('getty');
+    expect(core.smkFetcher.code).toBe('smk');
+    expect(core.wellcomeFetcher.code).toBe('wellcome');
+    expect(core.harvardFetcher.code).toBe('harvard');
+    expect(core.ngaFetcher.code).toBe('nga');
+  });
+});
+
+// Compile-time regression guard: the registry export must stay on /core's
+// public surface (mirrors the ObjectProvenance guard on cleveland.test.ts) —
+// this line fails tsc if the export is ever dropped.
+import type { FetcherRegistryEntry as CoreFetcherRegistryEntry } from '../src/core/index.js';
+const registrySurfaceCheck: (e: CoreFetcherRegistryEntry) => string = (e) => e.code;
+void registrySurfaceCheck;


### PR DESCRIPTION
## Summary
- Adds `FETCHER_REGISTRY` (`code`/`name`/`requiresApiKey`/`ingestOnly`) to `/core`, derived directly from the live fetcher instances, so a host describing the federation's coverage (e.g. a page listing which museums are federated) never has to hand-list it separately and risk drifting out of sync.
- Closing this out surfaced a larger gap: **5 of the 13 fetchers the engine ships (Getty, SMK, Wellcome Collection, Harvard Art Museums, National Gallery of Art) were never exported from `/core`** — a Workers-safe host could not register them; only the Node-based MCP server could. Getty/SMK/Wellcome/Harvard are straightforward additive exports (no Node-only imports). National Gallery of Art needed a real fix: its bundle loader used a static `node:fs`/`node:url`/`node:zlib` import, which pulls Node built-ins into any bundle that imports `/core` at all, even when the fetcher itself is never called. `createNgaFetcher(loadBundle?)` makes it an injectable, lazily-loaded seam — mirroring the existing Walters fetcher's pattern — with the default filesystem-backed instance preserved for the MCP server, unchanged.
- New optional `Fetcher` fields: `requiresApiKey?: string` (env var name; unset = always available) and `ingestOnly?: true` (bundled snapshot vs. live query API), set on the 3 key-gated and 2 ingest-only sources, following the same pattern as the existing `noCache`/`hotlinkRestricted` flags.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `NODE_OPTIONS=--experimental-sqlite npx vitest run` — 652/652 (9 new tests: an NGA bundle-loader seam suite mirroring the Walters tests, plus a new `tests/registry.test.ts` including a compile-time `/core` surface guard)
- [x] `npm run build` clean; the NGA gzip bundle still copies to `dist/data/`
- [x] Live smoke against the built `dist/`: `FETCHER_REGISTRY` reports all 13 sources with correct flags (10 always-available / 3 key-gated; 8 live-federated / 2 ingest-only); `core.ngaFetcher.search('Vermeer')` returns a real bundle hit that normalizes successfully; `getty`/`smk`/`wellcome`/`harvard` all resolve their `code` from `/core`

## Notes for review
- `/core`'s public surface is a stable contract for downstream consumers — this PR is purely additive (new exports, new optional interface fields); nothing existing changes shape. `server.ts`'s fetcher registration and env-gating logic are untouched.
- Registry entries are derived by importing the live fetcher objects and picking off `{code, name, requiresApiKey, ingestOnly}` — never hand-typed literals — so an added, renamed, or removed source can't silently drift from this list.
