### PR TITLE
chore: add a commit-message guard for public-repo writing

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Rejects internal process language and a non-project author/co-author
+# identity from commit messages before they can reach this public remote.
+# No-ops where the local check tool isn't installed (CI, other machines,
+# outside contributors), so it adds no friction to external contributions —
+# same design as the placeholder-code guard in .githooks/pre-commit.
+if ! type craft-check >/dev/null 2>&1; then
+  exit 0
+fi
+
+msg_file="$1"
+msg="$(cat "$msg_file")"
+fail=0
+reasons=()
+
+if echo "$msg" | grep -qE '\bOM-[A-Z][A-Z0-9-]{0,4}\b'; then
+  fail=1
+  reasons+=("looks like an internal lane code (e.g. OM-CR, OM-M)")
+fi
+
+if echo "$msg" | grep -qiE '\[(STARTED|PROGRESS|DISPATCH(-NEEDED)?|BLOCKED|DECISION-(NEEDED|MADE)|REVIEW-(READY|DONE)|MILESTONE|HANDOVER|DONE|ESCALATE|ROUTING)\]'; then
+  fail=1
+  reasons+=("contains a bracketed internal status tag")
+fi
+
+if echo "$msg" | grep -qiE "escalations log|session-states?/|craft-check|craft gate|shokunin|\\bT[12] review\\b|per (OM-OR|OM-CR|OM-QC)'s (dispatch|ruling)|Pramod (ruled|approved)"; then
+  fail=1
+  reasons+=("references internal tooling, process, or a private ruling")
+fi
+
+co_author_line=$(echo "$msg" | grep -i 'Co-Authored by' | tail -1)
+if [ -n "$co_author_line" ]; then
+  co_author_email=$(echo "$co_author_line" | sed -n 's/.*<\(.*\)>.*/\1/p')
+  if [[ -n "$co_author_email" && "$co_author_email" != *"@open-museum.art" ]]; then
+    fail=1
+    reasons+=("co-author trailer uses '$co_author_email', not an open-museum.art identity")
+  fi
+fi
+
+author_email=$(git var GIT_AUTHOR_IDENT | sed -n 's/.*<\([^>]*\)>.*/\1/p')
+if [[ "$author_email" != *"@open-museum.art" ]]; then
+  fail=1
+  reasons+=("author identity '$author_email' is not an open-museum.art address")
+fi
+
+if [ "$fail" -eq 1 ]; then
+  echo ""
+  echo "✗ Commit message rejected for a public repo:"
+  for r in "${reasons[@]}"; do
+    echo "  - $r"
+  done
+  echo "  Describe the change and its reason on the merits instead."
+  echo "  Deliberate, visible override: git commit --no-verify"
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## What

Adds a commit-msg hook (`.githooks/commit-msg`) that rejects a commit message before it can reach this public remote if it contains internal team shorthand, a bracketed internal status tag, a reference to internal review tooling or process, or an author/co-author email outside the project's own domain.

## Mechanism

- Shares the `core.hooksPath .githooks` wiring added in the companion placeholder-code guard — once both are merged, one `git config core.hooksPath .githooks` (or a fresh `npm run prepare`) arms both hooks together. This PR adds no new package.json wiring of its own to avoid a duplicate edit across the two PRs.
- No-ops entirely where the local check tool isn't installed (CI, other machines, outside contributors) — same design as the placeholder-code guard. It only ever activates on a machine that already has the project's own tooling set up, so it adds no friction to external contributions.
- `git commit --no-verify` remains available for a deliberate, visible override.

## Verification

Ran directly against a bank of sample messages:
- A message with an internal-style team-shorthand token is rejected with a clear reason, exit 1.
- A message with a bracketed internal status tag is rejected.
- A message referencing internal tooling/process by name is rejected.
- A message with a co-author email outside the project's domain is rejected.
- With an author identity outside the project's domain (simulated via `GIT_AUTHOR_EMAIL`), the commit is rejected.
- With the check tool removed from `PATH`, even a maximally bad message (all of the above at once) passes through untouched — confirming outside contributors are never affected.
- A real `git commit` with a bad message is rejected by git itself (not just the direct script invocation); the same commit with a clean message and the correct co-author identity passes clean, exit 0 — that commit is this PR's own history.

## Notes for review
- Companion to the placeholder-code guard PR — recommend merging both, since this hook isn't armed until `core.hooksPath` is wired (that happens in the other PR).

Co-Authored by Pramod Prasanth <pramod@open-museum.art>